### PR TITLE
fix: preserve uploads with malformed trajectories

### DIFF
--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -10,6 +10,7 @@ someone else with nothing counted. Split out of cli.py to separate this from
 identity (login/register) and doctor (environment checks) concerns.
 """
 
+import json
 import os
 import shutil
 import sys
@@ -289,9 +290,11 @@ def _upload_trial(
             HOME, assignment_id, keep_job_dir=keep_dir,
         )
 
-    def discard_unusable_checkpoint() -> None:
+    def discard_unusable_checkpoint(*, preserve_local: bool = False) -> None:
         item = checkpoints.find_latest(HOME, assignment_id)
         if item is None:
+            if preserve_local and job_dir and job_dir.is_dir():
+                (job_dir / checkpoints.KEEP_MARKER).touch(mode=0o600, exist_ok=True)
             return
         _discard_checkpoint_quietly(
             client, item,
@@ -299,6 +302,7 @@ def _upload_trial(
                 "resume_generation", item.resume_generation),
              "checkpoint_id": item.checkpoint_id},
             reason="invalid",
+            preserve_local=preserve_local,
         )
 
     patch, trajectory, result = trial_artifact_paths(Path(entry["trial_dir"]))
@@ -324,6 +328,14 @@ def _upload_trial(
         if trajectory:
             traj_scrubbed = scrubbed / "trajectory.json"
             scrub_file(trajectory, traj_scrubbed)
+            try:
+                value = json.loads(traj_scrubbed.read_bytes())
+                if not isinstance(value, dict):
+                    raise ValueError("top level is not an object")
+            except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+                print(f"  {task_id}: Pier produced a malformed optional trajectory "
+                      f"({exc}); uploading the verified result without it")
+                traj_scrubbed = None
         result_scrubbed = None
         if result:
             result_scrubbed = scrubbed / "result.json"
@@ -362,7 +374,8 @@ def _upload_trial(
                       "retrying can't fix it, dropping it from the retry queue "
                       f"(local artifact path: {patch.parent.parent})")
                 pending.remove(HOME, assignment_id)
-                discard_unusable_checkpoint()
+                discard_unusable_checkpoint(preserve_local=True)
+                print(f"  rejected artifacts kept for diagnosis: {patch.parent.parent}")
                 return "rejected"
             print(f"  {task_id}: upload failed ({exc}) — kept for retry "
                   "(`dradar retry-upload`)")
@@ -420,8 +433,9 @@ def _discard_checkpoint_quietly(
     assignment: dict | None = None,
     *,
     reason: str,
+    preserve_local: bool = False,
 ) -> bool:
-    """Invalidate server state first, then remove all local copies."""
+    """Invalidate server state, optionally preserving its local evidence."""
     assignment_id = item.assignment_id
     if not assignment_id:
         return False
@@ -450,7 +464,10 @@ def _discard_checkpoint_quietly(
         if exc.status_code not in (404, 409, 410):
             print(f"  couldn't discard checkpoint {item.checkpoint_id or '?'}: {exc}; kept locally")
             return False
-    checkpoints.cleanup_assignment(HOME, assignment_id)
+    if preserve_local:
+        checkpoints.mark_kept(HOME, item)
+    else:
+        checkpoints.cleanup_assignment(HOME, assignment_id)
     return True
 
 

--- a/tests/test_pending_upload.py
+++ b/tests/test_pending_upload.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from dradar import pending, runloop
+from dradar import checkpoints, pending, runloop
 from dradar.api_client import ApiError
 
 
@@ -80,6 +80,10 @@ class FakeClient:
         self.calls.append(assignment_id)
         return self.behavior(assignment_id)
 
+    def checkpoint_discard(self, assignment_id, checkpoint_id,
+                           resume_generation, reason):
+        self.discarded = (assignment_id, checkpoint_id, resume_generation, reason)
+
 
 def _make_trial_dir(tmp_path: Path, name: str = "t") -> Path:
     trial_dir = tmp_path / name
@@ -105,6 +109,27 @@ def test_upload_success_clears_ledger(tmp_path: Path, monkeypatch):
     outcome = runloop._upload_trial(client, _entry(trial_dir, meta={"k": "v"}))
     assert outcome == "submitted"
     assert pending.load(tmp_path) == []
+
+
+def test_upload_omits_malformed_optional_trajectory(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    (trial_dir / "agent").mkdir()
+    (trial_dir / "agent" / "trajectory.json").write_bytes(
+        b'{"agent":{},"steps":["bad\\q"]}'
+    )
+    (trial_dir / "result.json").write_text("{}")
+
+    class CaptureClient(FakeClient):
+        def submit(self, assignment_id, nonce, patch, trajectory, result, meta,
+                   outcome="completed", resume_generation=None):
+            assert trajectory is None
+            assert result is not None
+            return {"submission_id": "s1", "grade_status": "pending"}
+
+    outcome = runloop._upload_trial(CaptureClient(lambda _aid: None), _entry(trial_dir))
+    assert outcome == "submitted"
+    assert "malformed optional trajectory" in capsys.readouterr().out
 
 
 def test_upload_success_removes_current_and_superseded_checkpoint_jobs(
@@ -456,6 +481,31 @@ def test_definitively_rejected_upload_drops_ledger_entry(tmp_path: Path, monkeyp
     out = capsys.readouterr().out
     assert "retrying can't fix it" in out
     assert str(trial_dir) in out  # the local files are named, not vaporized
+
+
+def test_definitive_rejection_preserves_checkpoint_job(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    aid = "4" * 32
+    job = tmp_path / "work" / "jobs" / f"a{aid}"
+    trial = job / "task__one"
+    checkpoint = trial / "agent" / "checkpoint"
+    checkpoint.mkdir(parents=True)
+    (checkpoint / "checkpoint.json").write_text(json.dumps({
+        "schema_version": 1, "checkpoint_id": "checkpoint-rejected1",
+        "assignment_id": aid, "phase": "agent_completed",
+        "updated_at": "2026-07-19T01:00:00Z", "resume_generation": 0,
+    }))
+    (trial / "artifacts").mkdir()
+    (trial / "artifacts" / "model.patch").write_text("diff --git a b\n")
+    client = FakeClient(_raise(422))
+    outcome = runloop._upload_trial(
+        client,
+        _entry(trial, assignment_id=aid, job_dir=str(job), keep=False),
+    )
+    assert outcome == "rejected"
+    assert job.is_dir()
+    assert (job / checkpoints.KEEP_MARKER).is_file()
+    assert client.discarded[0] == aid
 
 
 def test_transient_5xx_keeps_ledger_entry(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary
- omit malformed optional Pier trajectories while uploading verified results
- preserve checkpoint job artifacts after permanent upload rejection
- add regression coverage for both paths

## Tests
- `python -m pytest tests -q` (243 passed)