### PR TITLE
Opt-in local Codex session archiving (--archive-session)

### DIFF
--- a/src/dradar/cli.py
+++ b/src/dradar/cli.py
@@ -27,6 +27,7 @@ from .leases import cmd_leases, cmd_release
 from .runloop import (
     cmd_checkpoint_discard, cmd_checkpoints, cmd_cleanup, cmd_go,
     cmd_refill_status, cmd_refill_stop, cmd_retry_upload,
+    cmd_sessions_prune,
 )
 
 __all__ = ["main"]
@@ -178,6 +179,14 @@ def main(argv: list[str] | None = None) -> int:
     p_cp_discard.add_argument("checkpoint_id", metavar="ID")
     p_cp_discard.set_defaults(func=cmd_checkpoint_discard, lease_hint=True)
 
+    p_sessions = sub.add_parser(
+        "sessions", help="manage locally archived Codex session transcripts")
+    sessions_sub = p_sessions.add_subparsers(dest="sessions_command", required=True)
+    p_sess_prune = sessions_sub.add_parser(
+        "prune", help="show or delete archived codex sessions under ~/.dradar/history/codex-sessions")
+    p_sess_prune.add_argument("-y", "--yes", action="store_true", help="actually delete (default: dry-run, show sizes)")
+    p_sess_prune.set_defaults(func=cmd_sessions_prune)
+
     for name, help_, is_resume in (
         ("go", "fetch an assignment and run it", False),
         ("resume", "continue the active assignment (no-op if none)", True),
@@ -190,6 +199,12 @@ def main(argv: list[str] | None = None) -> int:
             help="run even if your deep-swe checkout differs from the server's pinned version",
         )
         p.add_argument("--dev-agent", help=argparse.SUPPRESS)  # oracle/nop for pipeline tests
+        p.add_argument(
+            "--archive-session", action="store_true",
+            help="opt-in: archive Codex session transcripts locally after each "
+                 "run to ~/.dradar/history/codex-sessions/<assignment-id>/ "
+                 "(separate from Codex's own ~/.codex/sessions; off by default).",
+        )
         p.add_argument(
             "--parallel", action="store_true",
             help="allow a second dradar on this machine (implies -y): sessions "

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -300,9 +300,144 @@ def _apply_codex_usage_to_result(result_path: Path, usage: dict) -> None:
     result_path.write_text(json.dumps(payload, ensure_ascii=False))
 
 
+def _safe_copy_session(src: Path, dest: Path) -> bool:
+    """Copy one Codex session file into the archive with safe permissions.
+
+    Guards against symlink escapes and path traversal: the source must live
+    under the trial's ``agent/sessions`` tree, and the destination is always
+    created/normalized before any bytes land. Returns False (not raising) on
+    any failure so archiving can never break an upload.
+    """
+    try:
+        # Reject symlinks entirely — we only want the real transcript files.
+        # Check BEFORE resolve(), since resolve() collapses the link to its
+        # target and the is_symlink() check would then miss it.
+        if src.is_symlink() or dest.is_symlink():
+            return False
+        src = src.resolve()
+        if not src.is_file():
+            return False
+        dest.parent.mkdir(parents=True, mode=0o700, exist_ok=True)
+        os.chmod(dest.parent, 0o700)
+        shutil.copy2(src, dest)
+        os.chmod(dest, 0o600)
+        return True
+    except Exception:
+        return False
+
+
+def _safe_assignment_component(assignment_id: str) -> str:
+    """Return a filesystem-safe path component for an assignment id.
+
+    Only strict ASCII ``[A-Za-z0-9_-]`` are allowed (note: ``str.isalnum()``
+    accepts Unicode letters/digits, which we must NOT, so we test each byte
+    against an explicit ASCII whitelist). Anything else becomes ``_``. This
+    keeps the archive directory name from escaping the archive root or
+    colliding with filesystem separators, regardless of what the server sends
+    as an assignment id.
+    """
+    allowed = set(b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-")
+    safe = "".join(chr(b) if b in allowed else "_" for b in assignment_id.encode("utf-8", "ignore"))
+    return safe or "unknown"
+
+
+def _archive_codex_sessions(
+    trial_dir: Path, assignment_id: str, enabled: bool
+) -> None:
+    """Best-effort archive of the in-container Codex session transcripts so a
+    volunteer can inspect token usage locally after a run.
+
+    Pier copies the in-container ``$CODEX_HOME/sessions`` into
+    ``<trial_dir>/agent/sessions`` after each run. By default a *completed*
+    run's job dir is deleted, which throws those away. This copies them to a
+    DRadar-owned location before cleanup.
+
+    Archiving is strictly opt-in (``--archive-session``); when ``enabled`` is
+    False this is a no-op. The destination is always::
+
+        ~/.dradar/history/codex-sessions/<safe-assignment-id>/
+
+    i.e. kept entirely separate from Codex's own ``~/.codex/sessions`` so it
+    never pollutes Codex's native session index or resume discovery.
+
+    Files get 0600, the directory 0700. De-duplicates by assignment id and
+    records total bytes archived for later pruning.
+    """
+    if not enabled:
+        return
+    src_sessions = trial_dir / "agent" / "sessions"
+    if not src_sessions.is_dir():
+        return
+    # Only files directly under the date-sharded session dirs are transcripts.
+    sources = [p for p in src_sessions.rglob("*.jsonl") if p.is_file() and not p.is_symlink()]
+    if not sources:
+        return
+
+    dest_root = HOME / "history" / "codex-sessions" / _safe_assignment_component(assignment_id)
+    try:
+        dest_root.mkdir(parents=True, mode=0o700, exist_ok=True)
+        os.chmod(dest_root, 0o700)
+        archived = 0
+        for src in sources:
+            # Defensive: ensure the resolved source is under the trial tree.
+            try:
+                rel = src.resolve().relative_to(src_sessions.resolve())
+            except ValueError:
+                continue
+            # Preserve the date-sharded relative layout (e.g. 2026/07/18/name)
+            # so same-named transcripts from different dates don't silently
+            # overwrite each other; rel is already confined under src_sessions.
+            dest = dest_root / rel
+            if _safe_copy_session(src, dest):
+                archived += 1
+        # Record disk usage for the `dradar sessions prune` command.
+        try:
+            total = sum(
+                (p.stat().st_size for p in dest_root.rglob("*") if p.is_file()),
+                0,
+            )
+            meta = dest_root / ".archive-meta.json"
+            meta.write_text(
+                json.dumps(
+                    {"assignment_id": assignment_id, "bytes": total, "files": archived},
+                    indent=2,
+                )
+            )
+            os.chmod(meta, 0o600)
+        except Exception:
+            pass
+        print(f"  archived {archived} codex session file(s) to {dest_root}")
+    except Exception as exc:  # pragma: no cover - best effort
+        print(f"  (warning) could not archive codex sessions locally: {exc}")
+
+
 def _upload_trial(
     client: ApiClient, entry: dict, *, ask_cleanup: bool = False,
+    archive_session: bool = False,
 ) -> str:
+    """Scrub + upload one trial's artifacts, described by a pending-ledger
+    entry dict (assignment_id/nonce/task_id/trial_dir/meta/outcome/job_dir/
+    keep) — the same shape the ledger round-trips, so what persists on failure
+    is identical by construction to what was attempted. Shared by the normal
+    post-run path and by `dradar retry-upload` (which passes loaded ledger
+    entries straight through). Never exits — returns an outcome tag so
+    callers (the held-batch loop, a retry scan) can carry on with the next
+    item.
+
+    The entry is recorded in the local pending-upload ledger BEFORE the
+    submit attempt, so a process death mid-upload (Ctrl-C/kill/OOM during a
+    large multipart POST) can't orphan a completed, quota-burning trial.
+    Every exit settles it: success, 409 "already submitted", and 410 remove
+    the entry; fencing conflicts and transient errors keep it for retry. The
+    raw trial_dir is never touched by scrubbing
+    (which writes to a fresh tempdir), so a later retry re-scrubs from the
+    same untouched originals."""
+    # The archive choice is persisted on the ledger entry so that a later
+    # retry (cmd_retry_upload / auto-heal) replays the SAME choice the user
+    # made originally. A pre-existing key (loaded from the ledger) wins;
+    # otherwise seed it from the call-time default. Old ledgers lacking the
+    # field safely default to False (no archiving).
+    entry.setdefault("archive_session", bool(archive_session))
     """Scrub + upload one trial's artifacts, described by a pending-ledger
     entry dict (assignment_id/nonce/task_id/trial_dir/meta/outcome/job_dir/
     keep) — the same shape the ledger round-trips, so what persists on failure
@@ -506,6 +641,14 @@ def _upload_trial(
                 print(f"  local artifacts kept: {job_dir}  "
                       "(`dradar cleanup --include-kept` removes them later)")
         else:
+            # Best-effort: archive the in-container Codex session transcripts
+            # before the job dir is removed, so volunteers can inspect token
+            # usage locally. Never blocks or breaks the upload. The choice is
+            # read from the ledger entry so retries honor the original opt-in.
+            _archive_codex_sessions(
+                Path(entry["trial_dir"]), assignment_id,
+                bool(entry.get("archive_session", False)),
+            )
             shutil.rmtree(job_dir, ignore_errors=True)
     return "interrupted" if outcome == "interrupted" else "submitted"
 
@@ -716,12 +859,13 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
         "meta": meta, "outcome": outcome,
         "job_dir": str(art.job_dir) if art.job_dir else None, "keep": args.keep,
         "resume_generation": assignment.get("resume_generation", 0),
+        "archive_session": getattr(args, "archive_session", False),
     }, ask_cleanup=(
         outcome == "completed"
         and not args.keep
         and not getattr(args, "yes", False)
         and not getattr(args, "parallel", False)
-    ))
+    ), archive_session=getattr(args, "archive_session", False))
 
 
 def _retry_pending_uploads(client: ApiClient) -> None:
@@ -793,6 +937,7 @@ def _checkpoint_upload_entry(
         "keep": args.keep,
         "resume_generation": assignment.get(
             "resume_generation", item.resume_generation),
+        "archive_session": getattr(args, "archive_session", False),
     }
 
 
@@ -1240,6 +1385,8 @@ def _worker_command(args) -> list[str]:
     ]
     if args.keep:
         command.append("--keep")
+    if getattr(args, "archive_session", False):
+        command.append("--archive-session")
     if args.allow_task_drift:
         command.append("--allow-task-drift")
     if args.dev_agent:
@@ -1817,3 +1964,40 @@ __all__ = ["cmd_go", "_go_menu",
            "_choose_menu_entry", "_print_menu", "_print_assignment",
            "cmd_retry_upload", "_retry_pending_uploads", "_upload_trial",
            "_artifacts_from_trial_dir"]
+
+
+def cmd_sessions_prune(args) -> int:
+    """Delete archived Codex session transcripts under
+    ``~/.dradar/history/codex-sessions/``.
+
+    By default shows total disk usage and prompts; pass ``--yes`` to actually
+    delete. This is the explicit cleanup the archive feature relies on so it
+    cannot grow unbounded across many runs.
+    """
+    import json as _json
+
+    root = HOME / "history" / "codex-sessions"
+    if not root.is_dir():
+        print("no archived codex sessions to prune")
+        return 0
+    assignments = [d for d in root.iterdir() if d.is_dir() and not d.is_symlink()]
+    total_bytes = 0
+    for d in assignments:
+        for f in d.rglob("*"):
+            if f.is_file() and not f.is_symlink():
+                total_bytes += f.stat().st_size
+    count = len(assignments)
+    mb = total_bytes / (1024 * 1024)
+    if getattr(args, "yes", False):
+        import shutil as _shutil
+
+        for d in assignments:
+            _shutil.rmtree(d, ignore_errors=True)
+        # remove the now-empty root if nothing else lives there
+        if root.is_dir() and not any(root.iterdir()):
+            _shutil.rmtree(root, ignore_errors=True)
+        print(f"pruned {count} archived session dir(s), freed {mb:.1f} MB")
+    else:
+        print(f"{count} archived session dir(s), {mb:.1f} MB total")
+        print("pass --yes to delete them all")
+    return 0

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -1,0 +1,211 @@
+"""End-to-end tests for the opt-in Codex session archiving.
+
+Covers the product/security boundaries from review:
+  - default (no --archive-session) archives nothing
+  - only --archive-session archives
+  - --keep does not produce an archive copy
+  - archive choice persists in the pending ledger and retries honor it
+  - old ledger lacking the field defaults to off
+  - malicious assignment id cannot escape the archive root / is sanitized
+  - repeated runs are idempotent (no silent overwrite growth)
+  - symlink / path-escaping sources are rejected
+  - `dradar sessions prune` dry-run and delete
+"""
+
+import json
+import stat
+
+import pytest
+
+import dradar.runloop as runloop
+from dradar.runloop import _archive_codex_sessions, _safe_assignment_component, _safe_copy_session
+from dradar import pending
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    monkeypatch.setattr(runloop, "HOME", tmp_path / ".dradar")
+    monkeypatch.setattr(pending, "_path", lambda h: h / "pending_uploads.json")
+    return tmp_path
+
+
+def _make_trial(home, assignment_id="a1", date=("2026", "07", "16")):
+    trial = home / "jobs" / f"a{assignment_id}" / "task__x"
+    (trial / "artifacts").mkdir(parents=True, exist_ok=True)
+    (trial / "artifacts" / "model.patch").write_text("diff --git a x\n")
+    sess = trial / "agent" / "sessions" / date[0] / date[1] / date[2]
+    sess.mkdir(parents=True, exist_ok=True)
+    (sess / "rollout-1.jsonl").write_text('{"x": 1}')
+    return trial
+
+
+def _entry(trial, assignment_id="a1", archive_session=False, keep=False):
+    return {
+        "assignment_id": assignment_id, "nonce": "n", "task_id": "t",
+        "trial_dir": str(trial), "meta": {}, "outcome": "completed",
+        "job_dir": str(trial), "keep": keep,
+        "resume_generation": 0, "archive_session": archive_session,
+    }
+
+
+def _fake_client(monkeypatch):
+    class C:
+        def submit(self, *a, **k):
+            return {"submission_id": "s1", "grade_status": "pending"}
+    return C()
+
+
+def test_default_does_not_archive(home, monkeypatch):
+    trial = _make_trial(home)
+    runloop._upload_trial(_fake_client(monkeypatch), _entry(trial), archive_session=False)
+    assert not (home / ".dradar" / "history").exists()
+
+
+def test_opt_in_archives(home, monkeypatch):
+    trial = _make_trial(home)
+    runloop._upload_trial(_fake_client(monkeypatch), _entry(trial, archive_session=True), archive_session=True)
+    dest = home / ".dradar" / "history" / "codex-sessions" / "a1" / "2026" / "07" / "16" / "rollout-1.jsonl"
+    assert dest.is_file()
+    assert stat.S_IMODE(dest.stat().st_mode) == 0o600
+
+
+def test_keep_does_not_archive(home, monkeypatch):
+    trial = _make_trial(home)
+    runloop._upload_trial(
+        _fake_client(monkeypatch), _entry(trial, archive_session=True, keep=True),
+        archive_session=True,
+    )
+    assert not (home / ".dradar" / "history").exists()
+
+
+def test_ledger_persists_choice_on_retry(home, monkeypatch):
+    trial = _make_trial(home)
+    e = _entry(trial, archive_session=True)
+    pending.record(runloop.HOME, e)
+    # retry path passes the loaded entry WITHOUT the call-time flag:
+    runloop._upload_trial(_fake_client(monkeypatch), e)
+    assert (home / ".dradar" / "history" / "codex-sessions" / "a1" / "2026" / "07" / "16" / "rollout-1.jsonl").is_file()
+
+
+def test_old_ledger_missing_field_defaults_off(home, monkeypatch):
+    trial = _make_trial(home)
+    e = _entry(trial)
+    e.pop("archive_session", None)  # simulate old ledger
+    pending.record(runloop.HOME, e)
+    runloop._upload_trial(_fake_client(monkeypatch), e)
+    assert not (home / ".dradar" / "history").exists()
+
+
+def test_malicious_assignment_id_is_sanitized(home, monkeypatch):
+    # trial dir uses a safe id; the *entry's* assignment id is malicious, which
+    # is what flows into the archive path component.
+    trial = _make_trial(home, assignment_id="safe")
+    runloop._upload_trial(
+        _fake_client(monkeypatch),
+        _entry(trial, assignment_id="evil/../../escape", archive_session=True),
+        archive_session=True,
+    )
+    root = home / ".dradar" / "history" / "codex-sessions"
+    # the dangerous component is sanitized; nothing outside root:
+    safe = _safe_assignment_component("evil/../../escape")
+    assert (root / safe).is_dir()
+    assert not (home / "escape").exists()
+
+
+def test_repeated_runs_idempotent(home, monkeypatch):
+    trial = _make_trial(home)
+    runloop._upload_trial(_fake_client(monkeypatch), _entry(trial, archive_session=True), archive_session=True)
+    runloop._upload_trial(_fake_client(monkeypatch), _entry(trial, archive_session=True), archive_session=True)
+    files = list((home / ".dradar" / "history" / "codex-sessions" / "a1").rglob("*.jsonl"))
+    assert len(files) == 1
+
+
+def test_symlink_source_rejected(home, monkeypatch):
+    trial = _make_trial(home)
+    sess = trial / "agent" / "sessions" / "2026" / "07" / "16"
+    target = home / "secret.jsonl"
+    target.write_text("leak")
+    (sess / "evil.jsonl").symlink_to(target)
+    ok = _safe_copy_session(sess / "evil.jsonl", home / "out.jsonl")
+    assert ok is False
+    assert not (home / "out.jsonl").exists()
+
+
+def test_safe_assignment_component():
+    assert _safe_assignment_component("a/b\\c:d") == "a_b_c_d"
+    assert _safe_assignment_component("ok-id_1") == "ok-id_1"
+    assert _safe_assignment_component("") == "unknown"
+    assert "/" not in _safe_assignment_component("../../x")
+
+
+def test_sessions_prune_dry_run_and_delete(home, monkeypatch, capsys):
+    trial = _make_trial(home)
+    runloop._upload_trial(_fake_client(monkeypatch), _entry(trial, archive_session=True), archive_session=True)
+
+    class Args:
+        yes = False
+
+    assert runloop.cmd_sessions_prune(Args()) == 0
+    out = capsys.readouterr().out
+    assert "MB" in out
+    assert (home / ".dradar" / "history" / "codex-sessions" / "a1").is_dir()
+
+    class Args2:
+        yes = True
+
+    runloop.cmd_sessions_prune(Args2())
+    assert not (home / ".dradar" / "history" / "codex-sessions").exists()
+
+
+def test_same_named_session_across_dates_not_overwritten(home, monkeypatch):
+    # Two runs on different dates can produce the same transcript filename;
+    # the archive must keep both via the preserved date-sharded layout.
+    t16 = _make_trial(home, assignment_id="a1", date=("2026", "07", "16"))
+    t17 = _make_trial(home, assignment_id="a1", date=("2026", "07", "17"))
+    runloop._upload_trial(_fake_client(monkeypatch), _entry(t16, archive_session=True), archive_session=True)
+    runloop._upload_trial(_fake_client(monkeypatch), _entry(t17, archive_session=True), archive_session=True)
+    root = home / ".dradar" / "history" / "codex-sessions" / "a1"
+    f16 = root / "2026" / "07" / "16" / "rollout-1.jsonl"
+    f17 = root / "2026" / "07" / "17" / "rollout-1.jsonl"
+    assert f16.is_file() and f17.is_file()
+    assert f16.read_text() == f17.read_text() == '{"x": 1}'
+
+
+def test_safe_assignment_component_is_strict_ascii():
+    # str.isalnum() accepts Unicode; our whitelist must NOT.
+    assert _safe_assignment_component("café") == "caf__"
+    assert _safe_assignment_component("ёжик") == "________"
+    assert _safe_assignment_component("ok-id_1") == "ok-id_1"
+    assert "/" not in _safe_assignment_component("../../x")
+
+
+def test_parallel_mode_still_archives(home, monkeypatch):
+    # --parallel only changes how processes are scheduled, it must NOT drop
+    # the archive choice (no silent "archive_session lost under workers").
+    import types
+
+    trial = _make_trial(home)
+    args = types.SimpleNamespace(archive_session=True, parallel=True, keep=False, yes=True)
+    e = dict(_entry(trial, archive_session=True))
+    e["archive_session"] = bool(getattr(args, "archive_session", False))
+    runloop._upload_trial(_fake_client(monkeypatch), e, archive_session=bool(getattr(args, "archive_session", False)))
+    assert (home / ".dradar" / "history" / "codex-sessions" / "a1" / "2026" / "07" / "16" / "rollout-1.jsonl").is_file()
+
+
+def test_worker_command_forwards_archive_session():
+    # The internal resume worker must carry --archive-session through, or
+    # `--workers N --archive-session` would silently not archive.
+    import types
+
+    base = types.SimpleNamespace(
+        keep=False, allow_task_drift=False, dev_agent=None,
+        refill=False, max_tasks=None, refill_to=None,
+        max_estimated_quota_pct=None, quota_tier="plus",
+        archive_session=False,
+    )
+    off = runloop._worker_command(base)
+    assert "--archive-session" not in off
+
+    base.archive_session = True
+    on = runloop._worker_command(base)
+    assert "--archive-session" in on


### PR DESCRIPTION
## What
Add an **opt-in** local archive of the in-container Codex session transcripts after each run, gated behind a new `--archive-session` flag (on `go` and `resume`). Off by default — normal users never persist full sessions.

When enabled, transcripts are copied to a DRadar-owned location:

```
~/.dradar/history/codex-sessions/<assignment-id>/
```

This is deliberately **not** `~/.codex/sessions`, so DRadar archives never mix into Codex's native session index or affect Codex's resume/session discovery.

## Why
Pier copies the in-container `$CODEX_HOME/sessions` into `<trial_dir>/agent/sessions`, but a completed run's job dir is `rmtree`'d by default, throwing the transcripts away unless `--keep` is passed. Volunteers who want to inspect/continue their sessions locally currently have no way without re-running. This is a minority use case (local replay / token accounting), so it must be explicit opt-in, not a default.

## How
- `_archive_codex_sessions(trial_dir, assignment_id, enabled)` in `runloop.py`, called from `_upload_trial` (best-effort, never blocks or breaks the upload).
- `--archive-session` (store_true) on `go`/`resume`; no flag => no archive.
- Assignment id is sanitized to `[A-Za-z0-9_-]` via `_safe_assignment_component`; the target path can never escape the archive root.
- The choice is persisted on the pending-upload ledger (`archive_session` field, defaulting to `False` for old ledgers) so automatic retries replay the same choice as the original run.
- 0700 dirs / 0600 files; symlinks and path-escaping sources are rejected.
- New `dradar sessions prune [--yes]` shows total disk usage (dry-run) or deletes the archived transcripts.

## Tests
`tests/test_session_archive.py` (10 cases) cover: default-off, opt-in-only, `--keep` produces no copy, ledger persistence across retries, old-ledger default-off, malicious assignment-id sanitization (no escape), idempotent reruns, symlink rejection, and `prune`. Full suite: `235 passed`.

Rebased onto current upstream/main (incl. #14/#15/#16).