### PR TITLE
docs: 完善 CLI 全量命令与功能说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,199 +1,514 @@
 # dradar — DeepSWE 众测 CLI
 
-社区志愿者用自己的 Codex/Claude 订阅额度跑 DeepSWE 基准任务，产出提交给服务端独立重跑判分、汇总上榜。这个仓库是**客户端**——运行在你自己机器上的部分。服务端（调度、判分、榜单）不在这个仓库里，是私有的。
+`dradar` 是运行在志愿者自己电脑上的 DeepSWE 众测客户端。它负责查看和领取任务、在
+Docker 沙箱中调用本机已经登录的 Codex/Claude、保存中断恢复点、上传结果，并查看服务端
+的独立判分。调度、判分和榜单由服务端完成，不在本仓库中。
 
-## 它做什么
+- 官网与任务大表：[deng.codexradar.com](https://deng.codexradar.com)
+- CLI 仓库：[github.com/SecurityMind/dradar](https://github.com/SecurityMind/dradar)
+- 当前 CLI 版本：运行 `dradar --version` 查看
 
-```
-你的机器                                 服务端(独立仓库，私有)
-┌────────────────────────────┐          ┌──────────────────────────────┐
-│ dradar go / resume          │──领题──▶ │ 覆盖度优先调度 + 租约          │
-│  └─ pier run (docker 沙箱,  │◀─指派──  │ /submissions 二次脱敏入库      │
-│      无判分，出口白名单)      │          │  └─ grading worker:          │
-│  └─ 脱敏 → 上传 patch +     │──提交──▶ │      独立重跑判分              │
-│      trajectory + result    │          │ 榜单 / 大表 (公开可查)          │
-└────────────────────────────┘          └──────────────────────────────┘
-```
+## 工作原理
 
-- **判分不信任客户端**：服务端用任务自带的 verifier 对回传的 patch 重新判分，客户端自报的结果一概不算数
-- **你的订阅凭据全程留在你自己机器上**，从不上传到服务端——CLI 只是调用你本地已登录的 `codex`/`claude` CLI
-- 上传前有敏感信息扫描，带密钥的补丁直接拒收
-
-## 快速开始
-
-最简单的方式：去 [deng.codexradar.com](https://deng.codexradar.com) 用 GitHub 登录、在大表里点一个还没人做的格子认领——网站会直接给你一条粘贴命令，装 CLI、认证、开始跑这道题一次搞定。
-
-也可以手动来：
-
-```bash
-# 一次性
-uvx --from git+https://github.com/SecurityMind/dradar dradar login \
-  --server https://api.codexradar.com --token <your-token>
-uvx --from git+https://github.com/SecurityMind/dradar dradar doctor   # 体检，按提示修复
-
-# 日常
-uvx --from git+https://github.com/SecurityMind/dradar dradar go       # 领题 → 跑 → 自动上传
-uvx --from git+https://github.com/SecurityMind/dradar dradar resume   # 继续上次没跑完的
-uvx --from git+https://github.com/SecurityMind/dradar dradar leases   # 查看当前占用：运行中 / 排队中
-uvx --from git+https://github.com/SecurityMind/dradar dradar release  # 交互选择并释放不再准备跑的格子
+```text
+你的机器                                      DRadar 服务端
+┌────────────────────────────────┐           ┌────────────────────────────┐
+│ dradar cells / go / resume     │──查询/领题▶│ 推荐、原子领取、租约与心跳    │
+│  └─ Pier + Docker 沙箱          │           │                            │
+│      └─ 本机 Codex/Claude       │           │ 独立 verifier 重新判分       │
+│  └─ checkpoint / 脱敏 / 上传    │──提交结果▶│ 积分、榜单与公开大表          │
+└────────────────────────────────┘           └────────────────────────────┘
 ```
 
-一条命令并发执行多道题时，显式指定 worker 数；默认仍为 1，不会改变普通运行行为：
-
-```bash
-dradar go --auto 5 --workers 3       # 最多持有 5 道，同时运行 3 道
-dradar resume --workers 3            # 用 3 个 worker 继续现有任务
-dradar capacity                      # 查看本机保守推荐并发数
-dradar resume --workers auto         # 按 Docker CPU/内存、磁盘和账号上限自动选择
-```
-
-### 在 CLI 中查看全量格子
-
-`dradar cells` 读取与网页大表相同的公开 `/api/v1/table` 快照，只查看、不认领。
-默认按当前积分倍率从高到低显示前 20 个格子；可以组合模型、推理强度、状态、任务名、
-倍率和测试量条件，并切换排序字段：
-
-```bash
-dradar cells --available --model gpt-5.5 --effort xhigh
-dradar cells --available --min-multiplier 2 --sort multiplier
-dradar cells --model gpt-5.6-sol --max-tests 2 --sort tests --reverse
-dradar cells --state cooldown --task cache --sort minutes
-dradar cells --available --all --json
-```
-
-`--model`、`--effort` 和 `--state` 可以重复使用；模型和推理强度也接受逗号分隔。
-数值排序默认从高到低，文本排序默认按字母顺序，`--reverse` 反转方向。
-`--limit N` 控制显示数量（默认 20），`--all` 返回全部匹配项。表是公开快照，
-查看到的开放格子仍可能在随后认领前被其他人抢走；实际领取仍由
-`dradar go --pick TASK:MODEL:EFFORT` 或 `dradar go --auto N` 完成。
-
-父进程只认领一次任务，再由服务端原子地给各 worker 分题，不会让多个 worker 重复
-执行同一道题。worker 共享本机 CPU、内存和模型额度；未传 `-y` 时会在启动前确认一次。
-中断或部分 worker 启动失败时，父进程会统一停止已经启动的 worker，已完成上传和
-checkpoint 均保留。`--parallel` 继续作为手工启动多个独立 CLI 进程时的底层选项，
-使用 `--workers` 时不需要再传。
-
-`--workers auto` 读取 Docker 引擎实际可用资源（Docker Desktop/OrbStack 可能只分到
-宿主机的一部分），按每个任务至少 2 CPU、6 GiB 内存并预留构建峰值保守推荐。检测失败
-时自动退回 1；普通用户自动推荐最多 4。与 `--refill` 同时使用时，持有队列至少补到
-实际 worker 数，避免“1 题起步”把多并发锁成 1；额度和任务硬上限不会因此提高。
-手动 `--workers N` 的既有行为不变。
-
-任务仓库默认克隆到 `~/.dradar/deep-swe/tasks`；如需放在其他位置，再传
-`--tasks-root <路径>`。已有配置中的旧路径会继续使用，不会自动搬迁或重复克隆。
-
-批量释放尚未开始的格子用 `dradar release --all`；指定格子用
-`dradar release <assignment-id>`。正在本地运行的格子默认受到保护，只有确认本地
-runner 已停止但状态仍卡住时才使用 `dradar release <assignment-id> --force`，避免
-把仍在消耗额度的任务释放给别人重复运行。
-
-其他命令：`dradar status`（看自己的提交记录/积分/异常标记和占用摘要）、`dradar rename <新名字>`（改榜单显示名，积分不受影响）、`dradar link-github`（把账号和 GitHub 身份绑定，换机器能找回身份）、`dradar retry-upload`（补传因网络问题失败的提交）。
-
-## 中断续跑与本地清理
-
-Codex 任务运行期间，Pier 每 30 秒把工作区差异、未跟踪文件、Codex session id、
-运行阶段和心跳写入 `~/.dradar/work/jobs/` 下的私有 checkpoint。WebSocket/TLS
-断开、模型容量不足、CLI 退出或机器重启后，下一次 `dradar go` / `resume` 会先恢复
-checkpoint，再领取新格子。原 Codex session 不可用时会保留工作区，用已有进度摘要
-启动新 session 继续。
-
-```bash
-dradar resume                         # 优先恢复所有未完成 checkpoint
-dradar resume --assignment <id>       # 只恢复指定 assignment
-dradar checkpoints                    # 查看状态、更新时间和磁盘占用
-dradar checkpoint discard <id>        # 放弃 checkpoint 并重新开放格子
-```
-
-checkpoint 不保存账号 Token、assignment nonce 或 Codex `auth.json`；恢复时重新向
-服务端鉴权。凭据形态的工作区内容会使 checkpoint 安全失效，session 中检测到凭据
-则不持久化该 session，并降级为保留工作区的新会话恢复。
-
-磁盘默认不会无限增长：提交成功或服务端确认已提交后立即删除该题的所有本地副本；
-恢复产生新副本后删除旧副本；损坏、不兼容、超过 7 天或租约已失效的 checkpoint
-会被标记无效、重新开放格子并回收。上传暂时失败时只保留可重试的最新任务目录；
-只有显式传入 `--keep` 才保留成功任务的最终目录。
-
-交互运行在成功上传后会询问是否立即删除本地任务文件，直接回车保持原有的
-“成功后清理”默认行为；`-y` / `--parallel` 不会弹窗。随时运行
-`dradar cleanup --dry-run` 预览可释放空间，或运行 `dradar cleanup` 一键清理。
-清理命令会先向服务端确认当前租约，绝不删除仍在运行、可以恢复、等待上传或由
-`--keep` 明确保留的任务；清理由 `--keep` 保护的目录需显式使用
-`dradar cleanup --include-kept`。
-
-### 持续自动补题（显式开启）
-
-普通 `go` / `resume` 仍只运行用户已经认领的题，不会在后台继续领题。交互运行会在
-启动时询问一次是否持续补题，默认回答为否。无人值守或并发运行必须显式给出硬上限：
-
-```bash
-dradar resume -y --refill --refill-to 5 \
-  --quota-tier pro-5x --max-estimated-quota-pct 15
-```
-
-`--refill-to` 是持有/运行队列目标；预计额度上限是用户需要指定的主要停止条件，会按
-`--quota-tier` 换算。接近上限时不再补充，让队列自然排空；缺少可靠估价的题不会被
-自动领取。CLI 另有一个正常情况下不会触发的内部题数安全上限；高级用户仍可用
-`--max-tasks` 把它设得更低。多个本机
-`--parallel` worker 在同一个 `DRADAR_HOME` 下共用带文件锁的持久化计划，不会各自
-重新计算额度或任务数。任何非正常提交都会停止补题，但不会释放已有租约或删除
-checkpoint。
-
-```bash
-dradar refill status   # 查看共享计划、已预留题数和停止原因
-dradar refill stop     # 立即停止继续领题，已有任务保持原样
-```
-
-自动补题继续使用网页“系统推荐”同一个 `/api/v1/suggest` 接口，不在 CLI 内维护第二套
-推荐算法。当前共享上限以本机 `DRADAR_HOME` 为边界；不要在多台机器上分别创建补题
-计划，否则每台机器会拥有自己的独立上限。
-
-## 租约心跳与隐私
-
-`dradar go` / `resume` 会为本次 CLI 进程建立一个轻量会话心跳：运行或上传时约
-60 秒一次，准备、排队或暂停时约 120 秒一次。它按“会话”上报，不按认领的格子
-数量上报；一次拿 10 个格子也仍然只有一条心跳。服务端还可以返回更慢的间隔，
-以便在高峰期主动降流量。
-
-心跳只包含 CLI 版本、粗粒度平台（macOS/Linux/WSL/Windows）、阶段、当前
-assignment id、递增序号和进度计数；不会包含任务内容、prompt、trajectory、patch、
-命令输出、主机名、用户名、硬件信息或订阅凭据。正常心跳只保留当前会话状态和
-5 分钟聚合桶，不逐条写审计日志。
-
-当前为影子观察阶段：服务端只记录“按候选规则本来会怀疑/释放”，**不会因为心跳
-中断自动释放任何格子**。断网也不会终止正在运行的 Pier。你始终可以用
-`dradar leases` 查看占用，用 `dradar release` / `release --all` 手动归还；运行中格子
-仍受默认保护，需明确 `--force` 才能释放。
+- **客户端结果不直接算分**：服务端使用任务自带的 verifier 重新运行 patch 并独立判分。
+- **订阅凭据留在本机**：DRadar 调用本地已经登录的 Codex/Claude，不上传账号 Token、
+  Codex `auth.json` 或 Claude OAuth Token。
+- **上传前扫描敏感信息**：带密钥或凭据形态内容的补丁会被拒绝，trajectory 也会先脱敏。
+- **领取由服务端原子裁决**：查询到的 `open` 只是快照；真正领取时服务端会再次检查，
+  避免同一空位被并发重复发放。
 
 ## 环境要求
 
-- Docker（推荐 [OrbStack](https://orbstack.dev/)，macOS 上更轻量）
-- 本地已登录 `codex` 或 `claude` CLI（订阅凭据留在本地，不经过 dradar）
-- `dradar doctor` 会检查这些前置条件并给出针对性的修复建议（macOS/Linux/WSL2/Windows）
+- Python 3.11 或更高版本，以及 [`uv`](https://docs.astral.sh/uv/)
+- Docker，推荐 macOS 使用 [OrbStack](https://orbstack.dev/)
+- 本机已登录 `codex` 或 `claude` CLI，二者准备好一个即可
+- 至少约 20 GB 可用磁盘；多 worker 需要更多 CPU、内存和磁盘
 
-### 原生 Windows 候选支持
-
-原生 Windows 需要 Docker Desktop 运行 **Linux containers**，并在 PowerShell
-中安装可直接调用的 Codex CLI。IDE 扩展能登录不等于 `codex` 命令已在 `PATH` 中；
-请以 `dradar doctor` 的实际检查结果为准。Codex CLI 的官方 PowerShell 安装命令是：
+原生 Windows 为候选支持，需要 Docker Desktop 运行 Linux containers，并确保 Codex CLI
+能直接在 PowerShell 的 `PATH` 中调用。WSL2 也可使用，不限定 Ubuntu。
 
 ```powershell
 irm https://chatgpt.com/codex/install.ps1 | iex
 codex login
 ```
 
-WSL2 仍然可用，但不限定 Ubuntu；Debian、OpenSUSE 等普通 WSL2 Linux 发行版也可以。
-Docker Desktop 自己的 `docker-desktop` 是内部发行版，不能替代供用户安装并运行
-DRadar 的普通 WSL2 发行版。
+## 安装与快速开始
 
-常见环境坑：OrbStack 首次启动需要打开一次 GUI 初始化；`uv` 会给 `.venv` 打上 macOS 隐藏标志，导致 Python 3.12 跳过 `.pth` 文件（`doctor` 会检测并提示 `chflags -R nohidden .venv` 修复）。
+最简单的入口是在官网用 GitHub 登录，选择一个开放格子，然后把页面生成的完整提示词粘贴
+给 Codex。提示词会检查环境、安装最新版 CLI、登录并询问运行方式。
+
+手动使用时，可以一直通过 GitHub 主线运行最新版：
+
+```bash
+uvx --from git+https://github.com/SecurityMind/dradar dradar --version
+uvx --from git+https://github.com/SecurityMind/dradar dradar login \
+  --server https://api.codexradar.com --token <YOUR_TOKEN>
+uvx --from git+https://github.com/SecurityMind/dradar dradar doctor
+```
+
+下面的文档为了简洁统一写成 `dradar ...`。如果没有把它安装成全局命令，就在每条命令前
+加上：
+
+```bash
+uvx --from git+https://github.com/SecurityMind/dradar
+```
+
+最常见的一次运行：
+
+```bash
+dradar cells --available --limit 10    # 查看开放格子，不领取
+dradar go --auto 3                     # 自动选到总计 3 题，默认串行运行
+dradar status                          # 查看自己的提交和判分
+```
+
+## 命令总览
+
+| 命令 | 是否改动状态 | 用途 |
+| --- | --- | --- |
+| `dradar --version` | 否 | 查看当前 CLI 版本 |
+| `dradar login` | 本地配置 | 保存服务端和 Token、注册新账号或通过 GitHub 恢复身份 |
+| `dradar doctor` | 可能安装依赖 | 检查 Docker、Pier、Codex/Claude、任务仓库、磁盘和登录状态 |
+| `dradar capacity` | 否 | 根据 Docker 资源、磁盘和账号上限推荐安全 worker 数 |
+| `dradar cells` | 否 | 查看、筛选和排序完整格子表，不领取任务 |
+| `dradar go` | 是 | 使用网页已领任务，或从 CLI 精确/自动领题并运行、上传 |
+| `dradar resume` | 是 | 优先恢复 checkpoint，再继续当前仍持有的任务 |
+| `dradar status` | 否 | 查看自己的积分、最近提交、判分、异常标记和占用摘要 |
+| `dradar leases` | 否 | 查看当前持有的 assignment，区分 running 与 waiting |
+| `dradar release` | 是 | 释放不再准备运行的租约；运行中任务默认受保护 |
+| `dradar checkpoints` | 否 | 查看本地恢复点、阶段、更新时间和磁盘占用 |
+| `dradar checkpoint discard` | 是 | 删除指定恢复点，并安全重新开放对应格子 |
+| `dradar retry-upload` | 是 | 重试已经运行完成但因网络等原因没有上传的结果 |
+| `dradar cleanup` | 本地删除 | 安全清理已结算且不可恢复的本地任务文件 |
+| `dradar refill status` | 否 | 查看本机持续补题计划和额度预留 |
+| `dradar refill stop` | 是 | 停止继续领取新题，保留已有任务和 checkpoint |
+| `dradar rename` | 是 | 修改榜单昵称，积分不变 |
+| `dradar link-github` | 是 | 绑定 GitHub 身份，显示头像并支持跨机器找回账号 |
+
+任何命令都可以用 `--help` 查看当前版本的参数：
+
+```bash
+dradar --help
+dradar go --help
+dradar cells --help
+```
+
+## 账号与环境命令
+
+### `dradar login`
+
+保存服务端地址、身份 Token 和可选任务仓库位置。配置写入
+`$DRADAR_HOME/config.json`，默认 `DRADAR_HOME=~/.dradar`。
+
+```bash
+# 使用官网提供的 Token
+dradar login --server https://api.codexradar.com --token <YOUR_TOKEN>
+
+# 首次自行注册昵称
+dradar login --server https://api.codexradar.com --nickname alice
+
+# 只配置服务端；第一次 go 时自动生成匿名身份
+dradar login --server https://api.codexradar.com
+
+# 在新机器上恢复已经绑定 GitHub 的身份
+dradar login --server https://api.codexradar.com --github
+
+# 把任务仓库放到自定义位置
+dradar login --server https://api.codexradar.com --token <YOUR_TOKEN> \
+  --tasks-root /data/deep-swe/tasks
+```
+
+`--github` 只能恢复之前执行过 `dradar link-github` 的账号。新安装默认把任务仓库放到
+`~/.dradar/deep-swe/tasks`；升级时会保留已有的自定义路径，不会偷偷搬迁或重复克隆。
+
+### `dradar doctor`
+
+运行完整环境体检，并给出与 macOS、Linux、WSL2 或 Windows 对应的修复建议。它会检查：
+
+- Docker CLI、Docker daemon 和 Compose 插件；
+- 与 DRadar 固定版本兼容的 Pier，缺失时会尝试安装；
+- Codex CLI + `auth.json`，或 Claude CLI + OAuth Token；
+- DeepSWE 任务仓库，缺失时会尝试克隆；
+- 可用磁盘和服务端登录。
+
+```bash
+dradar doctor
+```
+
+体检失败不会领取任务。修复所有 `FAIL` 后重新运行即可。
+
+### `dradar capacity`
+
+只读检查本机适合的并发数，不领取任务。它使用 Docker 引擎实际可用资源，而不是宿主机
+宣传配置，因为 Docker Desktop/OrbStack 可能只分到一部分资源。
+
+```bash
+dradar capacity
+```
+
+当前保守规则包括：每个 worker 至少预留 2 CPU、6 GiB 内存，Docker 额外预留 2 GiB；
+第一个 worker 预留 20 GiB 磁盘，每增加一个再预留 12 GiB。普通自动推荐最多 4，最终
+结果还会被账号并发上限和可运行题目数限制。检测失败时回退到 1。
+
+### `dradar link-github`、`rename` 与 `status`
+
+```bash
+dradar link-github          # 浏览器设备码流程，绑定 GitHub
+dradar rename new-name     # 修改榜单昵称，保留积分
+dradar status              # 只读查看自己的状态
+```
+
+`status` 最多展示最近 20 条提交，包括模型、effort、`pending`/`grading`/`graded`/
+`error`/`invalid` 状态、通过或失败、异常标记和客户端错误摘要；还会提示待补传结果和当前
+租约数量。它不会自动上传或修改任何数据。
+
+## 查询格子：`dradar cells`
+
+`cells` 读取与网页大表相同的公开快照，只查看、不占位。默认按积分倍率从高到低显示前
+20 个格子。
+
+```bash
+dradar cells
+dradar cells --available --model gpt-5.6-sol --effort high
+dradar cells --available --min-multiplier 2 --sort multiplier
+dradar cells --model gpt-5.5 --max-tests 2 --sort tests --reverse
+dradar cells --state cooldown --task cache --sort minutes
+dradar cells --available --all --json
+```
+
+### 格子状态
+
+| 状态 | 含义 |
+| --- | --- |
+| `open` | 当前还有空位，可以尝试领取 |
+| `leased` | 已被持有或为专属保留格，当前容量已满 |
+| `running` | 已有人真正启动任务并持续上报心跳 |
+| `queued` | 已提交并等待服务端判分，判分队列占满该格容量 |
+| `cooldown` | 最近产生有效判分，处于重新开放前的冷却期 |
+
+使用 `--available` 等价于只看 `open`；也可以重复传入 `--state` 查看多个状态。
+
+### 输出字段
+
+| 字段 | 含义 |
+| --- | --- |
+| `TASK` | 任务 ID |
+| `MODEL` / `EFFORT` | 模型和推理强度 |
+| `MULT` | 如果此时成功领取，预计快照的积分倍率 |
+| `PRI` | 服务端推荐优先级，未设置时按 0 处理 |
+| `TESTS` | 该格子的历史测试总数 |
+| `PASS` | 最近滚动窗口中的通过率，不等于终身通过率 |
+| `MIN` | 预计运行分钟数 |
+| `COST` | 预计模型成本，仅供参考，不是订阅余额 |
+
+### 筛选与排序参数
+
+| 参数 | 作用 |
+| --- | --- |
+| `--model MODEL` | 按模型筛选；可重复或用逗号分隔 |
+| `--effort EFFORT` | 按推理强度筛选；可重复或用逗号分隔 |
+| `--available` | 只显示 `open` |
+| `--state STATE` | 按状态筛选；可重复，不能和 `--available` 同时使用 |
+| `--task TEXT` | 任务 ID 包含指定文本，不区分大小写 |
+| `--min-multiplier X` | 最低积分倍率 |
+| `--min-tests N` / `--max-tests N` | 历史测试数范围 |
+| `--min-priority N` | 最低推荐优先级 |
+| `--sort FIELD` | `multiplier`、`tests`、`pass-rate`、`minutes`、`cost`、`priority`、`task`、`model`、`effort` 或 `state` |
+| `--reverse` | 反转默认排序方向 |
+| `--limit N` | 最多显示 N 行，默认 20 |
+| `--all` | 显示全部匹配结果，不能和 `--limit` 同时使用 |
+| `--json` | 输出适合脚本或 Codex 读取的 JSON |
+
+查询与领取之间可能发生竞争：即使刚看到 `open`，也可能已被别人抢先领取。服务端会在
+数据库事务中最终确认，不会启动重复任务；CLI 会收到 `409 Conflict`。精确选题会提示
+未领取，自动选题会跳过冲突格继续尝试其他候选。
+
+## 领取与运行：`dradar go`
+
+`go` 会依次完成环境准备、补传旧结果、优先恢复本地 checkpoint、取得任务、运行 Pier、
+上传 patch/trajectory/result。任务来源有三种：
+
+### 1. 运行网页已经认领的任务
+
+```bash
+dradar go
+```
+
+如果账号已经持有任务，`go` 直接运行它们。没有任务时，普通自由选题实例会提示先去网页
+选择，或改用 `--pick` / `--auto`。
+
+### 2. 精确领取指定格子
+
+```bash
+dradar go --pick TASK:MODEL:EFFORT
+dradar go \
+  --pick task-a:gpt-5.6-sol:high \
+  --pick task-b:gpt-5.6-terra:xhigh
+```
+
+`--pick` 可以重复。如果已经持有其他任务，CLI 会优先处理已有租约并忽略新的精确选择。
+指定格子被占用时只跳过该格，不会擅自换成另一道题。
+
+### 3. 使用系统推荐自动选题
+
+```bash
+dradar go --auto        # 目标总持有数默认为 5
+dradar go --auto 3      # 把当前持有批次补到总计 3 题
+```
+
+`--auto N` 的 N 是“目标总数”，不是“再领取 N 题”。它调用与网页随机推荐相同的服务端
+`/api/v1/suggest`，不会在 CLI 中维护第二套推荐算法。某个候选在领取时发生 `409`，CLI
+会跳过并继续尝试其余候选；达到本人持有上限时会立即停止本轮领取。
+
+`--auto` 和 `--pick` 不能同时使用。
+
+## 继续任务：`dradar resume`
+
+```bash
+dradar resume
+dradar resume --assignment <ASSIGNMENT_ID>
+```
+
+`resume` 首先发现并恢复本地 checkpoint，再运行账号仍持有但尚未完成的任务。指定
+`--assignment` 时只恢复对应 assignment，且必须使用单 worker，不能同时开启持续补题。
+如果没有 checkpoint 和活动租约，它安全退出，不会重新提交已完成任务。
+
+## `go` / `resume` 通用运行参数
+
+| 参数 | 作用与安全边界 |
+| --- | --- |
+| `-y`, `--yes` | 跳过人工确认；适合自动化。不会取消服务端领取和额度上限检查 |
+| `--keep` | 成功上传后保留最终本地任务目录，供调试或审计 |
+| `--allow-task-drift` | 允许本地 DeepSWE 内容与服务端固定版本不一致；可能影响可复现性，谨慎使用 |
+| `--workers N` | 由一个父进程管理 N 个并发 worker，范围 1–32，默认 1 |
+| `--workers auto` | 检测 Docker、磁盘和账号限制后选择保守并发数 |
+| `--parallel` | 高级选项：允许手工启动另一个独立 DRadar 会话；隐含 `-y` |
+| `--refill` | 显式开启持续自动补题；必须同时给出额度或题数硬上限 |
+| `--refill-to N` | 持有/运行队列目标；传入时自动启用 `--refill`，但仍需硬上限 |
+| `--max-estimated-quota-pct PCT` | 预计 7 天模型额度占用上限 |
+| `--quota-tier TIER` | 额度换算档位：`plus`、`pro-5x`、`pro-20x`，默认 `plus` |
+| `--max-tasks N` | 高级题数硬上限；可以低于默认内部安全上限 |
+
+`--workers` 已经负责启动和监管子进程，不能和 `--parallel` 同时使用。父进程先统一认领，
+子进程再通过服务端原子 checkout 分题，因此不会让同一 assignment 在同一批次重复运行。
+
+## 多 worker 并发
+
+```bash
+dradar go --auto 5 --workers 3
+dradar resume --workers 3
+dradar resume --workers auto
+```
+
+- 默认始终是 1 worker，不改变普通用户原有行为。
+- worker 共享同一台机器的 CPU、内存、磁盘和模型额度。
+- 实际启动数不会超过已持有任务数、账号并发上限或用户硬上限。
+- 未传 `-y` 时，父进程会在领取任务之前确认并发数。
+- Ctrl-C 或部分子进程启动失败时，父进程会停止已经启动的子进程；已上传结果、现有租约
+  和 checkpoint 保留，可用 `dradar resume` 继续。
+- 只有需要手工运行多个独立 CLI 进程时才使用 `--parallel`。它们仍通过服务端 checkout
+  分配不同任务，但资源需要操作者自行控制。
+
+## 持续自动补题
+
+普通 `go` / `resume` 不会无限领取。交互模式会询问是否持续补题，默认答案为否；无人值守
+运行必须显式提供停止条件。
+
+```bash
+dradar resume -y --workers 3 \
+  --refill --refill-to 3 \
+  --quota-tier pro-5x --max-estimated-quota-pct 15
+```
+
+- `--refill-to` 是希望持续保持的“运行中 + waiting”队列大小。
+- 使用多个 worker 时，CLI 会把队列目标至少提高到实际 worker 数，但绝不会提高额度或
+  题数硬上限。
+- `--max-estimated-quota-pct` 是基于服务端成本估价的保守预算，不是订阅平台的实时余额。
+- `plus`、`pro-5x`、`pro-20x` 分别按对应额度窗口换算。
+- 没有可靠额度换算数据的题不会自动领取。
+- 接近预算或题数上限时停止补题，让已持有队列自然排空。
+- 任一任务没有正常提交时立即停止继续领题，但不会释放已有租约或删除 checkpoint。
+- 本机计划通过文件锁共享；正常新一轮可以安全替换无主旧计划，正常完成或显式执行
+  `refill stop` 后会清理活动计划文件。因安全条件自动停止的诊断状态可以暂留供
+  `refill status` 查看，但不会阻塞新计划。手工 `--parallel` 无法证明旧计划无人使用时
+  会保守拒绝覆盖。
+
+```bash
+dradar refill status    # 查看队列目标、已预留题数、额度和停止原因
+dradar refill stop      # 停止继续领题；已有任务保持原样
+```
+
+补题上限以单机 `DRADAR_HOME` 为边界。不要在多台机器上各自配置同一份“全局预算”，因为
+它们会各自维护独立计划。
+
+## 租约：`leases` 与 `release`
+
+```bash
+dradar leases
+```
+
+`leases` 显示当前账号持有的所有任务、assignment ID、到期时间以及：
+
+- `waiting`：已认领但尚未真正启动；
+- `running`：已经执行 started 流程，服务端认为正在运行。
+
+释放方式：
+
+```bash
+dradar release                              # 数字菜单交互选择
+dradar release <ASSIGNMENT_ID>              # 释放指定任务
+dradar release <ID1> <ID2>                  # 一次释放多个任务
+dradar release --all                        # 释放所有 waiting，保护 running
+dradar release <ASSIGNMENT_ID> --force      # 强制释放卡死的 running
+dradar release --all --force -y             # 高风险：无确认释放全部
+```
+
+默认不会释放 `running`。只有确认本地 Pier/Codex 已经停止、服务端状态仍卡住时才使用
+`--force`，否则任务可能仍在消耗额度，却被重新开放给其他人。
+
+## checkpoint 与中断续跑
+
+Pier 在任务运行期间约每 30 秒把工作区差异、未跟踪文件、Codex session ID、阶段和心跳
+写入 `~/.dradar/work/jobs/`。模型容量不足、WebSocket/TLS 断开、代理抖动、CLI 退出或
+机器重启后，下一次 `go` / `resume` 会先尝试恢复，而不是从头运行。
+
+```bash
+dradar checkpoints
+dradar resume
+dradar resume --assignment <ASSIGNMENT_ID>
+dradar checkpoint discard <CHECKPOINT_ID_OR_ASSIGNMENT_ID>
+```
+
+恢复优先级：
+
+1. 原工作区 + 原 Codex session；
+2. 原 session 不可用时，保留工作区，用进度摘要启动新 session；
+3. checkpoint 损坏、超过 7 天、版本不兼容或租约失效时，安全标记无效并重新开放格子。
+
+同一 assignment 使用本地文件锁，健康运行中的任务不会被第二个 `resume` 重复启动。超级
+账号批量运行时，每个 worker 独立认领 checkpoint，一个损坏项不会阻塞整个批次。
+
+checkpoint 不保存账号 Token、assignment nonce 或 Codex `auth.json`。manifest 出现
+敏感字段，或者 session 检测到凭据形态内容时，会拒绝持久化相应敏感状态并安全降级。
+
+`checkpoint discard` 会删除本地恢复数据；如果服务端租约仍有效，还会通过恢复协议重新
+开放格子。这是明确放弃进度的操作。
+
+## 上传补救：`dradar retry-upload`
+
+任务已经运行完成，但上传因断网、TLS 或服务端临时不可用失败时，CLI 会把最新可上传
+现场记录在 `~/.dradar/pending_uploads.json`。
+
+```bash
+dradar retry-upload
+```
+
+它只补传已有结果，不领取或运行新任务。每次 `go` / `resume` 启动时也会先自动执行同样
+的补传。服务端按 assignment 幂等接收，已经提交的结果不会重复计分。
+
+## 本地清理：`dradar cleanup`
+
+```bash
+dradar cleanup --dry-run
+dradar cleanup
+dradar cleanup -y
+dradar cleanup --include-kept
+```
+
+清理前必须成功从服务端取得当前租约列表；网络失败时什么都不删除。以下内容默认保护：
+
+- 仍在运行或可以恢复的任务；
+- 等待上传的任务；
+- 使用 `--keep` 明确保留的任务。
+
+`--dry-run` 只列出候选文件和预计释放空间。`--include-kept` 才会删除由 `--keep` 保护的
+已结算目录。成功上传后，非 `--keep` 的交互运行会询问是否立即清理；无人值守运行按
+安全生命周期自动回收已确认结算的副本。
+
+## 领取冲突与常见错误
+
+领取失败统一使用 HTTP `409 Conflict`，同时带稳定的机器错误码。CLI 的处理方式：
+
+| 错误码 | 含义 | CLI 行为 |
+| --- | --- | --- |
+| `cell_unavailable` | 格子已满、冷却或对当前用户不可领取 | 精确选题跳过；自动选题继续候选 |
+| `claim_limit_reached` | 本人持有任务达到上限 | 停止继续领取，先运行或释放已有任务 |
+| `invalid_cell` | 模型、effort 或任务已不在当前配置 | 跳过并提示刷新格子表 |
+| `run_limit_reached` | 正在运行的任务达到账号并发上限 | 保留租约，不启动超额任务 |
+
+新 CLI 优先读取错误码；连接旧服务端时仍兼容原有错误文案。前三种领取冲突发生在创建
+租约之前，因此不会启动容器或调用模型。`run_limit_reached` 针对已经持有、正准备启动的
+任务：服务端保留原租约，但拒绝建立超额运行槽。
+
+其他常见情况：
+
+- Docker 镜像构建在 agent 启动前失败：不消耗模型额度，CLI 自动重试一次；
+- CLI/Codex/Pier 中断：保留 checkpoint，使用 `dradar resume`；
+- 上传失败：使用 `dradar retry-upload`；
+- Token 失效：重新执行官网登录命令，或使用已绑定身份的 `login --github`；
+- Ctrl-C：CLI 返回退出码 130，租约保留，可通过 `leases`、`resume` 或 `release` 处理。
+
+## 本地文件与生命周期
+
+默认数据目录为 `~/.dradar`，可通过 `DRADAR_HOME` 修改。
+
+| 路径 | 内容 |
+| --- | --- |
+| `~/.dradar/config.json` | 服务端、Token 和任务仓库路径；私有文件 |
+| `~/.dradar/deep-swe/tasks/` | 默认 DeepSWE 任务仓库 |
+| `~/.dradar/work/jobs/` | Pier 任务目录、artifact 和 checkpoint |
+| `~/.dradar/pending_uploads.json` | 待补传结果账本，不保存订阅凭据 |
+| `~/.dradar/refill-plan.json` | 当前持续补题计划或最近一次安全停止诊断；不会阻塞明确的新计划 |
+
+提交成功或服务端确认已经提交后，CLI 会清理不再需要的副本；恢复产生新副本时删除旧副本；
+无效、过期或无租约的 checkpoint 会回收。需要保留现场时使用 `--keep`，之后可用
+`cleanup --include-kept` 清理。
+
+## 心跳与隐私
+
+`go` / `resume` 会建立轻量会话心跳：运行或上传时约 60 秒一次，准备、排队或暂停时约
+120 秒一次。它按 CLI 会话上报，不按持有格子数上报。
+
+心跳只包含 CLI 版本、粗粒度平台、阶段、当前 assignment ID、递增序号和进度计数；不
+包含任务内容、prompt、trajectory、patch、命令输出、主机名、用户名、硬件详情或订阅
+凭据。断网不会主动终止正在运行的 Pier。
+
+服务端处于保守租约模式：心跳用于展示和诊断，不会仅因一次心跳中断就立即释放正在运行
+的格子。用户始终可以通过 `leases` 查看，并用 `release` 明确归还。
+
+## 平台说明
+
+### macOS
+
+推荐 OrbStack，也支持 Docker Desktop。OrbStack 第一次安装后通常需要打开一次 GUI 完成
+初始化。如果某个 `.venv` 被 macOS 标记为 hidden，Python 可能跳过 editable 安装依赖的
+`.pth` 文件；`doctor` 会识别并提示使用 `chflags -R nohidden <目录>`。
+
+### Windows 与 WSL2
+
+- 原生 Windows：Docker Desktop 必须切换到 Linux containers；IDE 中的 Codex 扩展登录
+  不等于 PowerShell 可以执行 `codex`。
+- WSL2：Debian、Ubuntu、OpenSUSE 等普通发行版都可使用；Docker Desktop 自带的
+  `docker-desktop` 是内部发行版，不能作为用户运行 DRadar 的终端环境。
 
 ## 开发
 
 ```bash
 uv venv
-uv pip install -q --no-deps . --python .venv/bin/python   # 非 editable！改完源码要重跑这行
+uv pip install -q --no-deps . --python .venv/bin/python
 uv pip install -q pytest httpx --python .venv/bin/python
-pytest tests/
+.venv/bin/pytest tests/
 ```
 
-**不要用 `-e`（editable）安装**——macOS 上 `uv` 建的 `.venv` 会被打上隐藏标志，Python 3.12 因此跳过 editable 安装依赖的 `.pth` 文件，导致 `import dradar` 直接失败（`chflags -R nohidden .venv` 能临时解决，但标志会莫名其妙又回来）。非 editable 安装把包文件真正拷进 `site-packages`，不依赖 `.pth`，不受这个坑影响——代价是每次改了 `src/` 下的代码，都要重新跑一遍上面的 `uv pip install` 这行，`pytest` 测的才是新代码，不然会静默测到旧代码。
+开发测试推荐非 editable 安装。macOS 可能给 `uv` 创建的 `.venv` 设置 hidden 标志，导致
+Python 跳过 editable 安装依赖的 `.pth`。非 editable 安装会把包文件真正复制到
+`site-packages`；修改 `src/` 后要重新执行第一条 `uv pip install`，避免测试到旧代码。


### PR DESCRIPTION
## 内容

- 按实际 CLI 行为整理全部公开命令与子命令
- 补充今年新增的多 worker 并发、持续补题、额度上限、checkpoint 中断续跑、失败补传和安全清理
- 说明 cells 状态、结构化 409、租约/释放、数据目录与隐私边界
- 增加普通用户常见工作流、Windows/WSL 与开发说明

## 验证

- 全量测试：291 passed
- 使用各命令 --help 自动核对 README，全部公开长参数均已覆盖
- git diff --check 通过