### PR TITLE
fix: scope orphan cleanup to the current DRadar home

### DIFF
--- a/src/dradar/machine.py
+++ b/src/dradar/machine.py
@@ -9,8 +9,9 @@ three dradar sessions at once, 2026-07-14):
 - orphan compose sweep: pier launches each trial as a docker compose project
   named <task>__<trialid>; a killed dradar/pier never runs `compose down`, so
   the agent keeps running (and burning quota) inside a container nobody will
-  ever harvest. With the instance lock held, any such project that exists
-  BEFORE we launch our first trial belongs to a dead run — offer to clean it.
+  ever harvest. A project is eligible only when Docker proves that one of its
+  bind mounts or compose files lives below this DRADAR_HOME's work/jobs tree.
+  The per-home lock alone cannot prove ownership on a shared Docker daemon.
 """
 
 import json
@@ -26,6 +27,66 @@ from pathlib import Path
 _PIER_PROJECT_RE = re.compile(r"[a-z0-9][a-z0-9-]*__[a-z0-9]{6,8}$", re.IGNORECASE)
 
 _lock_handle = None  # keeps the OS lock alive for the process lifetime
+
+
+def _path_belongs_to(path: str, root: Path) -> bool:
+    if not path:
+        return False
+    try:
+        return Path(path).resolve().is_relative_to(root.resolve())
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def _project_belongs_to_home(name: str, home: Path) -> bool:
+    """Return True only with positive Docker evidence of project ownership.
+
+    Compose project names are not namespaced by user or DRADAR_HOME.  On a
+    shared daemon another live runner can therefore have a perfectly valid
+    Pier-shaped name.  Pier mounts its trial directory (and generated compose
+    files) below ``HOME/work/jobs``; inspect those paths before allowing an
+    automatic teardown.  Inspection failures deliberately fail closed.
+    """
+    try:
+        proc = subprocess.run(
+            ["docker", "ps", "-aq", "--filter",
+             f"label=com.docker.compose.project={name}"],
+            capture_output=True, text=True, timeout=20)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if proc.returncode != 0:
+        return False
+    container_ids = proc.stdout.split()
+    if not container_ids:
+        return False
+    try:
+        proc = subprocess.run(
+            ["docker", "inspect", *container_ids],
+            capture_output=True, text=True, timeout=20)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if proc.returncode != 0:
+        return False
+    try:
+        containers = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        return False
+
+    jobs_root = home / "work" / "jobs"
+    for container in containers:
+        if not isinstance(container, dict):
+            continue
+        for mount in container.get("Mounts", []):
+            if (isinstance(mount, dict)
+                    and mount.get("Type") == "bind"
+                    and _path_belongs_to(str(mount.get("Source", "")), jobs_root)):
+                return True
+        labels = (container.get("Config", {}).get("Labels", {}) or {})
+        config_files = labels.get("com.docker.compose.project.config_files", "")
+        if any(_path_belongs_to(path.strip(), jobs_root)
+               for path in config_files.split(",")):
+            return True
+    return False
 
 
 def acquire_run_lock(home: Path) -> None:
@@ -68,12 +129,12 @@ def acquire_run_lock(home: Path) -> None:
     _lock_handle = fh
 
 
-def sweep_orphan_compose(assume_yes: bool) -> None:
+def sweep_orphan_compose(home: Path, assume_yes: bool) -> None:
     """Find pier-shaped compose projects that predate this run and offer to
-    take them down. Only callable while holding the run lock — that is what
-    makes 'it exists now' imply 'no live dradar on this machine owns it'.
-    Every failure path is silent: this is a courtesy sweep, never a reason
-    to block a real run."""
+    take them down. Only callable while holding this home's run lock. Project
+    names are merely a first-pass filter; Docker mounts/config paths must also
+    prove that the project belongs to this home. Every failure path is silent:
+    this is a courtesy sweep, never a reason to block a real run."""
     try:
         proc = subprocess.run(
             ["docker", "compose", "ls", "--format", "json"],
@@ -86,8 +147,10 @@ def sweep_orphan_compose(assume_yes: bool) -> None:
         listed = json.loads(proc.stdout or "[]")
     except json.JSONDecodeError:
         return
-    orphans = [p.get("Name", "") for p in listed
-               if _PIER_PROJECT_RE.fullmatch(p.get("Name", "") or "")]
+    candidates = [p.get("Name", "") for p in listed
+                  if _PIER_PROJECT_RE.fullmatch(p.get("Name", "") or "")]
+    orphans = [name for name in candidates
+               if _project_belongs_to_home(name, home)]
     if not orphans:
         return
     print(f"found {len(orphans)} leftover task container project(s) from a "

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -1530,7 +1530,7 @@ def cmd_go(args) -> int:
                   "share this machine's CPU/RAM — expect slower individual runs.")
         else:
             acquire_run_lock(HOME)
-            sweep_orphan_compose(args.yes)
+            sweep_orphan_compose(HOME, args.yes)
             args.allow_new_claims = _maintain_image_cache(
                 client, cfg, phase="before run",
             )
@@ -1691,7 +1691,7 @@ def _run_worker_pool(args) -> int:
         client = _client(cfg, auto_register=True)
     tasks_root = tasks_root_from_config(cfg)
     acquire_run_lock(HOME)
-    sweep_orphan_compose(True)
+    sweep_orphan_compose(HOME, True)
     args.allow_new_claims = _maintain_image_cache(
         client, cfg, phase="before worker pool",
     )

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -40,52 +40,103 @@ def test_second_instance_refuses_to_start(tmp_path: Path):
     machine._lock_handle = None
 
 
-def _fake_compose(monkeypatch, projects):
+def _fake_compose(monkeypatch, projects, home: Path, owned=()):
     calls = []
+    owned = set(owned)
+    id_to_project = {f"container-{i}": project
+                     for i, project in enumerate(projects)}
+    project_to_id = {project: container_id
+                     for container_id, project in id_to_project.items()}
 
     def fake_run(cmd, **kw):
         calls.append(cmd)
         if cmd[:3] == ["docker", "compose", "ls"]:
             return subprocess.CompletedProcess(
                 cmd, 0, stdout=json.dumps([{"Name": p} for p in projects]), stderr="")
+        if cmd[:2] == ["docker", "ps"]:
+            project = cmd[-1].rsplit("=", 1)[-1]
+            container_id = project_to_id.get(project)
+            stdout = f"{container_id}\n" if container_id else ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+        if cmd[:2] == ["docker", "inspect"]:
+            inspected = []
+            for container_id in cmd[2:]:
+                project = id_to_project[container_id]
+                root = home if project in owned else home.parent / "other-home"
+                inspected.append({
+                    "Mounts": [{
+                        "Type": "bind",
+                        "Source": str(root / "work" / "jobs" / project / "artifacts"),
+                    }],
+                    "Config": {"Labels": {}},
+                })
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=json.dumps(inspected), stderr="")
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
     monkeypatch.setattr(machine.subprocess, "run", fake_run)
     return calls
 
 
-def test_sweep_downs_only_pier_shaped_projects(monkeypatch, capsys):
+def test_sweep_downs_only_owned_pier_shaped_projects(monkeypatch, capsys,
+                                                      tmp_path: Path):
+    first = "arktype-json-schema-refs-depende__ui7n6a5"
+    second = "boa-hierarchical-evaluation-canc__eeecwyc"
     calls = _fake_compose(monkeypatch, [
-        "arktype-json-schema-refs-depende__ui7n6a5",   # orphan pier trial
-        "boa-hierarchical-evaluation-canc__eeecwyc",   # orphan pier trial
+        first,                                           # ours
+        second,                                          # foreign runner
         "my-blog",                                     # someone's real project
         "web_app-dev",                                 # underscore but not __id
-    ])
-    sweep_orphan_compose(assume_yes=True)
+    ], tmp_path, owned={first})
+    sweep_orphan_compose(tmp_path, assume_yes=True)
     downed = [c[3] for c in calls if c[:3] == ["docker", "compose", "-p"]]
-    assert downed == ["arktype-json-schema-refs-depende__ui7n6a5",
-                      "boa-hierarchical-evaluation-canc__eeecwyc"]
+    assert downed == [first]
     out = capsys.readouterr().out
     assert "burning your quota" in out
 
 
-def test_sweep_silent_when_nothing_matches(monkeypatch, capsys):
-    calls = _fake_compose(monkeypatch, ["my-blog"])
-    sweep_orphan_compose(assume_yes=True)
+def test_sweep_silent_when_nothing_matches(monkeypatch, capsys, tmp_path: Path):
+    calls = _fake_compose(monkeypatch, ["my-blog"], tmp_path)
+    sweep_orphan_compose(tmp_path, assume_yes=True)
     assert len(calls) == 1                       # only the ls, no downs
     assert capsys.readouterr().out == ""
 
 
-def test_sweep_survives_missing_docker(monkeypatch):
+def test_sweep_survives_missing_docker(monkeypatch, tmp_path: Path):
     def boom(cmd, **kw):
         raise OSError("no docker")
     monkeypatch.setattr(machine.subprocess, "run", boom)
-    sweep_orphan_compose(assume_yes=True)        # must not raise
+    sweep_orphan_compose(tmp_path, assume_yes=True)  # must not raise
 
 
-def test_sweep_asks_before_touching_anything(monkeypatch, capsys):
-    calls = _fake_compose(monkeypatch, ["some-task__abc1234"])
+def test_sweep_asks_before_touching_anything(monkeypatch, capsys,
+                                             tmp_path: Path):
+    project = "some-task__abc1234"
+    calls = _fake_compose(monkeypatch, [project], tmp_path, owned={project})
     monkeypatch.setattr("builtins.input", lambda *_: "n")
-    sweep_orphan_compose(assume_yes=False)
-    assert len(calls) == 1                       # declined -> no downs
+    sweep_orphan_compose(tmp_path, assume_yes=False)
+    assert not any(c[:3] == ["docker", "compose", "-p"] for c in calls)
     assert "docker compose -p" in capsys.readouterr().out
+
+
+def test_sweep_fails_closed_when_inspect_fails(monkeypatch, capsys,
+                                                tmp_path: Path):
+    project = "some-task__abc1234"
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        if cmd[:3] == ["docker", "compose", "ls"]:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=json.dumps([{"Name": project}]), stderr="")
+        if cmd[:2] == ["docker", "ps"]:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="container-1\n", stderr="")
+        if cmd[:2] == ["docker", "inspect"]:
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="boom")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(machine.subprocess, "run", fake_run)
+    sweep_orphan_compose(tmp_path, assume_yes=True)
+    assert not any(c[:3] == ["docker", "compose", "-p"] for c in calls)
+    assert capsys.readouterr().out == ""

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -186,7 +186,7 @@ def _patch_pool_setup(monkeypatch, active_count=5):
     monkeypatch.setattr(runloop, "_client", lambda *_a, **_k: object())
     monkeypatch.setattr(runloop, "tasks_root_from_config", lambda _cfg: object())
     monkeypatch.setattr(runloop, "acquire_run_lock", lambda _home: None)
-    monkeypatch.setattr(runloop, "sweep_orphan_compose", lambda _yes: None)
+    monkeypatch.setattr(runloop, "sweep_orphan_compose", lambda _home, _yes: None)
     monkeypatch.setattr(runloop, "ensure_tasks_root", lambda _root: None)
     monkeypatch.setattr(runloop, "ensure_pier", lambda: None)
     monkeypatch.setattr(runloop, "_retry_pending_uploads", lambda _client: None)


### PR DESCRIPTION
## Summary
- require positive Docker mount/config ownership evidence before cleaning Pier-shaped Compose projects
- fail closed when Docker inspection is unavailable or malformed
- pass the active DRADAR_HOME through every run-loop cleanup call

## Why
On a shared Docker daemon, Compose project names are not sufficient proof of ownership. A runner could otherwise stop another user's live Pier project.

## Tests
- `pytest -q` (411 passed)
- coverage for owned projects, foreign projects, malformed inspect output, and inspection failure
