### PR TITLE
fix: bound checkpoint recovery after account failures

### DIFF
--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -38,9 +38,10 @@ from .providers import (
 )
 from .runner import (
     DIAG_ADVICE, BuildFlakeError, RunnerError, build_codex_trajectory_bundle,
-    check_task_content_hash, codex_trajectory_bundle_usage,
+    check_task_content_hash, classify_exception_message,
+    codex_trajectory_bundle_usage,
     diagnose_exception, ensure_pier, ensure_tasks_root,
-    is_insufficient_balance_message, local_deep_swe_commit, run_trial,
+    local_deep_swe_commit, run_trial,
     summarize_result, sync_deep_swe_commit, trial_artifact_paths,
 )
 from .scrub import (
@@ -55,11 +56,28 @@ from .telemetry import RunnerTelemetry
 # regression; normal quota-bounded plans should never reach it.
 DEFAULT_REFILL_TASK_SAFETY_CAP = 1000
 _TERMINAL_LOCAL_OUTCOMES = {"not-uploaded", "rejected"}
-_ACCOUNT_TERMINAL_OUTCOMES = {"insufficient-balance"}
+_ACCOUNT_TERMINAL_OUTCOMES = {
+    "auth-failure", "insufficient-balance", "quota-exhausted",
+    "recovery-exhausted", "runtime-incompatible",
+}
 _POOL_ABORT_ENV = "DRADAR_POOL_ABORT_FILE"
 _POOL_SUPERVISOR_POLL_SECONDS = 0.2
 _POOL_BACKFILL_REFRESH_SECONDS = 2.0
 _POOL_BACKFILL_ERROR_RETRY_SECONDS = 10.0
+MAX_CHECKPOINT_RESUMES = 5
+_CHECKPOINT_BACKOFF_BASE_SECONDS = 30.0
+_CHECKPOINT_BACKOFF_MAX_SECONDS = 600.0
+
+_TERMINAL_FAILURE_OUTCOMES = {
+    "auth": ("auth-failure", "agent authentication failed"),
+    "insufficient-balance": (
+        "insufficient-balance", "paid API balance exhausted",
+    ),
+    "quota-limit": ("quota-exhausted", "account quota exhausted"),
+    "stale-agent": (
+        "runtime-incompatible", "agent runtime is incompatible",
+    ),
+}
 
 
 def _is_trajectory_bundle_rejection(exc: ApiError) -> bool:
@@ -114,12 +132,44 @@ def _pool_abort_reason() -> str | None:
         return "another worker stopped the pool"
 
 
-def _announce_account_stop() -> None:
+def _announce_account_stop(outcome: str) -> None:
+    messages = {
+        "auth-failure": "agent authentication failed",
+        "insufficient-balance": "paid API balance is exhausted",
+        "quota-exhausted": "the account quota window is exhausted",
+        "recovery-exhausted": "checkpoint recovery reached its safety limit",
+        "runtime-incompatible": "the agent runtime is incompatible",
+    }
+    reason = messages.get(outcome, "an account-wide stop condition was detected")
     print(
-        "paid API balance is exhausted — stopping this batch before the next "
-        "task. Unstarted leases remain untouched; recharge, then run "
-        "`dradar resume`."
+        f"{reason} — stopping this batch before the next task or model run. "
+        "Unstarted leases and checkpoints remain untouched; fix or wait for "
+        "the condition, then explicitly start `dradar resume` again."
     )
+
+
+def _terminal_failure_outcome(kind: str | None) -> str | None:
+    policy = _TERMINAL_FAILURE_OUTCOMES.get(kind)
+    if policy is None:
+        return None
+    outcome, abort_reason = policy
+    _signal_pool_abort(abort_reason)
+    return outcome
+
+
+def _checkpoint_backoff_seconds(
+    item: checkpoints.Checkpoint, *, now: datetime | None = None,
+) -> float:
+    """Remaining bounded delay before the next checkpoint recovery attempt."""
+    if item.resume_generation <= 0:
+        return 0.0
+    delay = min(
+        _CHECKPOINT_BACKOFF_MAX_SECONDS,
+        _CHECKPOINT_BACKOFF_BASE_SECONDS * (2 ** (item.resume_generation - 1)),
+    )
+    current = now or datetime.now(timezone.utc)
+    elapsed = max(0.0, (current - item.updated_at).total_seconds())
+    return max(0.0, delay - elapsed)
 
 
 def _fmt_pct(pct: float) -> str:
@@ -342,8 +392,16 @@ def _exit_for(exc: ApiError) -> None:
     else (e.g. 403 account suspended) carries the server's own explanation
     verbatim."""
     if exc.status_code == 401:
+        _signal_pool_abort("DRadar account authentication failed")
         sys.exit(f"{exc}\nyour token was rejected — `dradar login --github` recovers a "
                  "linked identity, otherwise grab a fresh token on the radar page")
+    if exc.status_code in (402, 403):
+        _signal_pool_abort(f"DRadar account stopped with HTTP {exc.status_code}")
+        sys.exit(str(exc))
+    if exc.status_code == 429:
+        _signal_pool_abort("DRadar service rate limit persisted after bounded retries")
+        sys.exit(f"{exc}\nthe server rate limit persisted after bounded retries; "
+                 "the supervised pool has stopped instead of retrying in a loop")
     if exc.status_code is None:
         sys.exit(f"{exc}\ncheck your connection — held leases stay active, and "
                  "`dradar resume` continues where you left off")
@@ -853,20 +911,19 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
                 _mark_stopped_quietly(client, assignment)
             return "failed"
         except RunnerError as exc:
-            insufficient_balance = is_insufficient_balance_message(str(exc))
-            if insufficient_balance:
-                _signal_pool_abort("paid API balance exhausted")
+            failure_kind = classify_exception_message(str(exc))
+            terminal_outcome = _terminal_failure_outcome(failure_kind)
             item = _pause_checkpoint_quietly(client, assignment)
             if item is not None:
                 print(f"trial interrupted: {exc}\n"
                       f"checkpoint {item.checkpoint_id} was kept; `dradar resume` "
                       "continues the same workspace/session")
-                return "insufficient-balance" if insufficient_balance else "paused"
+                return terminal_outcome or "paused"
             print(f"trial failed: {exc}\n"
                   "use `dradar resume` to retry later, or `dradar release` to "
                   "give the cell back")
             _mark_stopped_quietly(client, assignment)
-            return "insufficient-balance" if insufficient_balance else "failed"
+            return terminal_outcome or "failed"
         except (KeyboardInterrupt, EOFError):
             _pause_checkpoint_quietly(client, assignment)
             raise
@@ -899,19 +956,14 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
     interrupted = art.returncode != 0 or stats.get("exception_info")
     diag = diagnose_exception(art.result) if interrupted else {}
     failure_kind = diag.get("kind")
-    if failure_kind == "insufficient-balance":
-        _signal_pool_abort("paid API balance exhausted")
+    terminal_outcome = _terminal_failure_outcome(failure_kind)
     item = checkpoints.find_latest(HOME, assignment["assignment_id"])
     if interrupted and item is not None and item.phase != "agent_completed":
         saved = _pause_checkpoint_quietly(client, assignment)
         if saved is not None:
             print(f"trial interrupted; checkpoint {saved.checkpoint_id} was kept — "
                   "the next `dradar resume` continues instead of submitting a partial run")
-            return (
-                "insufficient-balance"
-                if failure_kind == "insufficient-balance"
-                else "paused"
-            )
+            return terminal_outcome or "paused"
     outcome = "interrupted" if interrupted else "completed"
     if telemetry:
         telemetry.set_phase("uploading", assignment["assignment_id"])
@@ -967,9 +1019,7 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
         and not getattr(args, "yes", False)
         and not getattr(args, "parallel", False)
     ))
-    if failure_kind == "insufficient-balance":
-        return "insufficient-balance"
-    return upload_outcome
+    return terminal_outcome or upload_outcome
 
 
 def _retry_pending_uploads(client: ApiClient) -> None:
@@ -1119,6 +1169,29 @@ def _resume_one_checkpoint(
                         and not getattr(args, "parallel", False)
                     ),
                 )
+
+            generation = max(
+                item.resume_generation,
+                int(assignment.get("resume_generation") or 0),
+            )
+            if generation >= MAX_CHECKPOINT_RESUMES:
+                checkpoints.mark_terminal(HOME, item)
+                _signal_pool_abort("checkpoint recovery safety limit reached")
+                print(
+                    f"  {assignment_id}: checkpoint reached the "
+                    f"{MAX_CHECKPOINT_RESUMES}-resume safety limit; automatic "
+                    "recovery is now disabled and the diagnostic workspace was kept"
+                )
+                return "recovery-exhausted"
+
+            wait_seconds = _checkpoint_backoff_seconds(item)
+            if wait_seconds > 0:
+                print(
+                    f"  {assignment_id}: checkpoint recovery backoff "
+                    f"{wait_seconds:.0f}s (attempt {generation + 1}/"
+                    f"{MAX_CHECKPOINT_RESUMES})"
+                )
+                time.sleep(wait_seconds)
 
             if telemetry:
                 telemetry.bind_batch(assignment.get("batch_id"))
@@ -1706,6 +1779,13 @@ def _pool_ready_waiting_count(client: ApiClient) -> int | None:
 
 def _run_worker_pool(args) -> int:
     """Prepare one batch, then supervise several ordinary resume processes."""
+    configured_abort_file = _pool_abort_path()
+    if configured_abort_file is not None and configured_abort_file.is_file():
+        print(
+            f"worker pool is circuit-broken: {_pool_abort_reason() or 'account stop'}; "
+            "not claiming or starting model workers"
+        )
+        return 0
     cfg = client = None
     if args.workers == "auto":
         from .capacity import AUTO_WORKER_CAP, inspect_capacity, print_report
@@ -1762,10 +1842,11 @@ def _run_worker_pool(args) -> int:
         print(f"only {len(active)} task(s) are currently held; starting {count} worker(s)")
     print(f"starting {count} worker(s); server-side checkout assigns each task exactly once")
     command = _worker_command(args)
-    pool_abort_file = (
+    pool_abort_file = configured_abort_file or (
         Path(tempfile.gettempdir())
         / f"dradar-pool-abort-{os.getpid()}-{time.time_ns()}"
     )
+    owns_abort_file = configured_abort_file is None
     popen_kwargs = {}
     if os.name == "nt":
         popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
@@ -1774,6 +1855,11 @@ def _run_worker_pool(args) -> int:
     returncodes: list[tuple[int, int]] = []
     backfill_error: str | None = None
     backfill_disabled = False
+    abort_reason: str | None = None
+
+    def cleanup_abort_file() -> None:
+        if owns_abort_file:
+            pool_abort_file.unlink(missing_ok=True)
 
     def spawn_worker(slot: int) -> None:
         env = os.environ.copy()
@@ -1801,6 +1887,13 @@ def _run_worker_pool(args) -> int:
             if not active_processes:
                 break
             if pool_abort_file.is_file():
+                if abort_reason is None:
+                    try:
+                        abort_reason = pool_abort_file.read_text().strip() or "account stop"
+                    except OSError:
+                        abort_reason = "account stop"
+                    print(f"worker pool circuit opened: {abort_reason}; stopping sibling workers")
+                    _signal_workers(list(active_processes.values()))
                 time.sleep(_POOL_SUPERVISOR_POLL_SECONDS)
                 continue
 
@@ -1842,7 +1935,7 @@ def _run_worker_pool(args) -> int:
         print("\nstopping workers safely; active tasks remain resumable...")
         _signal_workers(processes)
         _maintain_image_cache(client, cfg, phase="after interrupted worker pool")
-        pool_abort_file.unlink(missing_ok=True)
+        cleanup_abort_file()
         raise
     except OSError as exc:
         # A later spawn can fail after earlier children are already live
@@ -1852,11 +1945,14 @@ def _run_worker_pool(args) -> int:
         print(f"couldn't start every worker ({exc}); stopping those already started")
         _signal_workers(processes)
         _maintain_image_cache(client, cfg, phase="after failed worker pool")
-        pool_abort_file.unlink(missing_ok=True)
+        cleanup_abort_file()
         return 1
-    pool_abort_file.unlink(missing_ok=True)
+    cleanup_abort_file()
     failed = [(slot, rc) for slot, rc in returncodes if rc != 0]
     _maintain_image_cache(client, cfg, phase="after worker pool")
+    if abort_reason is not None:
+        print(f"worker pool stopped cleanly by circuit breaker: {abort_reason}")
+        return 0
     if backfill_error:
         print("worker pool finished after a backfill spawn error; completed uploads "
               "are preserved and the next resume can restore the full pool")
@@ -1967,7 +2063,7 @@ def _run_batch(args, client: ApiClient, tasks_root: Path, active: list[dict],
         if telemetry:
             telemetry.set_phase("queued")
         if outcome in _ACCOUNT_TERMINAL_OUTCOMES:
-            _announce_account_stop()
+            _announce_account_stop(outcome)
             break
     ok = all(o in ("submitted", "interrupted") for o in results)
     return 0 if ok else 1
@@ -2063,8 +2159,8 @@ def _run_checkout_loop(args, client: ApiClient, tasks_root: Path,
             telemetry.set_phase("queued")
         if outcome in _ACCOUNT_TERMINAL_OUTCOMES:
             if getattr(args, "refill", False):
-                refill_plan.stop(HOME, "paid API balance exhausted")
-            _announce_account_stop()
+                refill_plan.stop(HOME, f"account stop: {outcome}")
+            _announce_account_stop(outcome)
             results.append(outcome)
             break
         fail_fast = os.environ.get("DRADAR_BATCH_FAIL_FAST", "").lower() in {

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -1327,10 +1327,56 @@ def summarize_result(result_path: Path | None) -> dict:
     }
 
 
+def classify_exception_message(message: str) -> str | None:
+    """Classify an agent failure by the recovery action it permits.
+
+    Account/runtime terminal failures must stop a supervised pool, while a
+    plain burst-rate 429 may be retried later with bounded backoff. Keep the
+    explicit quota signals ahead of the generic 429 fallback: Codex commonly
+    includes both in the same error payload.
+    """
+    low = message.lower()
+
+    def has_http_status(status: int) -> bool:
+        code = str(status)
+        return bool(re.search(
+            rf"(?:\bhttp(?:\s+status)?\s*|[\"']?(?:status|status_code|code)"
+            rf"[\"']?\s*[:=]\s*){code}\b|"
+            rf"\b{code}\s+(?:unauthorized|forbidden|payment required|"
+            rf"too many requests|rate limit)",
+            low,
+        ))
+
+    if "requires a newer version of codex" in low:
+        return "stale-agent"
+    if is_insufficient_balance_message(message):
+        return "insufficient-balance"
+    if any(s in low for s in (
+        "usage_limit", "usage limit", "quota exhausted", "quota_exhausted",
+        "quota exceeded", "weekly limit", "weekly quota",
+        "usage limit reached", "quota limit reached",
+        "you've hit your usage limit", "you have hit your usage limit",
+    )):
+        return "quota-limit"
+    if has_http_status(401) or has_http_status(403) or any(s in low for s in (
+        "unauthorized", "forbidden", "authentication failed",
+        "invalid api key", "token expired", "account suspended",
+    )):
+        return "auth"
+    if has_http_status(429) or any(s in low for s in (
+        "rate limit", "rate_limit", "too many requests",
+    )):
+        return "rate-limit"
+    if "at capacity" in low:
+        return "model-capacity"
+    return None
+
+
 def diagnose_exception(result_path: Path | None) -> dict:
     """Classify a trial's recorded exception for honest console reporting:
     {} when there is none, else {type, tail, kind} where kind is one of
-    stale-agent | insufficient-balance | rate-limit | auth | None
+    stale-agent | insufficient-balance | quota-limit | rate-limit | auth |
+    model-capacity | None
     (unrecognized). The message tail
     matters most: pier's exception_message embeds the agent's actual output,
     which for codex includes the API error JSON naming the real cause."""
@@ -1344,27 +1390,7 @@ def diagnose_exception(result_path: Path | None) -> dict:
     if not info:
         return {}
     msg = info.get("exception_message") or ""
-    low = msg.lower()
-    kind = None
-    if "requires a newer version of codex" in low:
-        kind = "stale-agent"
-    elif is_insufficient_balance_message(msg):
-        kind = "insufficient-balance"
-    elif any(s in low for s in ("rate limit", "rate_limit", "usage_limit",
-                                "too many requests", "429")):
-        kind = "rate-limit"
-    elif any(s in low for s in ("401", "unauthorized", "authentication failed",
-                                "invalid api key", "token expired")):
-        kind = "auth"
-    elif "at capacity" in low:
-        # codex treats a momentary "Selected model is at capacity" as a fatal
-        # turn.failed, which pier reports as a plain nonzero exit -- this is
-        # not a real failure of the agent's work (volunteer report #3,
-        # 2026-07-15: caught mid-run after 1,327 passing tests). The pinned
-        # SecurityMind Pier build resumes the root session with bounded
-        # retries; reaching this diagnostic means those retries were
-        # exhausted. Keep the distinct classification for honest reporting.
-        kind = "model-capacity"
+    kind = classify_exception_message(msg)
     tail = [ln.strip() for ln in msg.splitlines() if ln.strip()][-6:]
     return {"type": info.get("exception_type"), "kind": kind, "tail": tail}
 
@@ -1392,8 +1418,11 @@ DIAG_ADVICE = {
         "image automatically. If this repeats on the latest dradar, tell the "
         "radar operators — the server-side pin may need a bump."),
     "rate-limit": (
-        "this looks like a genuine rate/usage limit — wait for your quota "
-        "window to reset, then claim again."),
+        "the provider is rate-limiting requests — checkpoint recovery uses "
+        "bounded exponential backoff and will stop after its retry budget."),
+    "quota-limit": (
+        "the account quota window is exhausted. This batch stops now; after "
+        "the quota resets, start it again to resume the preserved checkpoints."),
     "insufficient-balance": (
         "the paid API account has insufficient balance. This batch stops now "
         "before starting another task; recharge it, then run `dradar resume`."),

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -174,6 +174,7 @@ def test_resume_one_passes_checkpoint_and_new_generation_to_runner(
     seen = {}
     monkeypatch.setattr(runloop, "HOME", tmp_path)
     monkeypatch.setattr(runloop, "_check_version_pin", lambda *a, **k: "base")
+    monkeypatch.setattr(runloop.time, "sleep", lambda _seconds: None)
 
     def fake_run(client_, resumed, tasks_root, args, local_commit, **kwargs):
         seen["assignment"] = resumed
@@ -188,6 +189,40 @@ def test_resume_one_passes_checkpoint_and_new_generation_to_runner(
     assert client.resumes[0][2] == 2
     assert seen["assignment"]["resume_generation"] == 3
     assert seen["checkpoint"].checkpoint_id == item.checkpoint_id
+
+
+def test_checkpoint_recovery_uses_exponential_backoff(tmp_path: Path):
+    aid = "7" * 32
+    now = datetime.now(timezone.utc)
+    item = _make_checkpoint(
+        tmp_path, aid, generation=3, updated_at=now.isoformat(),
+    )
+
+    assert runloop._checkpoint_backoff_seconds(item, now=now) == 120
+
+
+def test_checkpoint_recovery_limit_opens_circuit_without_resuming(
+        tmp_path: Path, monkeypatch, capsys):
+    aid = "8" * 32
+    item = _make_checkpoint(
+        tmp_path, aid, generation=runloop.MAX_CHECKPOINT_RESUMES,
+    )
+    assignment = _assignment(aid, generation=runloop.MAX_CHECKPOINT_RESUMES)
+    client = _RecoveryClient(assignment)
+    abort_file = tmp_path / "ACCOUNT_STOP"
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    monkeypatch.setenv("DRADAR_POOL_ABORT_FILE", str(abort_file))
+    monkeypatch.setattr(runloop, "_check_version_pin", lambda *a, **k: "base")
+
+    outcome = runloop._resume_one_checkpoint(
+        client, item, assignment, _args(), tmp_path / "tasks", None,
+    )
+
+    assert outcome == "recovery-exhausted"
+    assert client.resumes == []
+    assert checkpoints.is_terminal(tmp_path, item)
+    assert abort_file.read_text() == "checkpoint recovery safety limit reached"
+    assert "5-resume safety limit" in capsys.readouterr().out
 
 
 def test_completed_checkpoint_resume_recovers_missing_staged_patch_without_rerun(

--- a/tests/test_diagnosis.py
+++ b/tests/test_diagnosis.py
@@ -61,8 +61,25 @@ def test_diagnose_classifies_stale_agent(tmp_path):
 
 
 def test_diagnose_classifies_rate_limit(tmp_path):
-    d = diagnose_exception(_result(tmp_path, "codex: usage_limit_reached, retry later"))
+    d = diagnose_exception(_result(tmp_path, "429 Too Many Requests: burst rate limit"))
     assert d["kind"] == "rate-limit"
+
+
+def test_diagnose_classifies_quota_limit_before_generic_429(tmp_path):
+    d = diagnose_exception(_result(
+        tmp_path, "429 Too Many Requests: usage_limit_reached, retry after reset"))
+    assert d["kind"] == "quota-limit"
+
+
+def test_diagnose_classifies_403_as_auth_terminal(tmp_path):
+    d = diagnose_exception(_result(tmp_path, "403 Forbidden: account suspended"))
+    assert d["kind"] == "auth"
+
+
+def test_diagnose_does_not_treat_bare_task_numbers_as_http_errors(tmp_path):
+    d = diagnose_exception(_result(
+        tmp_path, "tests processed: 401; next case: 429; assertion failed"))
+    assert d["kind"] is None
 
 
 def test_diagnose_classifies_insufficient_balance_before_generic_http_errors(tmp_path):
@@ -106,7 +123,7 @@ def test_interrupted_prints_cause_keeps_artifacts_no_quota_claim(
     monkeypatch.setattr(runloop, "run_trial", lambda *a, **kw: art)
     client = InvalidAckClient({})
     tag = runloop._run_and_submit(client, ASSIGNMENT, tmp_path, _args(), "abc123")
-    assert tag == "interrupted"
+    assert tag == "runtime-incompatible"
     assert client.submissions[0]["meta"]["exception_type"] == "NonZeroAgentExitCodeError"
     out = capsys.readouterr().out
     assert "NonZeroAgentExitCodeError" in out
@@ -126,7 +143,30 @@ def test_interrupted_rate_limit_advice_mentions_quota(monkeypatch, capsys, tmp_p
     client = InvalidAckClient({})
     runloop._run_and_submit(client, ASSIGNMENT, tmp_path, _args(), "abc123")
     out = capsys.readouterr().out
-    assert "rate/usage limit" in out
+    assert "bounded exponential backoff" in out
+
+
+def test_interrupted_quota_limit_opens_pool_circuit(
+        monkeypatch, capsys, tmp_path: Path):
+    monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
+    abort_file = tmp_path / "ACCOUNT_STOP"
+    monkeypatch.setenv("DRADAR_POOL_ABORT_FILE", str(abort_file))
+    art = _fake_art(tmp_path, rc=0, result_data={
+        "exception_info": {
+            "exception_type": "AgentError",
+            "exception_message": "429: usage_limit_reached for weekly quota",
+        },
+        "agent_result": {},
+    })
+    monkeypatch.setattr(runloop, "run_trial", lambda *a, **kw: art)
+    client = InvalidAckClient({})
+
+    outcome = runloop._run_and_submit(
+        client, ASSIGNMENT, tmp_path, _args(), "abc123")
+
+    assert outcome == "quota-exhausted"
+    assert abort_file.read_text() == "account quota exhausted"
+    assert "quota window is exhausted" in capsys.readouterr().out
 
 
 def test_interrupted_insufficient_balance_returns_batch_terminal_outcome(

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -416,6 +416,22 @@ def test_pool_abort_never_restores_a_worker(monkeypatch):
     assert len(calls) == 2
 
 
+def test_external_pool_circuit_is_persistent_and_prevents_worker_start(
+        tmp_path, monkeypatch, capsys):
+    _patch_pool_setup(monkeypatch, active_count=2)
+    abort_file = tmp_path / "ACCOUNT_STOP"
+    abort_file.write_text("account quota exhausted")
+    monkeypatch.setenv("DRADAR_POOL_ABORT_FILE", str(abort_file))
+    monkeypatch.setattr(
+        runloop.subprocess, "Popen",
+        lambda *_a, **_k: pytest.fail("open circuit must not start workers"),
+    )
+
+    assert runloop._run_worker_pool(_args(workers=2)) == 0
+    assert abort_file.read_text() == "account quota exhausted"
+    assert "circuit-broken" in capsys.readouterr().out
+
+
 def test_backfill_spawn_failure_keeps_existing_worker_running(monkeypatch, capsys):
     _patch_pool_setup(monkeypatch, active_count=2)
 


### PR DESCRIPTION
## Summary
- classify quota exhaustion, balance, auth, and runtime incompatibility as pool-wide terminal failures
- add bounded exponential checkpoint recovery with a five-resume circuit breaker
- persist external pool abort markers and stop sibling workers safely
- avoid false-positive HTTP classification from bare task numbers

## Tests
- `pytest -q` (427 passed)
- `python -m compileall -q src tests`
- `git diff --check`