### PR TITLE
fix: stop paid API batches on insufficient balance

### DIFF
--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -29,8 +29,9 @@ from .providers import DEEPSEEK_PROVIDER, assignment_codex_provider
 from .runner import (
     DIAG_ADVICE, BuildFlakeError, RunnerError, build_codex_trajectory_bundle,
     check_task_content_hash, codex_trajectory_bundle_usage,
-    diagnose_exception, ensure_pier, ensure_tasks_root, local_deep_swe_commit,
-    run_trial, summarize_result, sync_deep_swe_commit, trial_artifact_paths,
+    diagnose_exception, ensure_pier, ensure_tasks_root,
+    is_insufficient_balance_message, local_deep_swe_commit, run_trial,
+    summarize_result, sync_deep_swe_commit, trial_artifact_paths,
 )
 from .scrub import (
     patch_structure_is_valid, redact_patch_secrets, scan_secrets, scrub_bytes,
@@ -44,6 +45,44 @@ from .telemetry import RunnerTelemetry
 # regression; normal quota-bounded plans should never reach it.
 DEFAULT_REFILL_TASK_SAFETY_CAP = 1000
 _TERMINAL_LOCAL_OUTCOMES = {"artifacts-gone", "not-uploaded", "rejected"}
+_ACCOUNT_TERMINAL_OUTCOMES = {"insufficient-balance"}
+_POOL_ABORT_ENV = "DRADAR_POOL_ABORT_FILE"
+
+
+def _pool_abort_path() -> Path | None:
+    raw = os.environ.get(_POOL_ABORT_ENV)
+    return Path(raw) if raw else None
+
+
+def _signal_pool_abort(reason: str) -> None:
+    """Tell sibling workers in this one supervised pool to stop checking out."""
+    path = _pool_abort_path()
+    if path is None:
+        return
+    try:
+        path.write_text(reason)
+    except OSError:
+        # The worker that observed the terminal condition still stops locally.
+        # Never turn a best-effort sibling signal into another task failure.
+        pass
+
+
+def _pool_abort_reason() -> str | None:
+    path = _pool_abort_path()
+    if path is None or not path.is_file():
+        return None
+    try:
+        return path.read_text().strip() or "another worker stopped the pool"
+    except OSError:
+        return "another worker stopped the pool"
+
+
+def _announce_account_stop() -> None:
+    print(
+        "paid API balance is exhausted — stopping this batch before the next "
+        "task. Unstarted leases remain untouched; recharge, then run "
+        "`dradar resume`."
+    )
 
 
 def _fmt_pct(pct: float) -> str:
@@ -714,17 +753,20 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
                 _mark_stopped_quietly(client, assignment)
             return "failed"
         except RunnerError as exc:
+            insufficient_balance = is_insufficient_balance_message(str(exc))
+            if insufficient_balance:
+                _signal_pool_abort("paid API balance exhausted")
             item = _pause_checkpoint_quietly(client, assignment)
             if item is not None:
                 print(f"trial interrupted: {exc}\n"
                       f"checkpoint {item.checkpoint_id} was kept; `dradar resume` "
                       "continues the same workspace/session")
-                return "paused"
+                return "insufficient-balance" if insufficient_balance else "paused"
             print(f"trial failed: {exc}\n"
                   "use `dradar resume` to retry later, or `dradar release` to "
                   "give the cell back")
             _mark_stopped_quietly(client, assignment)
-            return "failed"
+            return "insufficient-balance" if insufficient_balance else "failed"
         except (KeyboardInterrupt, EOFError):
             _pause_checkpoint_quietly(client, assignment)
             raise
@@ -744,13 +786,21 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
     # An interrupted/failed run (nonzero pier rc or recorded exception) is not a
     # model failure: report it so the server marks it invalid, not graded 0.
     interrupted = art.returncode != 0 or stats.get("exception_info")
+    diag = diagnose_exception(art.result) if interrupted else {}
+    failure_kind = diag.get("kind")
+    if failure_kind == "insufficient-balance":
+        _signal_pool_abort("paid API balance exhausted")
     item = checkpoints.find_latest(HOME, assignment["assignment_id"])
     if interrupted and item is not None and item.phase != "agent_completed":
         saved = _pause_checkpoint_quietly(client, assignment)
         if saved is not None:
             print(f"trial interrupted; checkpoint {saved.checkpoint_id} was kept — "
                   "the next `dradar resume` continues instead of submitting a partial run")
-            return "paused"
+            return (
+                "insufficient-balance"
+                if failure_kind == "insufficient-balance"
+                else "paused"
+            )
     outcome = "interrupted" if interrupted else "completed"
     if telemetry:
         telemetry.set_phase("uploading", assignment["assignment_id"])
@@ -761,7 +811,6 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
         # the recorded exception carries the in-container agent's real error
         # (exit code, API rejection) — hiding it sent a volunteer chasing a
         # quota problem that was a version problem.
-        diag = diagnose_exception(art.result)
         if diag:
             print(f"the agent failed inside the container: {diag.get('type') or 'unknown error'}")
             for ln in diag.get("tail", []):
@@ -786,7 +835,7 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
     if item is not None and item.job_dir == art.job_dir:
         checkpoints.prune_superseded(HOME, assignment["assignment_id"], item)
 
-    return _upload_trial(client, {
+    upload_outcome = _upload_trial(client, {
         "assignment_id": assignment["assignment_id"], "nonce": assignment["nonce"],
         "task_id": assignment["task_id"], "trial_dir": str(art.trial_dir),
         "meta": meta, "outcome": outcome,
@@ -798,6 +847,9 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
         and not getattr(args, "yes", False)
         and not getattr(args, "parallel", False)
     ))
+    if failure_kind == "insufficient-balance":
+        return "insufficient-balance"
+    return upload_outcome
 
 
 def _retry_pending_uploads(client: ApiClient) -> None:
@@ -1549,6 +1601,10 @@ def _run_worker_pool(args) -> int:
         print(f"only {len(active)} task(s) are currently held; starting {count} worker(s)")
     print(f"starting {count} worker(s); server-side checkout assigns each task exactly once")
     command = _worker_command(args)
+    pool_abort_file = (
+        Path(tempfile.gettempdir())
+        / f"dradar-pool-abort-{os.getpid()}-{time.time_ns()}"
+    )
     popen_kwargs = {}
     if os.name == "nt":
         popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
@@ -1558,6 +1614,7 @@ def _run_worker_pool(args) -> int:
             env = os.environ.copy()
             env["DRADAR_WORKER_INDEX"] = str(index)
             env["DRADAR_POOL_SIZE"] = str(count)
+            env[_POOL_ABORT_ENV] = str(pool_abort_file)
             process = subprocess.Popen(command, env=env, **popen_kwargs)
             processes.append(process)
             print(f"  worker {index}/{count}: pid {process.pid}")
@@ -1566,6 +1623,7 @@ def _run_worker_pool(args) -> int:
         print("\nstopping workers safely; active tasks remain resumable...")
         _signal_workers(processes)
         _maintain_image_cache(client, cfg, phase="after interrupted worker pool")
+        pool_abort_file.unlink(missing_ok=True)
         raise
     except OSError as exc:
         # A later spawn can fail after earlier children are already live
@@ -1575,7 +1633,9 @@ def _run_worker_pool(args) -> int:
         print(f"couldn't start every worker ({exc}); stopping those already started")
         _signal_workers(processes)
         _maintain_image_cache(client, cfg, phase="after failed worker pool")
+        pool_abort_file.unlink(missing_ok=True)
         return 1
+    pool_abort_file.unlink(missing_ok=True)
     failed = [(i, rc) for i, rc in enumerate(returncodes, 1) if rc != 0]
     _maintain_image_cache(client, cfg, phase="after worker pool")
     if failed:
@@ -1678,10 +1738,14 @@ def _run_batch(args, client: ApiClient, tasks_root: Path, active: list[dict],
             # subprocess can start or fail. assignment/started then stamps
             # started_at + this same session id in one server transaction.
             telemetry.flush()
-        results.append(_run_and_submit(
-            client, assignment, tasks_root, args, local_commit, telemetry=telemetry))
+        outcome = _run_and_submit(
+            client, assignment, tasks_root, args, local_commit, telemetry=telemetry)
+        results.append(outcome)
         if telemetry:
             telemetry.set_phase("queued")
+        if outcome in _ACCOUNT_TERMINAL_OUTCOMES:
+            _announce_account_stop()
+            break
     ok = all(o in ("submitted", "interrupted") for o in results)
     return 0 if ok else 1
 
@@ -1699,6 +1763,10 @@ def _run_checkout_loop(args, client: ApiClient, tasks_root: Path,
                                       args.allow_task_drift)
     results, failed_ids = [], set()
     while True:
+        pool_abort_reason = _pool_abort_reason()
+        if pool_abort_reason:
+            print(f"worker pool stopped before another checkout: {pool_abort_reason}")
+            break
         if getattr(args, "refill", False) and not refill_plan.is_running(HOME):
             print("continuous refill is stopped; leaving already held tasks for a later resume")
             break
@@ -1770,6 +1838,12 @@ def _run_checkout_loop(args, client: ApiClient, tasks_root: Path,
             client, assignment, tasks_root, args, local_commit, telemetry=telemetry)
         if telemetry:
             telemetry.set_phase("queued")
+        if outcome in _ACCOUNT_TERMINAL_OUTCOMES:
+            if getattr(args, "refill", False):
+                refill_plan.stop(HOME, "paid API balance exhausted")
+            _announce_account_stop()
+            results.append(outcome)
+            break
         fail_fast = os.environ.get("DRADAR_BATCH_FAIL_FAST", "").lower() in {
             "1", "true", "yes", "on",
         }

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -1209,7 +1209,8 @@ def summarize_result(result_path: Path | None) -> dict:
 def diagnose_exception(result_path: Path | None) -> dict:
     """Classify a trial's recorded exception for honest console reporting:
     {} when there is none, else {type, tail, kind} where kind is one of
-    stale-agent | rate-limit | auth | None (unrecognized). The message tail
+    stale-agent | insufficient-balance | rate-limit | auth | None
+    (unrecognized). The message tail
     matters most: pier's exception_message embeds the agent's actual output,
     which for codex includes the API error JSON naming the real cause."""
     if not result_path or not result_path.is_file():
@@ -1226,6 +1227,8 @@ def diagnose_exception(result_path: Path | None) -> dict:
     kind = None
     if "requires a newer version of codex" in low:
         kind = "stale-agent"
+    elif is_insufficient_balance_message(msg):
+        kind = "insufficient-balance"
     elif any(s in low for s in ("rate limit", "rate_limit", "usage_limit",
                                 "too many requests", "429")):
         kind = "rate-limit"
@@ -1245,6 +1248,17 @@ def diagnose_exception(result_path: Path | None) -> dict:
     return {"type": info.get("exception_type"), "kind": kind, "tail": tail}
 
 
+def is_insufficient_balance_message(message: str) -> bool:
+    """Recognize only explicit paid-API account exhaustion signals."""
+    low = message.lower()
+    return any(s in low for s in (
+        "insufficient balance",
+        "insufficient_balance",
+        "balance is insufficient",
+        "余额不足",
+    )) or ("402" in low and "payment required" in low)
+
+
 # Targeted advice per diagnose_exception kind. Only the rate-limit case may
 # mention quota — an unrecognized failure gets the artifact paths, not a
 # guess (a volunteer bug report proved "wait for your quota to reset" was
@@ -1259,6 +1273,9 @@ DIAG_ADVICE = {
     "rate-limit": (
         "this looks like a genuine rate/usage limit — wait for your quota "
         "window to reset, then claim again."),
+    "insufficient-balance": (
+        "the paid API account has insufficient balance. This batch stops now "
+        "before starting another task; recharge it, then run `dradar resume`."),
     "auth": (
         "the agent could not authenticate inside the container — for DeepSeek "
         "run `dradar provider status deepseek` (or set it up again); for the "

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -144,6 +144,52 @@ def test_checkout_loop_fuses_after_interrupted_trial(monkeypatch, capsys, tmp_pa
     assert "stopping this batch runner" in capsys.readouterr().out
 
 
+def test_checkout_loop_always_fuses_after_insufficient_balance(
+        monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(runloop, "_check_version_pin", lambda *a, **kw: None)
+    attempts = []
+
+    def run(client, assignment, *a, **kw):
+        attempts.append(assignment["assignment_id"])
+        runloop._signal_pool_abort("paid API balance exhausted")
+        return "insufficient-balance"
+
+    monkeypatch.setattr(runloop, "_run_and_submit", run)
+    abort_file = tmp_path / "pool-abort"
+    monkeypatch.setenv("DRADAR_POOL_ABORT_FILE", str(abort_file))
+    client = CheckoutClient(
+        {"active": [_cell("out-of-money")], "free_pick": True},
+        [{"assignment": _cell("out-of-money"), "held": 2, "unstarted": 1},
+         {"assignment": _cell("must-not-run"), "held": 2, "unstarted": 0}],
+    )
+
+    rc = runloop._go_menu(_args(), {}, client, tmp_path)
+
+    assert rc == 1
+    assert attempts == ["out-of-money"]
+    assert len(client._checkouts) == 1
+    assert abort_file.read_text() == "paid API balance exhausted"
+    assert "stopping this batch before the next task" in capsys.readouterr().out
+
+
+def test_checkout_worker_obeys_existing_pool_balance_fuse(
+        monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(runloop, "_check_version_pin", lambda *a, **kw: None)
+    abort_file = tmp_path / "pool-abort"
+    abort_file.write_text("paid API balance exhausted")
+    monkeypatch.setenv("DRADAR_POOL_ABORT_FILE", str(abort_file))
+    client = CheckoutClient(
+        {"active": [_cell("must-not-run")], "free_pick": True},
+        [{"assignment": _cell("must-not-run"), "held": 1, "unstarted": 0}],
+    )
+
+    rc = runloop._go_menu(_args(), {}, client, tmp_path)
+
+    assert rc == 0
+    assert client.checkout_exclusions == []
+    assert "stopped before another checkout" in capsys.readouterr().out
+
+
 def test_old_server_redispatching_failed_cell_is_unstamped_before_exit(
         monkeypatch, capsys, tmp_path):
     # Regression for case 019f656c-cf16-70e2-ae4c-d1d51146acb2: an old

--- a/tests/test_diagnosis.py
+++ b/tests/test_diagnosis.py
@@ -65,6 +65,12 @@ def test_diagnose_classifies_rate_limit(tmp_path):
     assert d["kind"] == "rate-limit"
 
 
+def test_diagnose_classifies_insufficient_balance_before_generic_http_errors(tmp_path):
+    d = diagnose_exception(_result(
+        tmp_path, "402 Payment Required: Insufficient Balance"))
+    assert d["kind"] == "insufficient-balance"
+
+
 def test_diagnose_classifies_model_capacity(tmp_path):
     d = diagnose_exception(_result(tmp_path,
         "turn.failed: Selected model is at capacity. Please try a different model."))
@@ -121,6 +127,28 @@ def test_interrupted_rate_limit_advice_mentions_quota(monkeypatch, capsys, tmp_p
     runloop._run_and_submit(client, ASSIGNMENT, tmp_path, _args(), "abc123")
     out = capsys.readouterr().out
     assert "rate/usage limit" in out
+
+
+def test_interrupted_insufficient_balance_returns_batch_terminal_outcome(
+        monkeypatch, capsys, tmp_path: Path):
+    monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
+    art = _fake_art(tmp_path, rc=0, result_data={
+        "exception_info": {
+            "exception_type": "AgentError",
+            "exception_message": "402 Payment Required: Insufficient Balance",
+        },
+        "agent_result": {},
+    })
+    monkeypatch.setattr(runloop, "run_trial", lambda *a, **kw: art)
+    client = InvalidAckClient({})
+
+    outcome = runloop._run_and_submit(
+        client, ASSIGNMENT, tmp_path, _args(), "abc123")
+
+    assert outcome == "insufficient-balance"
+    out = capsys.readouterr().out
+    assert "insufficient balance" in out.lower()
+    assert client.submissions[0]["outcome"] == "interrupted"
 
 
 def test_interrupted_model_capacity_advice_is_not_a_quota_guess(

--- a/tests/test_go_menu.py
+++ b/tests/test_go_menu.py
@@ -618,3 +618,23 @@ def test_mixed_batch_one_failure_yields_rc_1(monkeypatch, tmp_path: Path):
     rc = runloop._go_menu(_args(yes=True, dev_agent=None), {}, client, tmp_path)
     assert [s["assignment_id"] for s in client.submissions] == ["a2"]  # a2 still landed
     assert rc == 1  # but the batch as a whole reports failure
+
+
+def test_serial_batch_stops_before_second_cell_on_insufficient_balance(
+        monkeypatch, capsys, tmp_path: Path):
+    attempts = []
+
+    def run(client, assignment, *a, **kw):
+        attempts.append(assignment["assignment_id"])
+        return "insufficient-balance"
+
+    monkeypatch.setattr(runloop, "_run_and_submit", run)
+    monkeypatch.setattr(runloop, "_check_version_pin", lambda *a, **kw: None)
+    batch = [{**ASSIGNMENT, "assignment_id": "a1", "task_id": "t1"},
+             {**ASSIGNMENT, "assignment_id": "a2", "task_id": "t2"}]
+
+    rc = runloop._run_batch(_args(), SubmitClient({}), tmp_path, batch)
+
+    assert rc == 1
+    assert attempts == ["a1"]
+    assert "stopping this batch before the next task" in capsys.readouterr().out

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -273,6 +273,9 @@ def test_pool_prepares_once_then_starts_requested_resume_workers(monkeypatch):
     assert len(calls) == 3
     assert [p.env["DRADAR_WORKER_INDEX"] for p in calls] == ["1", "2", "3"]
     assert [p.env["DRADAR_POOL_SIZE"] for p in calls] == ["3", "3", "3"]
+    abort_files = {p.env["DRADAR_POOL_ABORT_FILE"] for p in calls}
+    assert len(abort_files) == 1
+    assert not runloop.Path(abort_files.pop()).exists()
     assert all("resume" in p.command and "--auto" not in p.command for p in calls)
 
 


### PR DESCRIPTION
## Summary\n- classify explicit 402 / insufficient-balance responses as an account-terminal outcome\n- stop serial and checkout batches before another task starts\n- propagate a one-run fuse across supervised workers while preserving in-flight work\n- keep the failed task technical/invalid rather than grading it as a model failure\n\n## Verification\n- 385 tests passed\n- reproduced classifier against the retained DeepSeek failure result (type only; no task or trajectory data)