### PR TITLE
fix: atomically publish shared runner inputs

### DIFF
--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -11,8 +11,10 @@ import math
 import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
+import tempfile
 import time
 import tomllib
 from collections.abc import Callable
@@ -247,22 +249,69 @@ def claude_oauth_token() -> str | None:
     return os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
 
 
+def _materialize_shared_file(path: Path, data: bytes, mode: int = 0o600) -> Path:
+    """Publish deterministic runner input without exposing partial contents.
+
+    ``HOME / work`` is shared by supervised workers.  A direct ``write_text``
+    or ``copyfile`` truncates the common destination before writing, so one
+    Pier process can observe another process's half-written adapter/config.
+    Reuse an identical regular file; otherwise write a uniquely named file in
+    the same directory and make ``os.replace`` the single publication point.
+    """
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        info = path.lstat()
+        if stat.S_ISREG(info.st_mode) and path.read_bytes() == data:
+            if os.name != "nt":
+                os.chmod(path, mode)
+            return path
+    except OSError:
+        pass
+
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    tmp = Path(tmp_name)
+    try:
+        if os.name != "nt":
+            os.fchmod(fd, mode)
+        handle = os.fdopen(fd, "wb")
+        fd = -1
+        with handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            fd = -1
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+    finally:
+        if fd >= 0:
+            os.close(fd)
+    return path
+
+
 def _ensure_allowlist(home: Path) -> Path:
     path = home / "codex-chatgpt-allowlist.toml"
-    path.write_text(ALLOWLIST_TOML)
-    return path
+    return _materialize_shared_file(path, ALLOWLIST_TOML.encode())
 
 
 def _ensure_codex_submission_prompt(home: Path) -> Path:
     path = home / "codex-submission-prompt.j2"
-    path.write_text(CODEX_SUBMISSION_PROMPT)
-    return path
+    return _materialize_shared_file(path, CODEX_SUBMISSION_PROMPT.encode())
 
 
 def _ensure_deepseek_config(home: Path) -> Path:
     path = home / "codex-deepseek-v4-flash.toml"
-    path.write_text(DEEPSEEK_TOML)
-    return path
+    return _materialize_shared_file(path, DEEPSEEK_TOML.encode())
 
 
 def _validated_deepseek_catalog() -> Path:
@@ -283,8 +332,7 @@ def _ensure_deepseek_agent_module(home: Path) -> Path:
             "before running a paid task"
         )
     target = home / DEEPSEEK_AGENT_MODULE_FILENAME
-    shutil.copyfile(source, target)
-    return target
+    return _materialize_shared_file(target, source.read_bytes())
 
 
 def _version_tuple(value: str) -> tuple[int, int, int]:

--- a/tests/test_deepseek_provider.py
+++ b/tests/test_deepseek_provider.py
@@ -3,7 +3,10 @@
 import hashlib
 import json
 import os
+import stat
+import threading
 import tomllib
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -163,6 +166,108 @@ def test_command_uses_official_catalog_adapter_and_auth_without_secret_env(
         "wire_api": "responses",
         "requires_openai_auth": True,
     }
+
+
+def test_deepseek_shared_inputs_are_reused_and_owner_only(
+    tmp_path: Path,
+    monkeypatch,
+):
+    _, home = _command(tmp_path, monkeypatch)
+    runner._ensure_allowlist(home)
+    expected = {
+        home / runner.DEEPSEEK_AGENT_MODULE_FILENAME: (
+            Path(runner.__file__).with_name("pier_deepseek.py").read_bytes()
+        ),
+        home / "codex-deepseek-v4-flash.toml": runner.DEEPSEEK_TOML.encode(),
+        home / "codex-submission-prompt.j2": (
+            runner.CODEX_SUBMISSION_PROMPT.encode()
+        ),
+        home / "codex-chatgpt-allowlist.toml": runner.ALLOWLIST_TOML.encode(),
+    }
+    inodes = {path: path.stat().st_ino for path in expected}
+    if os.name != "nt":
+        # Reusing matching content must also repair an overly broad legacy
+        # mode without replacing the file.
+        for path in expected:
+            path.chmod(0o644)
+
+    monkeypatch.setattr(
+        runner.os,
+        "replace",
+        lambda *_args: pytest.fail("matching shared inputs must be reused"),
+    )
+    assert runner._ensure_deepseek_agent_module(home) in expected
+    assert runner._ensure_deepseek_config(home) in expected
+    assert runner._ensure_codex_submission_prompt(home) in expected
+    assert runner._ensure_allowlist(home) in expected
+
+    for path, payload in expected.items():
+        assert path.read_bytes() == payload
+        assert path.stat().st_ino == inodes[path]
+        if os.name != "nt":
+            assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_shared_input_publication_is_atomic_under_concurrency(
+    tmp_path: Path,
+    monkeypatch,
+):
+    path = tmp_path / "codex-deepseek-v4-flash.toml"
+    old = b"complete-old-config\n"
+    payload = (b"complete-new-config\n" * 65536)
+    path.write_bytes(old)
+    participants = 8
+    ready_to_publish = threading.Barrier(participants)
+    replace_lock = threading.Lock()
+    real_replace = os.replace
+    temp_paths: list[Path] = []
+
+    def synchronized_replace(src, dst):
+        source = Path(src)
+        assert Path(dst) == path
+        assert source.parent == path.parent
+        assert source.read_bytes() == payload
+        if os.name != "nt":
+            assert stat.S_IMODE(source.stat().st_mode) == 0o600
+        temp_paths.append(source)
+        # No publisher may expose a truncated target while the other workers
+        # are still writing their own unique temporary files.
+        assert path.read_bytes() == old
+        ready_to_publish.wait(timeout=10)
+        with replace_lock:
+            real_replace(source, dst)
+
+    monkeypatch.setattr(runner.os, "replace", synchronized_replace)
+    with ThreadPoolExecutor(max_workers=participants) as pool:
+        results = list(pool.map(
+            lambda _index: runner._materialize_shared_file(path, payload),
+            range(participants),
+        ))
+
+    assert results == [path] * participants
+    assert len(temp_paths) == participants
+    assert len(set(temp_paths)) == participants
+    assert path.read_bytes() == payload
+    assert not list(tmp_path.glob(f".{path.name}.*"))
+
+
+def test_failed_shared_input_publication_keeps_previous_complete_file(
+    tmp_path: Path,
+    monkeypatch,
+):
+    path = tmp_path / "codex-submission-prompt.j2"
+    path.write_bytes(b"previous complete prompt")
+    monkeypatch.setattr(
+        runner.os,
+        "replace",
+        lambda *_args: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    with pytest.raises(OSError, match="disk full"):
+        runner._materialize_shared_file(path, b"replacement prompt")
+
+    assert path.read_bytes() == b"previous complete prompt"
+    assert not list(tmp_path.glob(f".{path.name}.*"))
 
 
 def test_command_fails_before_paid_run_when_catalog_is_modified(


### PR DESCRIPTION
## Summary
- atomically materialize shared DeepSeek adapter/config/prompt inputs
- reuse identical files and tighten permissions to 0600
- preserve the previous complete file if publication fails
- apply the same safe materialization to the Codex allowlist

## Why
A public `dradar --workers N` pool shares one DRADAR_HOME. Direct writes could let one worker observe another worker's partially written provider input.

## Tests
- `pytest -q` (414 passed)
- 8-thread concurrent publication test
- identical-file reuse/permission repair and failed-publication rollback tests
