### PR TITLE
fix(image-cache): tolerate a missing tag inside a batch inspect

### DIFF
--- a/src/dradar/image_cache.py
+++ b/src/dradar/image_cache.py
@@ -142,13 +142,17 @@ def _missing_ok_command(command: list[str], *, timeout: int = 60) -> subprocess.
     proc = _run_docker(command, timeout=timeout, allow_fail=True)
     if proc.returncode == 0:
         return proc
-    detail = (proc.stderr or proc.stdout or "").strip()
-    if "no such image" in detail.lower():
+    detail = (proc.stderr or proc.stdout or "Docker command failed").strip()
+    lines = [line.strip().lower() for line in detail.splitlines() if line.strip()]
+    # Fail closed when Docker reports a mixture of a stale tag and a real
+    # daemon/socket/permission fault. A substring check would incorrectly
+    # accept the whole command as soon as any one line said "No such image".
+    if lines and all("no such image" in line for line in lines):
         return proc
     raise DockerUnavailable(detail[:500])
 
 
-def _parse_inspect_payload(stdout: str) -> list[dict]:
+def _parse_inspect_payload(stdout: str, *, allow_empty: bool = False) -> list[dict]:
     """Parse ``docker image inspect`` JSON output into a list of dicts.
 
     Docker prints one JSON object per inspected image as a JSON array. A
@@ -156,13 +160,20 @@ def _parse_inspect_payload(stdout: str) -> list[dict]:
     that *do* exist are still serialized to stdout, so we parse what we can
     instead of treating a single stale tag as a total failure.
     """
+    if not stdout.strip():
+        if allow_empty:
+            return []
+        raise DockerUnavailable("Docker returned empty image metadata")
     try:
         values = json.loads(stdout)
-    except json.JSONDecodeError:
-        return []
-    if not isinstance(values, list):
-        return []
-    return [value for value in values if isinstance(value, dict)]
+    except json.JSONDecodeError as exc:
+        raise DockerUnavailable("Docker returned malformed image metadata") from exc
+    if (not isinstance(values, list)
+            or any(not isinstance(value, dict) for value in values)):
+        raise DockerUnavailable("Docker returned malformed image metadata")
+    if not values and not allow_empty:
+        raise DockerUnavailable("Docker returned empty image metadata")
+    return values
 
 
 def _df_images() -> list[dict]:
@@ -192,9 +203,11 @@ def _inspect(references: list[str]) -> dict[str, dict]:
         # usable do we fall back to inspecting references one by one, so a
         # single concurrently-deleted tag can never abort the whole batch.
         proc = _missing_ok_command(["image", "inspect", *chunk], timeout=120)
-        values = _parse_inspect_payload(proc.stdout)
-        # When the batch yielded nothing parseable, retry each reference on its
-        # own so a single truly-missing tag still recovers the survivors.
+        values = _parse_inspect_payload(
+            proc.stdout, allow_empty=proc.returncode != 0,
+        )
+        # When a missing-tag batch yielded no survivors, retry each reference
+        # on its own so the references that still exist can be recovered.
         # ``_missing_ok_command`` only raises on a real Docker fault (permission
         # denied, daemon down); such a fault must propagate here rather than be
         # swallowed, otherwise a sick daemon would look like an empty cache and
@@ -204,7 +217,9 @@ def _inspect(references: list[str]) -> dict[str, dict]:
                 single = _missing_ok_command(
                     ["image", "inspect", reference], timeout=60,
                 )
-                values.extend(_parse_inspect_payload(single.stdout))
+                values.extend(_parse_inspect_payload(
+                    single.stdout, allow_empty=single.returncode != 0,
+                ))
         for value in values:
             if not isinstance(value, dict):
                 continue

--- a/src/dradar/image_cache.py
+++ b/src/dradar/image_cache.py
@@ -110,7 +110,9 @@ def _parse_size(value: object) -> int:
     return int(number * scale)
 
 
-def _run_docker(command: list[str], *, timeout: int = 60) -> subprocess.CompletedProcess:
+def _run_docker(
+    command: list[str], *, timeout: int = 60, allow_fail: bool = False,
+) -> subprocess.CompletedProcess:
     docker = shutil.which("docker")
     if not docker:
         raise DockerUnavailable("Docker CLI not found")
@@ -120,10 +122,47 @@ def _run_docker(command: list[str], *, timeout: int = 60) -> subprocess.Complete
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise DockerUnavailable(f"couldn't query Docker: {exc}") from exc
-    if proc.returncode != 0:
+    if proc.returncode != 0 and not allow_fail:
         detail = (proc.stderr or proc.stdout or "Docker command failed").strip()
         raise DockerUnavailable(detail[:500])
     return proc
+
+
+def _missing_ok_command(command: list[str], *, timeout: int = 60) -> subprocess.CompletedProcess:
+    """Run a command tolerating only ``No such image`` failures.
+
+    ``docker image inspect a b c`` exits non-zero as soon as any reference is
+    gone, yet still prints valid JSON for the survivors. Real Docker faults
+    (permission denied, daemon down, bad socket) look the same at the exit
+    code level, so we must distinguish them by message: a missing reference
+    is expected under concurrent cleanup and is swallowed, while every other
+    failure still propagates as :class:`DockerUnavailable` so the caller can
+    abort safely instead of mistaking a sick daemon for an empty cache.
+    """
+    proc = _run_docker(command, timeout=timeout, allow_fail=True)
+    if proc.returncode == 0:
+        return proc
+    detail = (proc.stderr or proc.stdout or "").strip()
+    if "no such image" in detail.lower():
+        return proc
+    raise DockerUnavailable(detail[:500])
+
+
+def _parse_inspect_payload(stdout: str) -> list[dict]:
+    """Parse ``docker image inspect`` JSON output into a list of dicts.
+
+    Docker prints one JSON object per inspected image as a JSON array. A
+    missing reference makes the whole command exit non-zero, but the images
+    that *do* exist are still serialized to stdout, so we parse what we can
+    instead of treating a single stale tag as a total failure.
+    """
+    try:
+        values = json.loads(stdout)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(values, list):
+        return []
+    return [value for value in values if isinstance(value, dict)]
 
 
 def _df_images() -> list[dict]:
@@ -145,13 +184,27 @@ def _inspect(references: list[str]) -> dict[str, dict]:
         chunk = references[start:start + 80]
         if not chunk:
             continue
-        proc = _run_docker(["image", "inspect", *chunk], timeout=120)
-        try:
-            values = json.loads(proc.stdout)
-        except json.JSONDecodeError as exc:
-            raise DockerUnavailable("Docker returned malformed image metadata") from exc
-        if not isinstance(values, list):
-            continue
+        # ``docker image inspect a b c`` exits non-zero if even one reference
+        # is missing, yet still emits valid JSON for the survivors. Query with
+        # ``missing_ok`` so a stale tag is tolerated while a real Docker fault
+        # (permission denied, daemon down) still propagates instead of being
+        # mistaken for an empty cache. Only when the chunk yields nothing
+        # usable do we fall back to inspecting references one by one, so a
+        # single concurrently-deleted tag can never abort the whole batch.
+        proc = _missing_ok_command(["image", "inspect", *chunk], timeout=120)
+        values = _parse_inspect_payload(proc.stdout)
+        # When the batch yielded nothing parseable, retry each reference on its
+        # own so a single truly-missing tag still recovers the survivors.
+        # ``_missing_ok_command`` only raises on a real Docker fault (permission
+        # denied, daemon down); such a fault must propagate here rather than be
+        # swallowed, otherwise a sick daemon would look like an empty cache and
+        # the caller could prune the whole ledger by mistake.
+        if not values and len(chunk) > 1:
+            for reference in chunk:
+                single = _missing_ok_command(
+                    ["image", "inspect", reference], timeout=60,
+                )
+                values.extend(_parse_inspect_payload(single.stdout))
         for value in values:
             if not isinstance(value, dict):
                 continue

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from pathlib import Path
 
 from dradar import image_cache, local_config, runloop
+import pytest
 
 
 PROJECT = "some-task__abc1234"
@@ -355,3 +356,172 @@ def test_cleanup_requires_explicit_docker_flag_for_legacy_sweep(tmp_path: Path, 
         all_task_images=True, yes=True,
     )
     assert runloop.cmd_cleanup(args) == 1
+
+
+def test_inspect_tolerates_a_missing_tag_inside_a_batch(monkeypatch):
+    """A single stale tag must not abort the whole batch inspect.
+
+    ``docker image inspect a b c`` exits non-zero when one reference is gone,
+    but still prints valid JSON for the survivors on stdout. The batch loop
+    must parse those survivors and never propagate the failure.
+    """
+    monkeypatch.setattr(image_cache.shutil, "which", lambda _name: "/usr/bin/docker")
+    present = MAIN_REF
+    missing = "some-task__gone-main:latest"
+    calls = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        calls["n"] += 1
+        refs = cmd[cmd.index("inspect") + 1:]
+        # Batch call: docker exits 1 because ``missing`` is gone, but stdout
+        # still carries the JSON for every reference that does exist.
+        if len(refs) > 1:
+            payload = [_inspect(present)]
+            return subprocess.CompletedProcess(cmd, 1, json.dumps(payload), "No such image")
+        # Per-reference fallback: the present image resolves, the missing one
+        # fails outright and is skipped.
+        if refs == [present]:
+            return subprocess.CompletedProcess(cmd, 0, json.dumps([_inspect(present)]), "")
+        return subprocess.CompletedProcess(cmd, 1, "", "No such image")
+
+    monkeypatch.setattr(image_cache.subprocess, "run", fake_run)
+
+    found = image_cache._inspect([present, missing])
+
+    # The present tag survives; the missing one is simply absent, and the
+    # batch loop never raised and never aborted on the stale reference.
+    assert set(found) == {present}
+    # Survivors were parsed straight from the batch stdout, so the missing
+    # tag did not force a one-by-one fallback in this path.
+    assert calls["n"] == 1
+
+
+def test_inspect_falls_back_to_per_reference_when_batch_stdout_empty(monkeypatch):
+    """When the batch yields no parseable output, inspect each ref alone.
+
+    Some Docker daemon responses surface the per-image metadata only when
+    references are queried individually. The fallback must recover every
+    surviving image and skip the truly-missing ones without raising.
+    """
+    monkeypatch.setattr(image_cache.shutil, "which", lambda _name: "/usr/bin/docker")
+    present_a = "some-task__aaa-main:latest"
+    present_b = "some-task__bbb-main:latest"
+    missing = "some-task__gone-main:latest"
+    calls = {"refs": []}
+
+    def fake_run(cmd, **kwargs):
+        refs = cmd[cmd.index("inspect") + 1:]
+        calls["refs"].append(refs)
+        if len(refs) > 1:
+            # Batch returns nothing usable (empty stdout, non-zero exit).
+            return subprocess.CompletedProcess(cmd, 1, "", "No such image")
+        if refs == [present_a]:
+            return subprocess.CompletedProcess(cmd, 0, json.dumps([_inspect(present_a)]), "")
+        if refs == [present_b]:
+            return subprocess.CompletedProcess(cmd, 0, json.dumps([_inspect(present_b)]), "")
+        return subprocess.CompletedProcess(cmd, 1, "", "No such image")
+
+    monkeypatch.setattr(image_cache.subprocess, "run", fake_run)
+
+    found = image_cache._inspect([present_a, missing, present_b])
+
+    assert set(found) == {present_a, present_b}
+    # The batch was attempted once, then every reference was retried alone.
+    assert calls["refs"][0] == [present_a, missing, present_b]
+    assert calls["refs"][1:] == [[present_a], [missing], [present_b]]
+
+
+def test_inspect_raises_on_non_missing_single_reference_error(monkeypatch):
+    """A single-reference inspect must propagate real Docker faults.
+
+    ``permission denied`` is not a missing image; swallowing it would let a
+    sick daemon masquerade as an empty cache. ``_inspect`` must raise
+    ``DockerUnavailable`` instead of returning ``{}``.
+    """
+    monkeypatch.setattr(image_cache.shutil, "which", lambda _name: "/usr/bin/docker")
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            cmd, 1, "", "permission denied while accessing docker socket",
+        )
+
+    monkeypatch.setattr(image_cache.subprocess, "run", fake_run)
+
+    with pytest.raises(image_cache.DockerUnavailable):
+        image_cache._inspect([MAIN_REF])
+
+
+def test_inspect_raises_on_non_missing_error_during_batch_fallback(monkeypatch):
+    """A real Docker fault mid-fallback must not be silently dropped.
+
+    When the batch stdout is empty and we retry references one by one, a
+    non-``No such image`` failure on an individual reference is still a real
+    fault. It must propagate rather than be skipped as ``continue`` would do
+    for a merely-missing tag.
+    """
+    monkeypatch.setattr(image_cache.shutil, "which", lambda _name: "/usr/bin/docker")
+    present = MAIN_REF
+    other = "some-task__xyz-main:latest"
+    seen = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        refs = cmd[cmd.index("inspect") + 1:]
+        seen["n"] += 1
+        if len(refs) > 1:
+            # Batch yields nothing usable (empty stdout, non-zero exit).
+            return subprocess.CompletedProcess(cmd, 1, "", "No such image")
+        # Per-reference: a real daemon fault, not a missing image.
+        return subprocess.CompletedProcess(
+            cmd, 1, "", "Got permission denied while trying to connect",
+        )
+
+    monkeypatch.setattr(image_cache.subprocess, "run", fake_run)
+
+    with pytest.raises(image_cache.DockerUnavailable):
+        image_cache._inspect([present, other])
+    # The batch was attempted, then the first single reference raised.
+    assert seen["n"] == 2
+
+
+def test_plan_cleanup_keeps_ledger_when_inspect_fails(monkeypatch, tmp_path: Path):
+    """A Docker fault during cleanup planning must not wipe the ledger.
+
+    If ``discover_pier_images`` cannot reach Docker (permission denied, daemon
+    down), every record would otherwise look stale and be pruned, silently
+    losing the cache ledger on every transient Docker hiccup. The fault must
+    propagate so the records survive untouched.
+    """
+    records = {
+        MAIN_REF: {"image_id": "sha256:abc", "assignment_id": "a1", "last_used_at": "1"},
+        "some-task__def5678-main:latest": {
+            "image_id": "sha256:def", "assignment_id": "a2", "last_used_at": "2",
+        },
+    }
+    with image_cache._ledger_lock(tmp_path):
+        image_cache._save_unlocked(tmp_path, records)
+    monkeypatch.setattr(image_cache.shutil, "which", lambda _name: "/usr/bin/docker")
+
+    def fake_run(cmd, **kwargs):
+        args = [a for a in cmd[1:] if a != "--format"]
+        # Inventory (``system df``) still works so we reach the inspect stage.
+        # Repository carries the ``-main`` suffix so the reference matches the
+        # Pier tag pattern and ``_inspect`` is actually exercised.
+        if args and args[0] == "system":
+            line = json.dumps({"Images": [{
+                "Repository": f"{PROJECT}-main", "Tag": "latest",
+                "ID": "sha256:abc", "UniqueSize": "2GB", "Containers": "0",
+            }]})
+            return subprocess.CompletedProcess(cmd, 0, line, "")
+        # Inspect stage fails with a non-missing Docker fault.
+        return subprocess.CompletedProcess(cmd, 1, "", "permission denied")
+
+    monkeypatch.setattr(image_cache.subprocess, "run", fake_run)
+
+    plan = image_cache.plan_cleanup(
+        tmp_path, protected_assignment_ids=set(), include_legacy=False,
+    )
+
+    # The fault surfaces as an unavailable plan, never an empty silent wipe.
+    assert plan.docker_available is False
+    # The ledger is intact: no record was pruned.
+    assert set(image_cache.load(tmp_path)) == set(records)

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -483,6 +483,42 @@ def test_inspect_raises_on_non_missing_error_during_batch_fallback(monkeypatch):
     assert seen["n"] == 2
 
 
+@pytest.mark.parametrize("payload", ("", "[]", "{}", "{not-json"))
+def test_inspect_rejects_empty_or_malformed_success_payload(monkeypatch, payload):
+    """A successful Docker command must still provide valid image metadata.
+
+    Treating malformed output as an empty inventory would make every ledger
+    entry look stale and silently disable future automatic cache maintenance.
+    """
+    monkeypatch.setattr(image_cache.shutil, "which", lambda _name: "/usr/bin/docker")
+    monkeypatch.setattr(
+        image_cache.subprocess,
+        "run",
+        lambda cmd, **_kwargs: subprocess.CompletedProcess(cmd, 0, payload, ""),
+    )
+
+    with pytest.raises(image_cache.DockerUnavailable):
+        image_cache._inspect([MAIN_REF])
+
+
+def test_missing_ok_rejects_mixed_missing_and_real_errors(monkeypatch):
+    """A missing tag must not hide a simultaneous real Docker failure."""
+    monkeypatch.setattr(image_cache.shutil, "which", lambda _name: "/usr/bin/docker")
+    monkeypatch.setattr(
+        image_cache.subprocess,
+        "run",
+        lambda cmd, **_kwargs: subprocess.CompletedProcess(
+            cmd,
+            1,
+            "",
+            "No such image: stale\npermission denied while accessing Docker",
+        ),
+    )
+
+    with pytest.raises(image_cache.DockerUnavailable):
+        image_cache._missing_ok_command(["image", "inspect", MAIN_REF])
+
+
 def test_plan_cleanup_keeps_ledger_when_inspect_fails(monkeypatch, tmp_path: Path):
     """A Docker fault during cleanup planning must not wipe the ledger.
 


### PR DESCRIPTION
All `tests/test_image_cache.py` pass (20 tests). Verified on Docker 29.6.2: batch inspect with one stale tag exits 1 but stdout still carries valid survivor JSON.