### PR TITLE
fix: omit malformed scrubbed trajectory bundles

### DIFF
--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -385,10 +385,16 @@ def _upload_trial(
                 trajectory_bundle, ensure_ascii=False, separators=(",", ":"),
             ).encode("utf-8")
             trajectory_bundle_scrubbed.write_bytes(scrub_bytes(serialized))
-            # Redaction must never turn a valid bundle into malformed JSON.
-            # Treat that as a local bug and retain the pending upload instead
-            # of sending bytes the server must permanently reject.
-            json.loads(trajectory_bundle_scrubbed.read_bytes())
+            try:
+                json.loads(trajectory_bundle_scrubbed.read_bytes())
+            except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+                # The bundle is optional display data.  A redaction bug must
+                # not strand an otherwise valid patch/result or make every
+                # later `go` retry the same broken local upload forever.
+                print(f"  {task_id}: redaction produced a malformed optional "
+                      f"trajectory bundle ({exc}); uploading the verified "
+                      "result without it")
+                trajectory_bundle_scrubbed = None
         traj_scrubbed = None
         if trajectory:
             traj_scrubbed = scrubbed / "trajectory.json"

--- a/tests/test_pending_upload.py
+++ b/tests/test_pending_upload.py
@@ -175,6 +175,40 @@ def test_upload_replaces_pier_cost_with_complete_multi_agent_sum(
     assert outcome == "submitted"
 
 
+def test_upload_omits_bundle_when_redaction_breaks_its_json(
+    tmp_path: Path, monkeypatch, capsys,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    (trial_dir / "result.json").write_text(json.dumps({"agent_result": {
+        "cost_usd": 1.23, "n_input_tokens": 50}}))
+    sessions = trial_dir / "agent" / "sessions"
+    _write_codex_session(sessions / "root.jsonl", "root-1", "user",
+                         100, 60, 10)
+    _write_codex_session(sessions / "child.jsonl", "child-1", "subagent",
+                         50, 20, 5, parent="root-1")
+    monkeypatch.setattr(runloop, "scrub_bytes",
+                        lambda _data: b'{"broken":"bad\\q"}')
+
+    class CaptureClient(FakeClient):
+        def submit(self, assignment_id, nonce, patch, trajectory, result, meta,
+                   outcome="completed", resume_generation=None,
+                   trajectory_bundle=None):
+            assert trajectory_bundle is None
+            assert meta["usage_aggregation_complete"] is True
+            agent = json.loads(result.read_text())["agent_result"]
+            assert agent["cost_usd"] is None
+            assert agent["n_input_tokens"] == 150
+            return {"submission_id": "s1", "grade_status": "pending"}
+
+    outcome = runloop._upload_trial(
+        CaptureClient(lambda _aid: None),
+        _entry(trial_dir, meta={"cost_usd": 1.23}),
+    )
+    assert outcome == "submitted"
+    assert "malformed optional trajectory bundle" in capsys.readouterr().out
+
+
 def test_upload_leaves_single_session_cost_and_metadata_unchanged(
     tmp_path: Path, monkeypatch,
 ):


### PR DESCRIPTION
"'## Summary\n- keep completed patch/result uploads moving when redaction corrupts an optional multi-session trajectory bundle\n- omit only the malformed optional bundle instead of crashing before the pending ledger is recorded\n- add a regression test for the exact failure mode\n\n## Tests\n- ........................................................................ [ 28%]
........................................................................ [ 56%]
........................................................................ [ 85%]
......................................                                   [100%]
254 passed in 0.56s (254 passed)'"