### PR TITLE
Fix 422 trajectory bundle submission recovery

### DIFF
--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -58,6 +58,30 @@ _ACCOUNT_TERMINAL_OUTCOMES = {"insufficient-balance"}
 _POOL_ABORT_ENV = "DRADAR_POOL_ABORT_FILE"
 
 
+def _is_trajectory_bundle_rejection(exc: ApiError) -> bool:
+    """Whether a 422 only rejects the optional trajectory bundle.
+
+    Newer servers may provide a stable application code. Older deployments
+    only expose the safe detail string, so keep a deliberately narrow text
+    fallback for compatibility.
+    """
+    if exc.status_code != 422:
+        return False
+    if exc.code and exc.code.startswith("trajectory_bundle_"):
+        return True
+    detail = str(exc).lower()
+    return "trajectory_bundle" in detail or "trajectory bundle" in detail
+
+
+def _is_patch_secret_rejection(exc: ApiError) -> bool:
+    """A server-side secret rejection must never be bypassed automatically."""
+    if exc.status_code != 422:
+        return False
+    if exc.code in {"patch_secret_detected", "patch_contains_secret"}:
+        return True
+    return "patch appears to contain secrets" in str(exc).lower()
+
+
 def _pool_abort_path() -> Path | None:
     raw = os.environ.get(_POOL_ABORT_ENV)
     return Path(raw) if raw else None
@@ -568,49 +592,70 @@ def _upload_trial(
         # has the canonical paths + digest in its ledger entry. The server
         # dedupes replays (409 "already submitted"), so duplicates are safe.
         pending.record(HOME, entry)
-        try:
+        submit_bundle = (
+            None if entry.get("omit_trajectory_bundle")
+            else trajectory_bundle_scrubbed
+        )
+        while True:
             submit_kwargs = {
                 "outcome": outcome,
                 "resume_generation": entry.get("resume_generation"),
             }
-            if trajectory_bundle_scrubbed is not None:
-                submit_kwargs["trajectory_bundle"] = trajectory_bundle_scrubbed
-            ack = client.submit(
-                assignment_id, entry["nonce"], upload_patch, traj_scrubbed,
-                result_scrubbed, upload_meta, **submit_kwargs,
-            )
-        except ApiError as exc:
-            if exc.status_code == 409 and "already submitted" in str(exc).lower():
-                # Some earlier attempt actually landed server-side even
-                # though THIS process never saw the response — good news.
-                print(f"  {task_id}: already submitted (an earlier attempt landed) — clearing it")
-                pending.remove(HOME, assignment_id)
-                cleanup_settled()
-                return "submitted"
-            if exc.status_code == 410:
-                print(f"  {task_id}: lease expired, unsalvageable — the cell reopened "
-                      "for someone else, dropping it")
-                pending.remove(HOME, assignment_id)
-                cleanup_settled()
-                return "expired"
-            if exc.status_code in (404, 413, 422):
-                # Definitively rejected: the exact same bytes can never
-                # succeed (payload too large / unprocessable / assignment
-                # unknown), so an entry here would just fail identically on
-                # every future retry. 403 deliberately NOT in this list — it
-                # covers both a permanent nonce mismatch and a suspension
-                # that may be lifted, and dropping a suspended volunteer's
-                # completed trial would destroy recoverable work.
-                print(f"  {task_id}: the server rejected this upload for good ({exc}) — "
-                      "retrying can't fix it, dropping it from the retry queue "
-                      f"(local artifact path: {patch.parent.parent})")
-                pending.remove(HOME, assignment_id)
-                settle_terminal_local_failure()
-                print(f"  rejected artifacts kept for diagnosis: {patch.parent.parent}")
-                return "rejected"
-            print(f"  {task_id}: upload failed ({exc}) — kept for retry "
-                  "(`dradar retry-upload`)")
-            return "upload-failed"
+            if submit_bundle is not None:
+                submit_kwargs["trajectory_bundle"] = submit_bundle
+            try:
+                ack = client.submit(
+                    assignment_id, entry["nonce"], upload_patch, traj_scrubbed,
+                    result_scrubbed, upload_meta, **submit_kwargs,
+                )
+                break
+            except ApiError as exc:
+                if (submit_bundle is not None
+                        and _is_trajectory_bundle_rejection(exc)):
+                    # The bundle is optional. Persist the downgrade before the
+                    # second request so a crash/transport failure cannot make
+                    # the next retry rebuild and resend the rejected artifact.
+                    entry["omit_trajectory_bundle"] = True
+                    pending.record(HOME, entry)
+                    submit_bundle = None
+                    print(
+                        f"  {task_id}: server rejected the optional trajectory "
+                        "bundle; retrying the completed result without it"
+                    )
+                    continue
+
+                if exc.status_code == 409 and "already submitted" in str(exc).lower():
+                    # Some earlier attempt actually landed server-side even
+                    # though THIS process never saw the response — good news.
+                    print(f"  {task_id}: already submitted (an earlier attempt landed) — clearing it")
+                    pending.remove(HOME, assignment_id)
+                    cleanup_settled()
+                    return "submitted"
+                if exc.status_code == 410:
+                    print(f"  {task_id}: lease expired, unsalvageable — the cell reopened "
+                          "for someone else, dropping it")
+                    pending.remove(HOME, assignment_id)
+                    cleanup_settled()
+                    return "expired"
+                if (exc.status_code in (404, 413)
+                        or _is_patch_secret_rejection(exc)):
+                    # These are genuinely terminal for the current payload:
+                    # assignment unknown, request too large, or a patch the
+                    # server still considers unsafe. Never bypass the secret
+                    # gate by retrying a reduced optional-artifact set.
+                    print(f"  {task_id}: the server rejected this upload for good ({exc}) — "
+                          "retrying can't fix it, dropping it from the retry queue "
+                          f"(local artifact path: {patch.parent.parent})")
+                    pending.remove(HOME, assignment_id)
+                    settle_terminal_local_failure()
+                    print(f"  rejected artifacts kept for diagnosis: {patch.parent.parent}")
+                    return "rejected"
+                # Unknown 422 responses are not proof that the completed work
+                # is unrecoverable. Keep the ledger instead of silently losing
+                # a paid run; future CLI/server versions may understand it.
+                print(f"  {task_id}: upload failed ({exc}) — kept for retry "
+                      "(`dradar retry-upload`)")
+                return "upload-failed"
 
     pending.remove(HOME, assignment_id)
     cleanup_settled()

--- a/tests/test_pending_upload.py
+++ b/tests/test_pending_upload.py
@@ -887,8 +887,7 @@ def _raise(status):
 
 
 def test_definitively_rejected_upload_drops_ledger_entry(tmp_path: Path, monkeypatch, capsys):
-    """413/422/404 can never succeed with the same bytes — keeping the entry
-    would just re-fail identically on every future `dradar go`."""
+    """A 413 cannot succeed with the same bytes on a later retry."""
     monkeypatch.setattr(runloop, "HOME", tmp_path)
     trial_dir = _make_trial_dir(tmp_path)
     client = FakeClient(_raise(413))
@@ -915,7 +914,7 @@ def test_definitive_rejection_preserves_checkpoint_job(tmp_path: Path, monkeypat
     }))
     (trial / "artifacts").mkdir()
     (trial / "artifacts" / "model.patch").write_text("diff --git a b\n")
-    client = FakeClient(_raise(422))
+    client = FakeClient(_raise(413))
     outcome = runloop._upload_trial(
         client,
         _entry(trial, assignment_id=aid, job_dir=str(job), keep=False),
@@ -926,6 +925,91 @@ def test_definitive_rejection_preserves_checkpoint_job(tmp_path: Path, monkeypat
     assert (job / checkpoints.TERMINAL_MARKER).is_file()
     assert checkpoints.find_latest(tmp_path, aid) is None
     assert client.stopped == [aid]
+
+
+def test_bundle_422_retries_completed_result_without_optional_bundle(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    sessions = trial_dir / "agent" / "sessions"
+    _write_codex_session(sessions / "root.jsonl", "root-1", "user", 100)
+    _write_codex_session(
+        sessions / "child.jsonl", "child-1", "subagent", 50,
+        parent="root-1",
+    )
+
+    class BundleFallbackClient(FakeClient):
+        def submit(self, assignment_id, nonce, patch, trajectory, result, meta,
+                   outcome="completed", resume_generation=None,
+                   trajectory_bundle=None):
+            self.calls.append(trajectory_bundle is not None)
+            if trajectory_bundle is not None:
+                raise ApiError(
+                    "server returned 422: trajectory_bundle.json is not valid JSON",
+                    status_code=422,
+                )
+            return {"submission_id": "s1", "grade_status": "pending"}
+
+    client = BundleFallbackClient(lambda _aid: None)
+    outcome = runloop._upload_trial(client, _entry(trial_dir))
+    assert outcome == "submitted"
+    assert client.calls == [True, False]
+    assert pending.load(tmp_path) == []
+    assert client.stopped == []
+
+
+def test_bundle_422_persists_downgrade_when_fallback_transport_fails(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    sessions = trial_dir / "agent" / "sessions"
+    _write_codex_session(sessions / "root.jsonl", "root-1", "user", 100)
+    _write_codex_session(
+        sessions / "child.jsonl", "child-1", "subagent", 50,
+        parent="root-1",
+    )
+
+    class FailingFallbackClient(FakeClient):
+        def submit(self, assignment_id, nonce, patch, trajectory, result, meta,
+                   outcome="completed", resume_generation=None,
+                   trajectory_bundle=None):
+            self.calls.append(trajectory_bundle is not None)
+            if trajectory_bundle is not None:
+                raise ApiError(
+                    "server returned 422: trajectory_bundle.json is not valid JSON",
+                    status_code=422,
+                )
+            raise ApiError("server returned 503: retry", status_code=503)
+
+    first = FailingFallbackClient(lambda _aid: None)
+    assert runloop._upload_trial(first, _entry(trial_dir)) == "upload-failed"
+    assert first.calls == [True, False]
+    retry_entry = pending.load(tmp_path)[0]
+    assert retry_entry["omit_trajectory_bundle"] is True
+
+    class RecoveryClient(FakeClient):
+        def submit(self, assignment_id, nonce, patch, trajectory, result, meta,
+                   outcome="completed", resume_generation=None,
+                   trajectory_bundle=None):
+            self.calls.append(trajectory_bundle is not None)
+            assert trajectory_bundle is None
+            return {"submission_id": "s1", "grade_status": "pending"}
+
+    second = RecoveryClient(lambda _aid: None)
+    assert runloop._upload_trial(second, retry_entry) == "submitted"
+    assert second.calls == [False]
+    assert pending.load(tmp_path) == []
+
+
+def test_unknown_422_keeps_completed_work_for_retry(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    client = FakeClient(_raise(422))
+    assert runloop._upload_trial(client, _entry(trial_dir)) == "upload-failed"
+    assert [e["assignment_id"] for e in pending.load(tmp_path)] == ["a1"]
+    assert client.stopped == []
 
 
 def test_transient_5xx_keeps_ledger_entry(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary
- retry completed submissions without the optional trajectory bundle when that bundle is specifically rejected with HTTP 422
- persist the downgrade so later retries do not resend the rejected bundle
- retain unknown 422 failures instead of discarding paid completed work
- keep assignment, size, and secret rejections terminal

## Validation
- python -m pytest -q
- 410 passed

## Impact
Fixes the shared public CLI path for ordinary and privileged accounts. Contains no ds0-private Pier code.