### PR TITLE
fix: normalize text line endings in task hashes

### DIFF
--- a/src/dradar/manifest.py
+++ b/src/dradar/manifest.py
@@ -10,6 +10,21 @@ import hashlib
 from pathlib import Path
 
 
+def _portable_content(path: Path) -> bytes:
+    """Return bytes stable across Git's LF/CRLF text checkout modes.
+
+    Git's ``core.autocrlf=true`` can write CRLF into an otherwise clean work
+    tree.  Hashing those raw checkout bytes made an identical commit look
+    tampered with on some Windows/WSL machines.  Git does not line-normalize
+    binary files; mirror that safety boundary with its primary NUL-byte
+    signal so binary integrity remains byte-for-byte strict.
+    """
+    data = path.read_bytes()
+    if b"\0" not in data:
+        return data.replace(b"\r\n", b"\n")
+    return data
+
+
 def task_content_hash(deep_swe_tasks_dir: Path, task_id: str) -> str:
     task_dir = Path(deep_swe_tasks_dir) / task_id
     digest = hashlib.sha256()
@@ -17,11 +32,11 @@ def task_content_hash(deep_swe_tasks_dir: Path, task_id: str) -> str:
         path = task_dir / name
         if path.is_file():
             digest.update(name.encode())
-            digest.update(path.read_bytes())
+            digest.update(_portable_content(path))
     env_dir = task_dir / "environment"
     if env_dir.is_dir():
         rel_paths = sorted(p.relative_to(env_dir).as_posix() for p in env_dir.rglob("*") if p.is_file())
         for rel in rel_paths:
             digest.update(rel.encode())
-            digest.update((env_dir / rel).read_bytes())
+            digest.update(_portable_content(env_dir / rel))
     return digest.hexdigest()

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,6 +1,23 @@
+import hashlib
 from pathlib import Path
 
 from dradar.manifest import task_content_hash
+
+
+def _legacy_raw_hash(root: Path, task_id: str) -> str:
+    task = root / task_id
+    digest = hashlib.sha256()
+    for name in ("instruction.md", "task.toml"):
+        path = task / name
+        if path.is_file():
+            digest.update(name.encode())
+            digest.update(path.read_bytes())
+    env = task / "environment"
+    for rel in sorted(p.relative_to(env).as_posix()
+                      for p in env.rglob("*") if p.is_file()):
+        digest.update(rel.encode())
+        digest.update((env / rel).read_bytes())
+    return digest.hexdigest()
 
 
 def _write_task(root: Path, task_id: str, instruction="hi", toml="a=1",
@@ -31,6 +48,12 @@ def test_hash_stable_across_calls(tmp_path: Path):
     h1 = task_content_hash(tmp_path, "t1")
     h2 = task_content_hash(tmp_path, "t1")
     assert h1 == h2
+
+
+def test_lf_checkout_keeps_the_legacy_hash(tmp_path: Path):
+    _write_task(tmp_path, "t1", instruction="one\ntwo\n",
+                env_files={"Dockerfile": "FROM python\nRUN true\n"})
+    assert task_content_hash(tmp_path, "t1") == _legacy_raw_hash(tmp_path, "t1")
 
 
 def test_hash_ignores_solution_and_tests(tmp_path: Path):
@@ -71,3 +94,30 @@ def test_hash_same_content_different_task_dir_matches(tmp_path: Path):
     _write_task(root_a, "t1", solution="server-only solution")
     _write_task(root_b, "t1", solution=None, tests=None)  # volunteer lacks solution/tests locally too, still matches
     assert task_content_hash(root_a, "t1") == task_content_hash(root_b, "t1")
+
+
+def test_hash_treats_lf_and_crlf_text_checkouts_as_identical(tmp_path: Path):
+    lf, crlf = tmp_path / "lf", tmp_path / "crlf"
+    content = {
+        "instruction": "first line\nsecond line\n",
+        "toml": "name = 'example'\nenabled = true\n",
+        "env_files": {"Dockerfile": "FROM python\nRUN echo ready\n"},
+    }
+    _write_task(lf, "t1", **content)
+    _write_task(crlf, "t1", **content)
+    task = crlf / "t1"
+    for path in (task / "instruction.md", task / "task.toml",
+                 task / "environment" / "Dockerfile"):
+        path.write_bytes(path.read_bytes().replace(b"\n", b"\r\n"))
+
+    assert task_content_hash(lf, "t1") == task_content_hash(crlf, "t1")
+
+
+def test_hash_keeps_binary_line_endings_byte_exact(tmp_path: Path):
+    left, right = tmp_path / "left", tmp_path / "right"
+    _write_task(left, "t1")
+    _write_task(right, "t1")
+    (left / "t1" / "environment" / "payload.bin").write_bytes(b"\0row\r\n")
+    (right / "t1" / "environment" / "payload.bin").write_bytes(b"\0row\n")
+
+    assert task_content_hash(left, "t1") != task_content_hash(right, "t1")


### PR DESCRIPTION
## Summary
- normalize CRLF to LF for text files before task-content hashing
- keep binary files byte-for-byte strict
- preserve the exact legacy hash for normal LF checkouts

Fixes false task hash mismatches for WSL users whose Git inherited Windows `core.autocrlf=true`.

## Tests
- `.venv/bin/python -m pytest tests/ -q` (224 passed)