### PR TITLE
Fix JSON-safe trajectory redaction

### DIFF
--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -34,8 +34,8 @@ from .runner import (
     summarize_result, sync_deep_swe_commit, trial_artifact_paths,
 )
 from .scrub import (
-    patch_structure_is_valid, redact_patch_secrets, scan_secrets, scrub_bytes,
-    scrub_file,
+    patch_structure_is_valid, redact_patch_secrets, scan_secrets,
+    scrub_json_bytes,
 )
 from .telemetry import RunnerTelemetry
 
@@ -494,9 +494,9 @@ def _upload_trial(
             serialized = json.dumps(
                 trajectory_bundle, ensure_ascii=False, separators=(",", ":"),
             ).encode("utf-8")
-            trajectory_bundle_scrubbed.write_bytes(scrub_bytes(serialized))
             try:
-                json.loads(trajectory_bundle_scrubbed.read_bytes())
+                scrubbed_bundle = scrub_json_bytes(serialized)
+                json.loads(scrubbed_bundle)
             except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
                 # The bundle is optional display data.  A redaction bug must
                 # not strand an otherwise valid patch/result or make every
@@ -505,22 +505,26 @@ def _upload_trial(
                       f"trajectory bundle ({exc}); uploading the verified "
                       "result without it")
                 trajectory_bundle_scrubbed = None
+            else:
+                trajectory_bundle_scrubbed.write_bytes(scrubbed_bundle)
         traj_scrubbed = None
         if trajectory:
             traj_scrubbed = scrubbed / "trajectory.json"
-            scrub_file(trajectory, traj_scrubbed)
             try:
-                value = json.loads(traj_scrubbed.read_bytes())
+                scrubbed_trajectory = scrub_json_bytes(trajectory.read_bytes())
+                value = json.loads(scrubbed_trajectory)
                 if not isinstance(value, dict):
                     raise ValueError("top level is not an object")
             except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
                 print(f"  {task_id}: Pier produced a malformed optional trajectory "
                       f"({exc}); uploading the verified result without it")
                 traj_scrubbed = None
+            else:
+                traj_scrubbed.write_bytes(scrubbed_trajectory)
         result_scrubbed = None
         if result:
             result_scrubbed = scrubbed / "result.json"
-            scrub_file(result, result_scrubbed)
+            result_scrubbed.write_bytes(scrub_json_bytes(result.read_bytes()))
             if usage is not None:
                 _apply_codex_usage_to_result(result_scrubbed, usage)
         # Record before submitting: from here on an unacked completed trial

--- a/src/dradar/scrub.py
+++ b/src/dradar/scrub.py
@@ -10,7 +10,10 @@ Two artifact classes, two mechanisms (design doc):
   is never rewritten.
 
 - **Display** (trajectory.json, result.json): shown in the public viewer, so
-  redact destructively (`scrub_bytes`). Over-redaction is acceptable here.
+  redact destructively. JSON artifacts are parsed and scrubbed structurally;
+  applying regexes to their serialized bytes can consume JSON escape
+  backslashes and corrupt otherwise valid data. Over-redaction is acceptable
+  here.
 
 Both run client-side before upload AND server-side before storage. Neither
 path ever bypasses on non-UTF-8 input: bytes are decoded with
@@ -18,6 +21,7 @@ path ever bypasses on non-UTF-8 input: bytes are decoded with
 are still caught.
 """
 
+import json
 import re
 import subprocess
 from pathlib import Path
@@ -68,6 +72,17 @@ _SCRUB_PATTERNS: list[tuple[re.Pattern[str], str]] = [
 
 # Home-dir paths reveal local usernames; container paths (/app, /logs) are fine.
 _HOME_RE = re.compile(r"/(?:Users|home)/[A-Za-z0-9._-]+")
+
+# The text scrubber recognizes values written next to these field names. When
+# JSON is parsed first, key and value are separate strings, so retain that
+# protection explicitly instead of relying on serialized punctuation.
+_SENSITIVE_JSON_KEY_RE = re.compile(
+    r"(?i)(?:authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|"
+    r"client[_-]?secret|secret)$"
+)
+_AUTH_JSON_KEY_RE = re.compile(r"(?i)authorization$")
+_OPAQUE_AUTH_VALUE_RE = re.compile(r"[^\s\"']{12,}")
+_OPAQUE_SECRET_VALUE_RE = re.compile(r"[A-Za-z0-9._~+/-]{16,}=*")
 
 
 def _decode(data: bytes) -> str:
@@ -136,6 +151,54 @@ def scrub_bytes(data: bytes) -> bytes:
     """Destructively redact a display artifact. Never bypasses: arbitrary
     bytes round-trip via surrogateescape while ASCII secrets are redacted."""
     return scrub_text(_decode(data)).encode("utf-8", errors="surrogateescape")
+
+
+def _scrub_json_value(value: object) -> object:
+    if isinstance(value, str):
+        return scrub_text(value)
+    if isinstance(value, list):
+        return [_scrub_json_value(item) for item in value]
+    if isinstance(value, dict):
+        scrubbed: dict[str, object] = {}
+        for key, item in value.items():
+            # json.loads always produces string object keys.
+            clean_key = scrub_text(key)
+            is_auth = bool(_AUTH_JSON_KEY_RE.search(key))
+            is_sensitive = bool(_SENSITIVE_JSON_KEY_RE.search(key))
+            should_redact = isinstance(item, str) and (
+                (is_auth and _OPAQUE_AUTH_VALUE_RE.match(item) is not None)
+                or (is_sensitive and not is_auth
+                    and _OPAQUE_SECRET_VALUE_RE.match(item) is not None)
+            )
+            if should_redact:
+                scrubbed[clean_key] = ("[REDACTED-AUTH]"
+                                       if is_auth else "[REDACTED]")
+            else:
+                scrubbed[clean_key] = _scrub_json_value(item)
+        return scrubbed
+    return value
+
+
+def scrub_json_bytes(data: bytes) -> bytes:
+    """Redact a JSON artifact without editing its serialized syntax.
+
+    Parsing before redaction keeps escape backslashes out of the regex input;
+    re-serialization therefore guarantees that valid input remains valid JSON.
+    Invalid JSON raises instead of being uploaded or bypassing redaction.
+    """
+    value = json.loads(data)
+    scrubbed = _scrub_json_value(value)
+    serialized = json.dumps(
+        scrubbed, ensure_ascii=False, separators=(",", ":"),
+    )
+    try:
+        return serialized.encode("utf-8")
+    except UnicodeEncodeError:
+        # JSON may legally contain an escaped unpaired surrogate. Keep the
+        # output valid and portable without rejecting the whole artifact.
+        return json.dumps(
+            scrubbed, ensure_ascii=True, separators=(",", ":"),
+        ).encode("ascii")
 
 
 def scrub_file(source: Path, target: Path) -> None:

--- a/tests/test_pending_upload.py
+++ b/tests/test_pending_upload.py
@@ -191,8 +191,13 @@ def test_upload_omits_bundle_when_redaction_breaks_its_json(
                          100, 60, 10)
     _write_codex_session(sessions / "child.jsonl", "child-1", "subagent",
                          50, 20, 5, parent="root-1")
-    monkeypatch.setattr(runloop, "scrub_bytes",
-                        lambda _data: b'{"broken":"bad\\q"}')
+    real_scrub_json_bytes = runloop.scrub_json_bytes
+    monkeypatch.setattr(
+        runloop, "scrub_json_bytes",
+        lambda data: (b'{"broken":"bad\\q"}'
+                      if b'"schema_version"' in data
+                      else real_scrub_json_bytes(data)),
+    )
 
     class CaptureClient(FakeClient):
         def submit(self, assignment_id, nonce, patch, trajectory, result, meta,
@@ -344,6 +349,34 @@ def test_upload_omits_malformed_optional_trajectory(tmp_path: Path, monkeypatch,
     outcome = runloop._upload_trial(CaptureClient(lambda _aid: None), _entry(trial_dir))
     assert outcome == "submitted"
     assert "malformed optional trajectory" in capsys.readouterr().out
+
+
+def test_upload_preserves_valid_trajectory_when_redaction_has_escaped_quote(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    (trial_dir / "agent").mkdir()
+    token = "abcdefghijklmnop"
+    payload = {"steps": [{
+        "message": "authorization:" + token + '"suffix',
+    }]}
+    (trial_dir / "agent" / "trajectory.json").write_text(json.dumps(payload))
+    (trial_dir / "result.json").write_text("{}")
+
+    class CaptureClient(FakeClient):
+        def submit(self, assignment_id, nonce, patch, trajectory, result, meta,
+                   outcome="completed", resume_generation=None):
+            uploaded = json.loads(trajectory.read_text())
+            message = uploaded["steps"][0]["message"]
+            assert token not in message
+            assert message.endswith('"suffix')
+            return {"submission_id": "s1", "grade_status": "pending"}
+
+    outcome = runloop._upload_trial(
+        CaptureClient(lambda _aid: None), _entry(trial_dir),
+    )
+    assert outcome == "submitted"
 
 
 def test_upload_success_removes_current_and_superseded_checkpoint_jobs(

--- a/tests/test_scrub.py
+++ b/tests/test_scrub.py
@@ -1,6 +1,8 @@
+import json
+
 from dradar.scrub import (
     patch_structure_is_valid, redact_patch_secrets, scan_secrets, scrub_bytes,
-    scrub_text,
+    scrub_json_bytes, scrub_text,
 )
 
 
@@ -38,6 +40,37 @@ def test_scrub_bytes_never_bypasses_on_bad_utf8():
     out = scrub_bytes(data)
     assert b"sk-proj" not in out
     assert b"\x80\xff" in out  # non-secret bytes round-trip intact
+
+
+def test_scrub_json_bytes_preserves_escaped_quotes_and_redacts_values():
+    token = "abcdefghijklmnop"
+    payload = {
+        "authorization": token + '"suffix',
+        "nested": [{"message": "authorization:" + token + '"suffix'}],
+        "contact": "aloha@example.com at /Users/aloha/project",
+    }
+
+    out = scrub_json_bytes(json.dumps(payload).encode())
+    decoded = json.loads(out)
+
+    assert decoded["authorization"] == "[REDACTED-AUTH]"
+    assert decoded["nested"][0]["message"].endswith('"suffix')
+    assert token not in decoded["nested"][0]["message"]
+    assert "aloha@example.com" not in decoded["contact"]
+    assert "/Users/aloha" not in decoded["contact"]
+
+
+def test_scrub_json_bytes_handles_sensitive_keys_inside_nested_objects():
+    payload = {
+        "headers": {"Proxy-Authorization": "opaque-value", "ok": True},
+        "credentials": [{"api_key": "not-a-real-key-12345"}],
+    }
+
+    decoded = json.loads(scrub_json_bytes(json.dumps(payload).encode()))
+
+    assert decoded["headers"]["Proxy-Authorization"] == "[REDACTED-AUTH]"
+    assert decoded["headers"]["ok"] is True
+    assert decoded["credentials"][0]["api_key"] == "[REDACTED]"
 
 
 def test_scan_secrets_detects_without_rewriting():


### PR DESCRIPTION
## Summary

- parse JSON display artifacts before redacting their string content
- redact sensitive object fields without touching serialized JSON escape syntax
- re-serialize trajectories, trajectory bundles, and results after sanitization
- retain the existing safe fallback for genuinely malformed optional Pier trajectories
- add regression coverage for escaped quotes, nested sensitive fields, and upload fallback

## Why

The byte-oriented display scrubber could consume the backslash that escaped a quote after an authorization-shaped value. That turned valid JSON into invalid JSON and caused DRadar to omit otherwise usable optional trajectory evidence.

The fix is provider-independent and does not change model patches, verified results, usage accounting, or grading semantics.

## Tests

- `pytest -q tests/test_scrub.py tests/test_pending_upload.py` — 54 passed
- `pytest -q` — 388 passed

Fixes #60