### PR TITLE
Fix multi-agent trajectory upload and Ultra accounting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dradar"
-version = "0.5.6"
+version = "0.5.7"
 description = "DRadar crowdtest client — run DeepSWE benchmark tasks on your own subscription, submit for independent server-side grading"
 requires-python = ">=3.11"
 dependencies = ["httpx[socks]>=0.27"]

--- a/src/dradar/api_client.py
+++ b/src/dradar/api_client.py
@@ -252,6 +252,7 @@ class ApiClient:
         client_meta: dict[str, Any],
         outcome: str = "completed",
         resume_generation: int | None = None,
+        trajectory_bundle: Path | None = None,
     ) -> dict[str, Any]:
         files: list[tuple[str, tuple[str, bytes]]] = [
             ("patch", ("model.patch", patch.read_bytes())),
@@ -260,6 +261,9 @@ class ApiClient:
             files.append(("trajectory", ("trajectory.json", trajectory.read_bytes())))
         if result and result.exists():
             files.append(("result", ("result.json", result.read_bytes())))
+        if trajectory_bundle and trajectory_bundle.exists():
+            files.append(("trajectory_bundle", (
+                "trajectory_bundle.json", trajectory_bundle.read_bytes())))
         data = {
             "assignment_id": assignment_id,
             "nonce": nonce,

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -23,11 +23,12 @@ from .identity import _client
 from .local_config import HOME, _load_config, tasks_root_from_config
 from .machine import acquire_run_lock, sweep_orphan_compose
 from .runner import (
-    DIAG_ADVICE, BuildFlakeError, RunnerError, check_task_content_hash,
+    DIAG_ADVICE, BuildFlakeError, RunnerError, build_codex_trajectory_bundle,
+    check_task_content_hash, codex_trajectory_bundle_usage,
     diagnose_exception, ensure_pier, ensure_tasks_root, local_deep_swe_commit,
     run_trial, summarize_result, sync_deep_swe_commit, trial_artifact_paths,
 )
-from .scrub import scan_secrets, scrub_file
+from .scrub import scan_secrets, scrub_bytes, scrub_file
 from .telemetry import RunnerTelemetry
 
 
@@ -256,6 +257,39 @@ def _check_version_pin(pinned: str | None, tasks_root: Path, allow_drift: bool) 
 _artifacts_from_trial_dir = trial_artifact_paths
 
 
+def _apply_codex_usage_to_result(result_path: Path, usage: dict) -> None:
+    """Replace Pier's arbitrary single-session totals in an upload copy.
+
+    The raw result remains untouched for retry/debugging.  Clearing cost_usd
+    is intentional: the server owns the model price table and recomputes the
+    cost from these normalized aggregate token counters.
+    """
+    try:
+        payload = json.loads(result_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return
+    if not isinstance(payload, dict):
+        return
+    agent_result = payload.get("agent_result")
+    if not isinstance(agent_result, dict):
+        agent_result = {}
+        payload["agent_result"] = agent_result
+    agent_result["cost_usd"] = None
+    complete = bool(usage.get("complete"))
+    for result_key, usage_key in (
+        ("n_input_tokens", "n_input_tokens"),
+        ("n_cache_tokens", "n_cache_tokens"),
+        ("n_output_tokens", "n_output_tokens"),
+    ):
+        agent_result[result_key] = usage.get(usage_key) if complete else None
+    metadata = agent_result.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+        agent_result["metadata"] = metadata
+    metadata["codex_session_usage"] = usage
+    result_path.write_text(json.dumps(payload, ensure_ascii=False))
+
+
 def _upload_trial(
     client: ApiClient, entry: dict, *, ask_cleanup: bool = False,
 ) -> str:
@@ -322,8 +356,39 @@ def _upload_trial(
         discard_unusable_checkpoint()
         return "not-uploaded"
 
+    trajectory_bundle = build_codex_trajectory_bundle(Path(entry["trial_dir"]))
+    usage = (codex_trajectory_bundle_usage(trajectory_bundle)
+             if trajectory_bundle is not None else None)
+    multi_session = bool(usage and (
+        usage.get("subagent_session_count", 0) > 0
+        or usage.get("agent_session_count", 0) > 1
+        or usage.get("session_file_count", 0) > 1
+    ))
+    upload_meta = dict(entry.get("meta") or {})
+    if multi_session:
+        upload_meta["cost_usd"] = None
+        upload_meta["usage_aggregation"] = usage["schema"]
+        upload_meta["usage_aggregation_complete"] = usage["complete"]
+        upload_meta["agent_session_count"] = usage["agent_session_count"]
+        upload_meta["root_session_count"] = usage["root_session_count"]
+        upload_meta["subagent_session_count"] = usage["subagent_session_count"]
+        upload_meta["agent_session_usage"] = usage["sessions"]
+        for key in ("n_input_tokens", "n_cache_tokens", "n_output_tokens"):
+            upload_meta[key] = usage[key] if usage["complete"] else None
+
     with tempfile.TemporaryDirectory() as td:
         scrubbed = Path(td)
+        trajectory_bundle_scrubbed = None
+        if multi_session:
+            trajectory_bundle_scrubbed = scrubbed / "trajectory_bundle.json"
+            serialized = json.dumps(
+                trajectory_bundle, ensure_ascii=False, separators=(",", ":"),
+            ).encode("utf-8")
+            trajectory_bundle_scrubbed.write_bytes(scrub_bytes(serialized))
+            # Redaction must never turn a valid bundle into malformed JSON.
+            # Treat that as a local bug and retain the pending upload instead
+            # of sending bytes the server must permanently reject.
+            json.loads(trajectory_bundle_scrubbed.read_bytes())
         traj_scrubbed = None
         if trajectory:
             traj_scrubbed = scrubbed / "trajectory.json"
@@ -340,14 +405,23 @@ def _upload_trial(
         if result:
             result_scrubbed = scrubbed / "result.json"
             scrub_file(result, result_scrubbed)
+            if multi_session:
+                _apply_codex_usage_to_result(result_scrubbed, usage)
         # Record before submitting: from here on an unacked completed trial
         # always has a ledger entry, whatever kills the upload. The server
         # dedupes replays (409 "already submitted"), so duplicates are safe.
         pending.record(HOME, entry)
         try:
-            ack = client.submit(assignment_id, entry["nonce"], patch, traj_scrubbed,
-                                result_scrubbed, entry["meta"], outcome=outcome,
-                                resume_generation=entry.get("resume_generation"))
+            submit_kwargs = {
+                "outcome": outcome,
+                "resume_generation": entry.get("resume_generation"),
+            }
+            if trajectory_bundle_scrubbed is not None:
+                submit_kwargs["trajectory_bundle"] = trajectory_bundle_scrubbed
+            ack = client.submit(
+                assignment_id, entry["nonce"], patch, traj_scrubbed,
+                result_scrubbed, upload_meta, **submit_kwargs,
+            )
         except ApiError as exc:
             if exc.status_code == 409 and "already submitted" in str(exc).lower():
                 # Some earlier attempt actually landed server-side even

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -290,6 +290,269 @@ def trial_artifact_paths(trial_dir: Path) -> tuple[Path, Path | None, Path | Non
     return patch, (trajectory if trajectory.is_file() else None), (result if result.is_file() else None)
 
 
+CODEX_TRAJECTORY_BUNDLE_SCHEMA = "dradar-codex-trajectory-bundle-v1"
+
+
+def _codex_usage(value) -> dict | None:
+    """Normalize one cumulative Codex token counter object."""
+    if not isinstance(value, dict):
+        return None
+    names = ("input_tokens", "cached_input_tokens", "output_tokens")
+    counters = {}
+    for name in names:
+        item = value.get(name)
+        if isinstance(item, bool) or not isinstance(item, int) or item < 0:
+            return None
+        counters[name] = item
+    if counters["cached_input_tokens"] > counters["input_tokens"]:
+        return None
+    reasoning = value.get("reasoning_output_tokens", 0)
+    if isinstance(reasoning, bool) or not isinstance(reasoning, int) or reasoning < 0:
+        reasoning = 0
+    counters["reasoning_output_tokens"] = reasoning
+    return counters
+
+
+def _analyze_codex_session_events(events: list[dict], fallback_id: str) -> dict:
+    """Describe one Codex JSONL file and isolate this agent's own usage.
+
+    A spawned Codex agent currently receives a copy of its parent's event
+    prefix.  Consequently its final cumulative counters include the inherited
+    parent tokens.  Summing the final counters would overcharge just as badly
+    as Pier's single-file conversion undercharges.  The last ``task_started``
+    marks the spawned agent's own segment; subtract the final counter before
+    that boundary.
+    """
+    meta_events = [event for event in events if event.get("type") == "session_meta"]
+    first_meta = meta_events[0].get("payload", {}) if meta_events else {}
+    if not isinstance(first_meta, dict):
+        first_meta = {}
+    raw_id = first_meta.get("id") or first_meta.get("session_id")
+    session_id = raw_id if isinstance(raw_id, str) and raw_id else fallback_id
+    raw_role = first_meta.get("thread_source")
+    role = "root" if raw_role == "user" else (
+        "subagent" if raw_role == "subagent" else "unknown")
+    parent_session_id = None
+    source = first_meta.get("source") or {}
+    if isinstance(source, dict) and isinstance(source.get("subagent"), dict):
+        spawn = source["subagent"].get("thread_spawn")
+        if isinstance(spawn, dict):
+            raw_parent = spawn.get("parent_thread_id")
+            if isinstance(raw_parent, str) and raw_parent:
+                parent_session_id = raw_parent
+
+    starts = []
+    usage_events: list[tuple[int, dict]] = []
+    for index, event in enumerate(events):
+        payload = event.get("payload") or {}
+        if event.get("type") == "event_msg" and isinstance(payload, dict):
+            if payload.get("type") == "task_started":
+                starts.append(index)
+            elif payload.get("type") == "token_count":
+                info = payload.get("info") or {}
+                usage = _codex_usage(
+                    info.get("total_token_usage") if isinstance(info, dict) else None)
+                if usage is not None:
+                    usage_events.append((index, usage))
+
+    # Root files start at zero.  Child files containing an inherited prefix
+    # have multiple session_meta/task_started events; their last task_started
+    # is the beginning of the child's own work.
+    inherited_prefix = role == "subagent" and (
+        len(meta_events) > 1 or len(starts) > 1)
+    boundary = starts[-1] if starts else 0
+    baseline = {name: 0 for name in (
+        "input_tokens", "cached_input_tokens", "output_tokens",
+        "reasoning_output_tokens",
+    )}
+    baseline_found = not inherited_prefix
+    if inherited_prefix:
+        for index, usage in usage_events:
+            if index >= boundary:
+                break
+            baseline = usage
+            baseline_found = True
+
+    final_usage = usage_events[-1][1] if usage_events else None
+    final_after_boundary = bool(usage_events and usage_events[-1][0] >= boundary)
+    own_usage = None
+    if final_usage is not None and final_after_boundary and baseline_found:
+        candidate = {name: final_usage[name] - baseline[name] for name in baseline}
+        if (all(value >= 0 for value in candidate.values())
+                and candidate["cached_input_tokens"] <= candidate["input_tokens"]):
+            own_usage = candidate
+
+    model_name = None
+    for event in events[boundary:]:
+        if event.get("type") != "turn_context":
+            continue
+        payload = event.get("payload") or {}
+        model = payload.get("model") if isinstance(payload, dict) else None
+        if isinstance(model, str) and model:
+            model_name = model
+
+    return {
+        "session_id": session_id,
+        "role": role,
+        "parent_session_id": parent_session_id,
+        "model_name": model_name,
+        "inherited_usage": baseline if baseline_found else None,
+        "total_usage": final_usage,
+        "usage": own_usage,
+        "complete": (
+            role != "unknown" and model_name is not None and own_usage is not None
+        ),
+        "events": events,
+    }
+
+
+def build_codex_trajectory_bundle(trial_dir: Path) -> dict | None:
+    """Convert all Codex JSONL files into one versioned multi-agent bundle.
+
+    The bundle retains every parsed event and the root/subagent relationship.
+    It is scrubbed immediately before upload and scrubbed again by the server.
+    Malformed lines or missing identity/usage evidence make the bundle
+    incomplete; callers must suppress cost rather than report a partial sum.
+    """
+    sessions_dir = trial_dir / "agent" / "sessions"
+    if not sessions_dir.is_dir():
+        return None
+
+    files = sorted(sessions_dir.rglob("*.jsonl"))
+    if not files:
+        return None
+
+    sessions = []
+    parse_complete = True
+    for artifact_index, session_file in enumerate(files):
+        events = []
+        parse_error_count = 0
+        try:
+            handle = session_file.open(errors="replace")
+        except OSError:
+            parse_complete = False
+            record = _analyze_codex_session_events(
+                [], fallback_id=f"artifact:{artifact_index}")
+            record["artifact_index"] = artifact_index
+            record["parse_error_count"] = 1
+            record["complete"] = False
+            sessions.append(record)
+            continue
+        with handle:
+            for line in handle:
+                try:
+                    event = json.loads(line)
+                except (json.JSONDecodeError, TypeError):
+                    parse_error_count += 1
+                    continue
+                if not isinstance(event, dict):
+                    parse_error_count += 1
+                    continue
+                events.append(event)
+
+        record = _analyze_codex_session_events(
+            events, fallback_id=f"artifact:{artifact_index}")
+        record["artifact_index"] = artifact_index
+        record["parse_error_count"] = parse_error_count
+        if parse_error_count:
+            record["complete"] = False
+            parse_complete = False
+        sessions.append(record)
+
+    if not sessions:
+        return None
+
+    # A resumed run can leave multiple files for the same Codex session id.
+    # Retain every event stream in the bundle, but count the richest complete
+    # representative only once for billing.
+    representatives = {}
+    for item in sessions:
+        key = item["session_id"]
+        score = len(item["events"])
+        previous = representatives.get(key)
+        if previous is None or (item["complete"], score) > (
+                previous["complete"], len(previous["events"])):
+            representatives[key] = item
+
+    usage_sessions = []
+    for item in representatives.values():
+        usage = item.get("usage")
+        if usage is None:
+            continue
+        usage_sessions.append({
+            "session_id": item["session_id"],
+            "role": item["role"],
+            "parent_session_id": item["parent_session_id"],
+            "model_name": item["model_name"],
+            "n_input_tokens": usage["input_tokens"],
+            "n_cache_tokens": usage["cached_input_tokens"],
+            "n_output_tokens": usage["output_tokens"],
+            "n_reasoning_output_tokens": usage["reasoning_output_tokens"],
+        })
+    usage_sessions.sort(key=lambda item: (
+        item["role"] != "root", item["session_id"]))
+    root_count = sum(1 for item in representatives.values()
+                     if item["role"] == "root")
+    ids = set(representatives)
+    parent_graph_valid = True
+    for session_id, item in representatives.items():
+        if item["role"] != "subagent":
+            continue
+        parent = item["parent_session_id"]
+        seen = {session_id}
+        while parent is not None:
+            if parent in seen or parent not in ids:
+                parent_graph_valid = False
+                break
+            seen.add(parent)
+            parent = representatives[parent]["parent_session_id"]
+    complete = (
+        parse_complete
+        and all(item["complete"] for item in representatives.values())
+        and root_count == 1
+        and parent_graph_valid
+    )
+    aggregate = {
+        "n_input_tokens": sum(item["n_input_tokens"] for item in usage_sessions),
+        "n_cache_tokens": sum(item["n_cache_tokens"] for item in usage_sessions),
+        "n_output_tokens": sum(item["n_output_tokens"] for item in usage_sessions),
+        "n_reasoning_output_tokens": sum(
+            item["n_reasoning_output_tokens"] for item in usage_sessions),
+    }
+    return {
+        "schema_version": CODEX_TRAJECTORY_BUNDLE_SCHEMA,
+        "complete": complete,
+        "session_file_count": len(files),
+        "agent_session_count": len(representatives),
+        "root_session_count": root_count,
+        "subagent_session_count": sum(1 for item in representatives.values()
+                                      if item["role"] == "subagent"),
+        "aggregate_usage": aggregate,
+        "usage_sessions": usage_sessions,
+        "sessions": sessions,
+    }
+
+
+def codex_trajectory_bundle_usage(bundle: dict) -> dict:
+    """Return the compact accounting/audit view of a full bundle."""
+    return {
+        "schema": bundle["schema_version"],
+        "complete": bundle["complete"],
+        "session_file_count": bundle["session_file_count"],
+        "agent_session_count": bundle["agent_session_count"],
+        "root_session_count": bundle["root_session_count"],
+        "subagent_session_count": bundle["subagent_session_count"],
+        **bundle["aggregate_usage"],
+        "sessions": bundle["usage_sessions"],
+    }
+
+
+def aggregate_codex_session_usage(trial_dir: Path) -> dict | None:
+    """Build a bundle and return its compact accounting/audit view."""
+    bundle = build_codex_trajectory_bundle(trial_dir)
+    return codex_trajectory_bundle_usage(bundle) if bundle is not None else None
+
+
 def local_deep_swe_commit(tasks_root: Path) -> str | None:
     """HEAD commit of the volunteer's deep-swe checkout, or None when git is
     unavailable or tasks_root isn't inside a work tree (e.g. a plain tarball

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -167,6 +167,25 @@ def test_submit_sends_three_parts_and_client_meta_as_json_string(tmp_path):
     assert json.dumps({"dradar_version": "0.test"}).encode() in body
 
 
+def test_submit_sends_multi_agent_trajectory_bundle(tmp_path):
+    seen = {}
+
+    def handler(request):
+        seen["body"] = request.read()
+        return httpx.Response(200, json={"submission_id": "s1", "grade_status": "pending"})
+
+    patch = tmp_path / "model.patch"
+    patch.write_text("diff")
+    bundle = tmp_path / "trajectory_bundle.json"
+    bundle.write_text('{"schema_version":"dradar-codex-trajectory-bundle-v1"}')
+    _client(handler).submit(
+        "a1", "nonce", patch, None, None, {}, trajectory_bundle=bundle,
+    )
+    body = seen["body"]
+    assert b'name="trajectory_bundle"' in body
+    assert b'filename="trajectory_bundle.json"' in body
+
+
 def test_submit_sends_resume_generation_when_fenced(tmp_path):
     seen = {}
 

--- a/tests/test_multi_agent_usage.py
+++ b/tests/test_multi_agent_usage.py
@@ -1,0 +1,101 @@
+import json
+from pathlib import Path
+
+from dradar.runner import aggregate_codex_session_usage
+
+
+def _session(path: Path, session_id: str, role: str, usages: list[dict],
+             parent: str | None = None, inherited: dict | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    source = "exec"
+    if role == "subagent":
+        source = {"subagent": {"thread_spawn": {"parent_thread_id": parent}}}
+    events = [{"type": "session_meta", "payload": {
+        "id": session_id, "thread_source": role, "source": source,
+    }}]
+    if inherited is not None:
+        events += [
+            {"type": "session_meta", "payload": {
+                "id": parent, "thread_source": "user", "source": "exec",
+            }},
+            {"type": "event_msg", "payload": {
+                "type": "task_started",
+            }},
+            {"type": "event_msg", "payload": {
+                "type": "token_count", "info": {
+                    "total_token_usage": inherited},
+            }},
+        ]
+    events += [
+        {"type": "event_msg", "payload": {"type": "task_started"}},
+        {"type": "turn_context", "payload": {"model": "gpt-5.6-terra"}},
+    ]
+    events += [{"type": "event_msg", "payload": {
+        "type": "token_count", "info": {"total_token_usage": usage},
+    }} for usage in usages]
+    path.write_text("\n".join(json.dumps(event) for event in events) + "\n")
+
+
+def _usage(input_tokens, cached, output, reasoning=0):
+    return {"input_tokens": input_tokens, "cached_input_tokens": cached,
+            "output_tokens": output, "reasoning_output_tokens": reasoning,
+            "total_tokens": input_tokens + output}
+
+
+def test_aggregates_final_root_and_subagent_counters(tmp_path: Path):
+    sessions = tmp_path / "agent" / "sessions" / "2026" / "07" / "19"
+    _session(sessions / "root.jsonl", "root-1", "user", [
+        _usage(20, 10, 2), _usage(100, 60, 10, 4),
+    ])
+    _session(sessions / "child.jsonl", "child-1", "subagent", [
+        _usage(150, 80, 15, 7),
+    ], parent="root-1", inherited=_usage(100, 60, 10, 4))
+
+    usage = aggregate_codex_session_usage(tmp_path)
+
+    assert usage is not None and usage["complete"] is True
+    assert usage["agent_session_count"] == 2
+    assert usage["root_session_count"] == 1
+    assert usage["subagent_session_count"] == 1
+    assert usage["n_input_tokens"] == 150
+    assert usage["n_cache_tokens"] == 80
+    assert usage["n_output_tokens"] == 15
+    assert usage["n_reasoning_output_tokens"] == 7
+    assert usage["sessions"][1]["parent_session_id"] == "root-1"
+
+
+def test_duplicate_session_id_uses_largest_cumulative_record(tmp_path: Path):
+    sessions = tmp_path / "agent" / "sessions"
+    _session(sessions / "old.jsonl", "root-1", "user", [_usage(10, 5, 1)])
+    _session(sessions / "new.jsonl", "root-1", "user", [_usage(30, 20, 4)])
+
+    usage = aggregate_codex_session_usage(tmp_path)
+
+    assert usage is not None and usage["complete"] is True
+    assert usage["session_file_count"] == 2
+    assert usage["agent_session_count"] == 1
+    assert usage["n_input_tokens"] == 30
+    assert usage["n_output_tokens"] == 4
+
+
+def test_missing_child_token_count_marks_aggregate_incomplete(tmp_path: Path):
+    sessions = tmp_path / "agent" / "sessions"
+    _session(sessions / "root.jsonl", "root-1", "user", [_usage(30, 20, 4)])
+    child = sessions / "child.jsonl"
+    child.write_text(json.dumps({"type": "session_meta", "payload": {
+        "id": "child-1", "thread_source": "subagent",
+        "source": {"subagent": {"thread_spawn": {
+            "parent_thread_id": "root-1"}}},
+    }}) + "\n" + json.dumps({"type": "turn_context", "payload": {
+        "model": "gpt-5.6-terra"}}) + "\n")
+
+    usage = aggregate_codex_session_usage(tmp_path)
+
+    assert usage is not None and usage["complete"] is False
+    assert usage["agent_session_count"] == 2
+    assert usage["subagent_session_count"] == 1
+    assert usage["n_input_tokens"] == 30
+
+
+def test_no_sessions_returns_none(tmp_path: Path):
+    assert aggregate_codex_session_usage(tmp_path) is None

--- a/tests/test_pending_upload.py
+++ b/tests/test_pending_upload.py
@@ -111,6 +111,172 @@ def test_upload_success_clears_ledger(tmp_path: Path, monkeypatch):
     assert pending.load(tmp_path) == []
 
 
+def _write_codex_session(path: Path, session_id: str, role: str,
+                         input_tokens: int | None, cached: int = 0,
+                         output: int = 0, parent: str | None = None):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    source = "exec" if role == "user" else {
+        "subagent": {"thread_spawn": {"parent_thread_id": parent}}}
+    events = [{"type": "session_meta", "payload": {
+        "id": session_id, "thread_source": role, "source": source}}]
+    events += [
+        {"type": "event_msg", "payload": {"type": "task_started"}},
+        {"type": "turn_context", "payload": {"model": "gpt-5.6-terra"}},
+    ]
+    if input_tokens is not None:
+        events.append({"type": "event_msg", "payload": {
+            "type": "token_count", "info": {"total_token_usage": {
+                "input_tokens": input_tokens,
+                "cached_input_tokens": cached,
+                "output_tokens": output,
+                "reasoning_output_tokens": 0,
+                "total_tokens": input_tokens + output,
+            }}}})
+    path.write_text("\n".join(json.dumps(event) for event in events) + "\n")
+
+
+def test_upload_replaces_pier_cost_with_complete_multi_agent_sum(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    (trial_dir / "result.json").write_text(json.dumps({"agent_result": {
+        "cost_usd": 1.23, "n_input_tokens": 50,
+        "n_cache_tokens": 20, "n_output_tokens": 5}}))
+    sessions = trial_dir / "agent" / "sessions"
+    _write_codex_session(sessions / "root.jsonl", "root-1", "user",
+                         100, 60, 10)
+    _write_codex_session(sessions / "child.jsonl", "child-1", "subagent",
+                         50, 20, 5, parent="root-1")
+
+    class CaptureClient(FakeClient):
+        def submit(self, assignment_id, nonce, patch, trajectory, result, meta,
+                   outcome="completed", resume_generation=None,
+                   trajectory_bundle=None):
+            assert meta["cost_usd"] is None
+            assert meta["n_input_tokens"] == 150
+            assert meta["n_cache_tokens"] == 80
+            assert meta["n_output_tokens"] == 15
+            assert meta["usage_aggregation_complete"] is True
+            assert meta["subagent_session_count"] == 1
+            assert len(meta["agent_session_usage"]) == 2
+            bundle = json.loads(trajectory_bundle.read_text())
+            assert bundle["schema_version"] == meta["usage_aggregation"]
+            assert len(bundle["sessions"]) == 2
+            uploaded = json.loads(result.read_text())
+            agent = uploaded["agent_result"]
+            assert agent["cost_usd"] is None
+            assert agent["n_input_tokens"] == 150
+            assert agent["metadata"]["codex_session_usage"]["complete"] is True
+            return {"submission_id": "s1", "grade_status": "pending"}
+
+    outcome = runloop._upload_trial(
+        CaptureClient(lambda _aid: None), _entry(trial_dir, meta={"cost_usd": 1.23}))
+    assert outcome == "submitted"
+
+
+def test_upload_leaves_single_session_cost_and_metadata_unchanged(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    original_result = {"agent_result": {
+        "cost_usd": 1.23, "n_input_tokens": 50,
+        "n_cache_tokens": 20, "n_output_tokens": 5}}
+    (trial_dir / "result.json").write_text(json.dumps(original_result))
+    _write_codex_session(
+        trial_dir / "agent" / "sessions" / "root.jsonl",
+        "root-1", "user", 50, 20, 5,
+    )
+
+    original_meta = {
+        "cost_usd": 1.23, "n_input_tokens": 50,
+        "n_cache_tokens": 20, "n_output_tokens": 5,
+    }
+
+    class CaptureClient(FakeClient):
+        def submit(self, assignment_id, nonce, patch, trajectory, result, meta,
+                   outcome="completed", resume_generation=None,
+                   trajectory_bundle=None):
+            assert meta == original_meta
+            assert json.loads(result.read_text()) == original_result
+            return {"submission_id": "s1", "grade_status": "pending"}
+
+    outcome = runloop._upload_trial(
+        CaptureClient(lambda _aid: None),
+        _entry(trial_dir, meta=original_meta),
+    )
+    assert outcome == "submitted"
+
+
+def test_upload_suppresses_cost_when_any_subagent_usage_is_missing(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    (trial_dir / "result.json").write_text(json.dumps({"agent_result": {
+        "cost_usd": 1.23, "n_input_tokens": 50}}))
+    sessions = trial_dir / "agent" / "sessions"
+    _write_codex_session(sessions / "root.jsonl", "root-1", "user", 100, 60, 10)
+    _write_codex_session(sessions / "child.jsonl", "child-1", "subagent",
+                         None, parent="root-1")
+
+    class CaptureClient(FakeClient):
+        def submit(self, assignment_id, nonce, patch, trajectory, result, meta,
+                   outcome="completed", resume_generation=None,
+                   trajectory_bundle=None):
+            assert meta["cost_usd"] is None
+            assert meta["n_input_tokens"] is None
+            assert meta["usage_aggregation_complete"] is False
+            assert trajectory_bundle is not None
+            agent = json.loads(result.read_text())["agent_result"]
+            assert agent["cost_usd"] is None
+            assert agent["n_input_tokens"] is None
+            return {"submission_id": "s1", "grade_status": "pending"}
+
+    outcome = runloop._upload_trial(
+        CaptureClient(lambda _aid: None), _entry(trial_dir, meta={"cost_usd": 1.23}))
+    assert outcome == "submitted"
+
+
+def test_retry_rebuilds_and_resends_multi_agent_bundle(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    (trial_dir / "result.json").write_text(json.dumps({"agent_result": {
+        "cost_usd": 1.23}}))
+    sessions = trial_dir / "agent" / "sessions"
+    _write_codex_session(sessions / "root.jsonl", "root-1", "user", 100, 60, 10)
+    _write_codex_session(sessions / "child.jsonl", "child-1", "subagent",
+                         50, 20, 5, parent="root-1")
+
+    class FlakyClient(FakeClient):
+        def __init__(self):
+            super().__init__(lambda _aid: None)
+            self.attempts = 0
+
+        def submit(self, assignment_id, nonce, patch, trajectory, result, meta,
+                   outcome="completed", resume_generation=None,
+                   trajectory_bundle=None):
+            self.attempts += 1
+            assert trajectory_bundle is not None
+            assert json.loads(trajectory_bundle.read_text())["complete"] is True
+            if self.attempts == 1:
+                raise ApiError("server returned 503: retry", status_code=503)
+            return {"submission_id": "s1", "grade_status": "pending"}
+
+    client = FlakyClient()
+    first = runloop._upload_trial(
+        client, _entry(trial_dir, meta={"cost_usd": 1.23}))
+    assert first == "upload-failed"
+    retry_entry = pending.load(tmp_path)[0]
+    second = runloop._upload_trial(client, retry_entry)
+    assert second == "submitted"
+    assert client.attempts == 2
+    assert pending.load(tmp_path) == []
+
+
 def test_upload_omits_malformed_optional_trajectory(tmp_path: Path, monkeypatch, capsys):
     monkeypatch.setattr(runloop, "HOME", tmp_path)
     trial_dir = _make_trial_dir(tmp_path)


### PR DESCRIPTION
Adds a versioned Codex trajectory bundle containing root and subagent event streams, subtracts inherited parent context before aggregating usage, suppresses partial costs, preserves single-session behavior, and uploads the bundle for independent server validation. Includes retry, malformed/incomplete, transport, and accounting regression tests. CLI version: 0.5.7. Tests: 252 passed.