### PR TITLE
Recover completed artifacts and update managed task packs

### DIFF
--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -620,6 +620,84 @@ def trial_artifact_paths(trial_dir: Path) -> tuple[Path, Path | None, Path | Non
     return patch, (trajectory if trajectory.is_file() else None), (result if result.is_file() else None)
 
 
+def _plain_file(path: Path) -> bool:
+    """True only for a regular file at the named path, never a symlink."""
+    try:
+        return stat.S_ISREG(path.lstat().st_mode)
+    except OSError:
+        return False
+
+
+def _recover_completed_checkpoint_patch(
+    trial_dir: Path,
+    assignment: dict,
+) -> tuple[bool, str | None]:
+    """Recover Pier's downloaded patch from a completed Codex checkpoint.
+
+    Older visual-task bundles omitted ``pre_artifacts.sh``. The Codex agent
+    still committed a valid answer and the checkpoint provider preserved its
+    workspace patch, but Pier had no ``artifacts/model.patch`` to download.
+    Recover only from an identity-matched, completed checkpoint and never
+    follow symlinks or accept arbitrary bytes as a submission patch.
+    """
+    checkpoint_dir = trial_dir / "agent" / "checkpoint"
+    metadata_path = checkpoint_dir / "checkpoint.json"
+    if not _plain_file(metadata_path):
+        return False, None
+    try:
+        metadata = json.loads(metadata_path.read_text())
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False, "completed checkpoint metadata is unreadable"
+    if not isinstance(metadata, dict) or metadata.get("phase") != "agent_completed":
+        return False, None
+
+    expected = {
+        "assignment_id": assignment.get("assignment_id"),
+        "task_id": assignment.get("task_id"),
+        "model": assignment.get("model"),
+        "effort": assignment.get("effort"),
+    }
+    mismatched = [
+        key for key, value in expected.items()
+        if not isinstance(value, str) or metadata.get(key) != value
+    ]
+    if mismatched:
+        return False, (
+            "completed checkpoint identity mismatch: " + ", ".join(mismatched)
+        )
+
+    workspace_name = metadata.get("workspace_patch")
+    if workspace_name != "workspace.patch":
+        return False, "completed checkpoint has an unsafe workspace_patch path"
+    workspace_patch = checkpoint_dir / workspace_name
+    if not _plain_file(workspace_patch):
+        return False, "completed checkpoint is missing its workspace patch"
+    try:
+        data = workspace_patch.read_bytes()
+    except OSError:
+        return False, "completed checkpoint workspace patch is unreadable"
+    if b"\x00" in data or (data and not data.startswith(b"diff --git ")):
+        return False, "completed checkpoint workspace patch is not a Git diff"
+
+    artifact_dir = trial_dir / "artifacts"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    patch_path = artifact_dir / "model.patch"
+    fd, temp_name = tempfile.mkstemp(prefix=".model.patch.", dir=artifact_dir)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, patch_path)
+    except BaseException:
+        try:
+            os.unlink(temp_name)
+        except OSError:
+            pass
+        raise
+    return True, None
+
+
 CODEX_TRAJECTORY_BUNDLE_SCHEMA = "dradar-codex-trajectory-bundle-v1"
 
 
@@ -1377,6 +1455,21 @@ def run_trial(
     if not patch.is_file():
         if terminal_error is not None:
             raise terminal_error
+        recovered, checkpoint_error = _recover_completed_checkpoint_patch(
+            trial_dir, effective_assignment,
+        )
+        if recovered:
+            print(
+                "  recovered model.patch from the completed, identity-matched "
+                "checkpoint (the task artifact hook did not run)"
+            )
+        elif checkpoint_error is not None:
+            raise RunnerError(
+                "agent completed, but model.patch collection failed and the "
+                f"checkpoint could not be recovered: {checkpoint_error}; "
+                f"see {log_path} and {trial_dir}"
+            )
+    if not patch.is_file():
         # No patch at all means the agent never produced anything — usually
         # the environment died under it. Say which, instead of blaming the
         # agent for a mirror hiccup.

--- a/src/dradar/taskpacks.py
+++ b/src/dradar/taskpacks.py
@@ -40,6 +40,26 @@ def _installed(tasks_root: Path, benchmark_id: str, digest: str) -> bool:
             and payload.get("sha256") == digest)
 
 
+def _managed_pack(tasks_root: Path, benchmark_id: str) -> bool:
+    """Whether an existing directory is a checksum-pinned DRadar task pack."""
+    if tasks_root.is_symlink():
+        return False
+    marker = tasks_root / MARKER
+    if marker.is_symlink() or not marker.is_file():
+        return False
+    try:
+        payload = json.loads(marker.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    digest = payload.get("sha256")
+    return (
+        payload.get("benchmark_id") == benchmark_id
+        and isinstance(digest, str)
+        and len(digest) == 64
+        and all(char in "0123456789abcdef" for char in digest)
+    )
+
+
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as source:
@@ -103,9 +123,15 @@ def ensure_benchmark_task_pack(
         raise TaskPackError("server advertised an invalid task-bundle SHA-256")
     if _installed(tasks_root, benchmark_id, digest):
         return False
+    replace_managed_pack = False
     if tasks_root.exists():
         if tasks_root.is_dir() and not any(tasks_root.iterdir()):
             tasks_root.rmdir()
+        elif _managed_pack(tasks_root, benchmark_id):
+            # A checksum change is a normal signed bundle upgrade. Only a
+            # directory carrying our valid marker may be replaced; arbitrary
+            # user directories remain strictly protected.
+            replace_managed_pack = True
         else:
             raise TaskPackError(
                 f"task directory already exists but does not match the advertised bundle: "
@@ -130,7 +156,20 @@ def ensure_benchmark_task_pack(
             "benchmark_id": benchmark_id,
             "sha256": digest,
         }, indent=2) + "\n")
-        os.replace(staged, tasks_root)
+        if replace_managed_pack:
+            backup = Path(tempfile.mkdtemp(
+                prefix=f".{tasks_root.name}-previous-", dir=parent,
+            ))
+            backup.rmdir()
+            os.replace(tasks_root, backup)
+            try:
+                os.replace(staged, tasks_root)
+            except BaseException:
+                os.replace(backup, tasks_root)
+                raise
+            shutil.rmtree(backup)
+        else:
+            os.replace(staged, tasks_root)
     except (ApiError, OSError, tarfile.TarError, KeyError) as exc:
         raise TaskPackError(f"could not install benchmark task pack: {exc}") from exc
     finally:

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -561,6 +561,119 @@ def test_run_trial_missing_patch_raises(tmp_path, monkeypatch):
         run_trial(_assignment("codex"), tmp_path, tmp_path)
 
 
+def _fake_completed_checkpoint_pier(
+        monkeypatch, work_dir, assignment, *, patch_bytes=None,
+        metadata_overrides=None):
+    captured = {}
+
+    def fake_build(_assignment, tasks_root, jobs_dir, job_name, home,
+                   dev_agent=None):
+        captured["job_name"] = job_name
+        return ["pier"]
+
+    class FakePopen:
+        def __init__(self, cmd, **kw):
+            checkpoint = (
+                work_dir / "jobs" / captured["job_name"] / "task__t0"
+                / "agent" / "checkpoint"
+            )
+            checkpoint.mkdir(parents=True)
+            (checkpoint.parent.parent / "artifacts").mkdir()
+            metadata = {
+                "phase": "agent_completed",
+                "assignment_id": assignment["assignment_id"],
+                "task_id": assignment["task_id"],
+                "model": assignment["model"],
+                "effort": assignment["effort"],
+                "workspace_patch": "workspace.patch",
+            }
+            metadata.update(metadata_overrides or {})
+            (checkpoint / "checkpoint.json").write_text(json.dumps(metadata))
+            if patch_bytes is not None:
+                (checkpoint / "workspace.patch").write_bytes(patch_bytes)
+            self.returncode = 0
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(runner_mod, "build_pier_command", fake_build)
+    monkeypatch.setattr(runner_mod.subprocess, "Popen", FakePopen)
+
+
+def test_run_trial_recovers_patch_from_matching_completed_checkpoint(
+        tmp_path, monkeypatch, capsys):
+    assignment = _assignment("codex")
+    patch = b"diff --git a/model_answer.json b/model_answer.json\n"
+    _fake_completed_checkpoint_pier(
+        monkeypatch, tmp_path, assignment, patch_bytes=patch,
+    )
+
+    artifacts = run_trial(assignment, tmp_path, tmp_path)
+
+    assert artifacts.patch.read_bytes() == patch
+    assert "recovered model.patch" in capsys.readouterr().out
+
+
+def test_run_trial_does_not_recover_mismatched_completed_checkpoint(
+        tmp_path, monkeypatch):
+    assignment = _assignment("codex")
+    _fake_completed_checkpoint_pier(
+        monkeypatch, tmp_path, assignment,
+        patch_bytes=b"diff --git a/x b/x\n",
+        metadata_overrides={"assignment_id": "another-lease"},
+    )
+
+    with pytest.raises(RunnerError, match="identity mismatch: assignment_id"):
+        run_trial(assignment, tmp_path, tmp_path)
+
+
+def test_run_trial_reports_completed_checkpoint_collection_failure(
+        tmp_path, monkeypatch):
+    assignment = _assignment("codex")
+    _fake_completed_checkpoint_pier(
+        monkeypatch, tmp_path, assignment, patch_bytes=None,
+    )
+
+    with pytest.raises(RunnerError) as exc:
+        run_trial(assignment, tmp_path, tmp_path)
+    message = str(exc.value)
+    assert "agent completed" in message
+    assert "missing its workspace patch" in message
+    assert "agent likely failed" not in message
+
+
+def test_completed_checkpoint_recovery_rejects_workspace_patch_symlink(
+        tmp_path, monkeypatch):
+    assignment = _assignment("codex")
+    _fake_completed_checkpoint_pier(
+        monkeypatch, tmp_path, assignment, patch_bytes=None,
+    )
+    checkpoint = tmp_path / "jobs" / "aa1" / "task__t0" / "agent" / "checkpoint"
+    # Create the symlink during Popen construction by wrapping the fake.
+    original = runner_mod.subprocess.Popen
+
+    class SymlinkPopen:
+        def __init__(self, cmd, **kwargs):
+            self.inner = original(cmd, **kwargs)
+            target = tmp_path / "outside.patch"
+            target.write_bytes(b"diff --git a/x b/x\n")
+            (checkpoint / "workspace.patch").symlink_to(target)
+            self.returncode = self.inner.returncode
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(runner_mod.subprocess, "Popen", SymlinkPopen)
+    with pytest.raises(RunnerError, match="missing its workspace patch"):
+        run_trial(assignment, tmp_path, tmp_path)
+
+
 def test_run_trial_classifies_build_failure_from_nested_result(tmp_path, monkeypatch):
     # Pier's console tail can contain only a generic teardown; the actual
     # Docker failure from the production case is preserved in result.json.

--- a/tests/test_taskpacks.py
+++ b/tests/test_taskpacks.py
@@ -58,6 +58,45 @@ def test_task_pack_install_is_atomic_verified_and_idempotent(tmp_path):
     assert client.downloads == 1
 
 
+def test_task_pack_checksum_upgrade_atomically_replaces_managed_pack(tmp_path):
+    old = FakeClient(_archive({"task/old.txt": b"old"}))
+    root = tmp_path / "tasks"
+    assert ensure_benchmark_task_pack(old, "pompeii-adjacency", root) is True
+
+    new = FakeClient(_archive({"task/new.txt": b"new"}))
+    assert ensure_benchmark_task_pack(new, "pompeii-adjacency", root) is True
+
+    assert not (root / "task" / "old.txt").exists()
+    assert (root / "task" / "new.txt").read_bytes() == b"new"
+    assert new.downloads == 1
+
+
+def test_task_pack_upgrade_checksum_failure_preserves_installed_pack(tmp_path):
+    old = FakeClient(_archive({"task/old.txt": b"old"}))
+    root = tmp_path / "tasks"
+    assert ensure_benchmark_task_pack(old, "pompeii-adjacency", root) is True
+
+    bad = FakeClient(_archive({"task/new.txt": b"new"}), digest="0" * 64)
+    with pytest.raises(TaskPackError, match="checksum mismatch"):
+        ensure_benchmark_task_pack(bad, "pompeii-adjacency", root)
+
+    assert (root / "task" / "old.txt").read_bytes() == b"old"
+    assert not (root / "task" / "new.txt").exists()
+
+
+def test_task_pack_never_replaces_unmanaged_existing_directory(tmp_path):
+    root = tmp_path / "tasks"
+    root.mkdir()
+    (root / "user-file").write_text("keep")
+    client = FakeClient(_archive({"task/new.txt": b"new"}))
+
+    with pytest.raises(TaskPackError, match="already exists"):
+        ensure_benchmark_task_pack(client, "pompeii-adjacency", root)
+
+    assert (root / "user-file").read_text() == "keep"
+    assert client.downloads == 0
+
+
 def test_task_pack_checksum_mismatch_leaves_no_partial_install(tmp_path):
     payload = _archive({"task/task.toml": b"x"})
     client = FakeClient(payload, digest="0" * 64)


### PR DESCRIPTION
## Summary
- recover a missing model.patch from an identity-matched completed Codex checkpoint
- report artifact-collection failures accurately instead of blaming the agent
- atomically replace checksum-pinned managed benchmark packs when the server publishes a new digest

## Validation
- 447 tests passed
- Pompeii task-pack smoke test produced a valid 669-byte Git patch from a real completed answer
- public bundle contains 86 pre_artifacts scripts and no gold/grader files