### PR TITLE
fix(runner): stop live account error loops

### DIFF
--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -121,6 +121,10 @@ class RunnerError(RuntimeError):
     pass
 
 
+class LiveAccountTerminalError(RunnerError):
+    """A running agent reported an account-wide terminal provider failure."""
+
+
 def resolve_latest_codex_cli_version(
     server_version: str | None = None,
     server_version_verified: bool = False,
@@ -1085,6 +1089,10 @@ def _tail(log_path: Path, n: int = 15) -> str:
 
 HEARTBEAT_SEC = 60
 TRIAL_TIMEOUT_RETURNCODE = 124
+LIVE_ACCOUNT_ERROR_CONFIRMATIONS = 3
+_LIVE_ACCOUNT_TERMINAL_KINDS = {
+    "auth", "insufficient-balance", "quota-limit",
+}
 
 
 def _last_activity(log_path: Path) -> str:
@@ -1094,6 +1102,80 @@ def _last_activity(log_path: Path) -> str:
     raw = _tail(log_path, 1)
     chunks = [c.strip() for c in raw.replace("\r", "\n").splitlines() if c.strip()]
     return (chunks[-1][:120] if chunks else "still running (no new log output)")
+
+
+def _scan_live_account_errors(
+    jobs_dir: Path,
+    job_name: str,
+    offsets: dict[Path, int],
+    counts: dict[str, int],
+) -> str | None:
+    """Inspect only structured Codex error events from the current job.
+
+    Pier normally reports the agent's exception after ``pier run`` exits.  A
+    Codex process can instead keep retrying a terminal account error forever,
+    which prevents that post-process classification from ever running.  Read
+    new JSONL records incrementally and return a confirmed account-wide kind.
+    Prompt, reasoning, tool calls and trajectory content are ignored.
+    """
+    root = jobs_dir / job_name
+    try:
+        paths = sorted(root.glob("*/agent/codex.txt"))
+    except OSError:
+        return None
+    for path in paths:
+        try:
+            size = path.stat().st_size
+            offset = offsets.get(path, 0)
+            if offset > size:
+                offset = 0
+            with path.open("rb") as stream:
+                stream.seek(offset)
+                while True:
+                    line_start = stream.tell()
+                    raw = stream.readline()
+                    if not raw:
+                        offsets[path] = stream.tell()
+                        break
+                    if not raw.endswith(b"\n"):
+                        # Do not consume a record while Codex is still writing it.
+                        offsets[path] = line_start
+                        break
+                    offsets[path] = stream.tell()
+                    try:
+                        event = json.loads(raw)
+                    except (UnicodeDecodeError, json.JSONDecodeError):
+                        continue
+                    if not isinstance(event, dict):
+                        continue
+                    if event.get("type") == "turn.completed":
+                        counts.clear()
+                        continue
+                    if event.get("type") != "error":
+                        continue
+                    message = event.get("message")
+                    if not isinstance(message, str):
+                        continue
+                    kind = classify_exception_message(message)
+                    if kind not in _LIVE_ACCOUNT_TERMINAL_KINDS:
+                        continue
+                    counts[kind] = counts.get(kind, 0) + 1
+                    if counts[kind] >= LIVE_ACCOUNT_ERROR_CONFIRMATIONS:
+                        return kind
+        except OSError:
+            continue
+    return None
+
+
+def _live_account_error_message(kind: str) -> str:
+    messages = {
+        "auth": "live agent repeatedly reported authentication failed",
+        "insufficient-balance": (
+            "live agent repeatedly reported insufficient balance"
+        ),
+        "quota-limit": "live agent repeatedly reported quota exhausted",
+    }
+    return messages[kind] + "; aborting this trial safely"
 
 
 def _trial_timeout_sec(assignment: dict) -> int:
@@ -1150,6 +1232,11 @@ def run_trial(
     # `interrupted` -> the server marks it invalid and the cell reopens.
     timeout_sec = _trial_timeout_sec(effective_assignment)
     terminal_error: RunnerError | None = None
+    live_error_offsets: dict[Path, int] = {}
+    live_error_counts: dict[str, int] = {}
+    watch_live_account_errors = (
+        (dev_agent or effective_assignment["agent"]) == "codex"
+    )
 
     provider_auth_path = None
     try:
@@ -1209,6 +1296,15 @@ def run_trial(
                     except subprocess.TimeoutExpired:
                         pass
                     now = time.time()
+                    if watch_live_account_errors:
+                        live_failure = _scan_live_account_errors(
+                            jobs_dir, job_name,
+                            live_error_offsets, live_error_counts,
+                        )
+                        if live_failure is not None:
+                            raise LiveAccountTerminalError(
+                                _live_account_error_message(live_failure)
+                            )
                     if now - started > timeout_sec:
                         log.flush()
                         raise RunnerError(
@@ -1253,6 +1349,11 @@ def run_trial(
                     f"{provider_auth_path}: {exc}"
                 ) from exc
     duration = time.time() - started
+    if isinstance(terminal_error, LiveAccountTerminalError):
+        # Let the existing runloop checkpoint/pause path classify this
+        # normalized failure and open the supervised pool's graceful drain.
+        # Do not upload a partial patch from a terminal account failure.
+        raise terminal_error
 
     tail = _tail(log_path)
     try:

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -441,6 +441,76 @@ def test_run_trial_timeout_raises_naming_log(tmp_path, monkeypatch):
     assert "docker: no space left on device" in str(exc.value)
 
 
+def test_run_trial_stops_live_codex_quota_error_loop(tmp_path, monkeypatch):
+    captured = {}
+    terminated = []
+
+    def fake_build(assignment, tasks_root, jobs_dir, job_name, home, dev_agent=None):
+        captured["job_name"] = job_name
+        return ["pier"]
+
+    class QuotaLoopPopen:
+        def __init__(self, cmd, **kwargs):
+            agent_dir = (
+                tmp_path / "jobs" / captured["job_name"]
+                / "task__t0" / "agent"
+            )
+            agent_dir.mkdir(parents=True)
+            records = [
+                {"type": "thread.started"},
+                *(
+                    {"type": "error", "message": "usage limit reached"}
+                    for _ in range(
+                        runner_mod.LIVE_ACCOUNT_ERROR_CONFIRMATIONS
+                    )
+                ),
+            ]
+            (agent_dir / "codex.txt").write_text(
+                "".join(json.dumps(record) + "\n" for record in records)
+            )
+            self.returncode = None
+
+        def wait(self, timeout=None):
+            if self.returncode is None:
+                raise subprocess.TimeoutExpired("pier", timeout)
+            return self.returncode
+
+        def terminate(self):
+            terminated.append(True)
+            self.returncode = 1
+
+        def kill(self):
+            raise AssertionError("clean TERM should not escalate to KILL")
+
+    monkeypatch.setattr(runner_mod, "build_pier_command", fake_build)
+    monkeypatch.setattr(runner_mod.subprocess, "Popen", QuotaLoopPopen)
+
+    with pytest.raises(RunnerError, match="quota exhausted") as exc:
+        run_trial(_assignment("codex"), tmp_path, tmp_path)
+
+    assert terminated == [True]
+    assert runner_mod.classify_exception_message(str(exc.value)) == "quota-limit"
+
+
+def test_live_error_watchdog_ignores_prompt_and_transient_errors(tmp_path):
+    path = tmp_path / "jobs" / "a1" / "task__t0" / "agent" / "codex.txt"
+    path.parent.mkdir(parents=True)
+    path.write_text("".join((
+        json.dumps({"type": "item.completed", "item": {
+            "type": "agent_message", "text": "quota exhausted in user prompt",
+        }}) + "\n",
+        json.dumps({"type": "error", "message": "temporary network error"}) + "\n",
+        json.dumps({"type": "error", "message": "rate limit"}) + "\n",
+    )))
+    offsets = {}
+    counts = {}
+
+    assert runner_mod._scan_live_account_errors(
+        tmp_path / "jobs", "a1", offsets, counts,
+    ) is None
+    assert counts == {}
+
+
 def test_run_trial_timeout_salvages_patch_as_interrupted(tmp_path, monkeypatch):
     """A paid run that reached artifacts must report cost, never vanish."""
     captured = {}


### PR DESCRIPTION
## Summary
- watch the active structured Codex event stream for repeated terminal account errors
- terminate the exact Pier cleanly and reuse the existing checkpoint/pause path
- ignore prompt/trajectory text and transient errors to avoid false positives

## Safety
- requires three confirmed structured error events
- never logs raw provider messages
- does not upload partial patches after an account-terminal stop
- preserves the existing timeout artifact-salvage behavior

## Tests
- `432 passed`
- `git diff --check`