### PR TITLE
Recover completed checkpoint before direct upload

### DIFF
--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -40,6 +40,7 @@ from .providers import (
 )
 from .runner import (
     DIAG_ADVICE, BuildFlakeError, RunnerError, build_codex_trajectory_bundle,
+    _recover_completed_checkpoint_patch,
     check_task_content_hash, classify_exception_message,
     codex_trajectory_bundle_usage,
     diagnose_exception, ensure_pier, ensure_tasks_root,
@@ -1118,6 +1119,16 @@ def _active_by_id(client: ApiClient) -> dict[str, dict]:
 def _checkpoint_upload_entry(
     item: checkpoints.Checkpoint, assignment: dict, args, local_commit: str | None,
 ) -> dict:
+    recovered, checkpoint_error = _recover_completed_checkpoint_patch(
+        item.trial_dir, assignment,
+    )
+    if recovered:
+        print(
+            "  recovered model.patch from the completed, identity-matched "
+            "checkpoint; uploading without rerunning"
+        )
+    elif checkpoint_error is not None:
+        print(f"  completed checkpoint patch recovery blocked: {checkpoint_error}")
     _patch, _trajectory, result = trial_artifact_paths(item.trial_dir)
     stats = summarize_result(result)
     return {

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -274,6 +274,43 @@ def test_completed_checkpoint_resume_recovers_missing_staged_patch_without_rerun
     assert pending.load(tmp_path) == []
 
 
+def test_completed_checkpoint_resume_recovers_workspace_patch_without_rerun(
+    tmp_path: Path, monkeypatch, capsys,
+):
+    aid = "f" * 32
+    item = _make_checkpoint(tmp_path, aid, phase="agent_completed")
+    assignment = _assignment(aid)
+    metadata = json.loads(item.manifest_path.read_text())
+    metadata["workspace_patch"] = "workspace.patch"
+    item.manifest_path.write_text(json.dumps(metadata))
+    patch_bytes = b"diff --git a/model_answer.json b/model_answer.json\n-old\n+new\n"
+    (item.checkpoint_dir / "workspace.patch").write_bytes(patch_bytes)
+    client = _RecoveryClient(assignment)
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    monkeypatch.setattr(runloop, "_check_version_pin", lambda *a, **k: "base")
+
+    class CompletedClient(_RecoveryClient):
+        def __init__(self, assignment_):
+            super().__init__(assignment_)
+            self.submissions = []
+
+        def submit(self, assignment_id, nonce, patch, trajectory, result, meta,
+                   outcome="completed", resume_generation=None):
+            self.submissions.append(patch.read_bytes())
+            return {"submission_id": "s-workspace", "grade_status": "pending"}
+
+    client = CompletedClient(assignment)
+    outcome = runloop._resume_one_checkpoint(
+        client, item, assignment, _args(yes=True), tmp_path / "tasks", None,
+    )
+
+    assert outcome == "submitted"
+    assert client.resumes == []
+    assert client.submissions == [patch_bytes]
+    assert "uploading without rerunning" in capsys.readouterr().out
+    assert pending.load(tmp_path) == []
+
+
 def test_healthy_local_run_holds_assignment_lock_before_checkpoint_resume(
     tmp_path: Path, monkeypatch,
 ):


### PR DESCRIPTION
Follow-up to #80: the completed-checkpoint fast path now materializes an identity-matched workspace.patch before staging and upload, so old Pompeii runs upload without rerunning the model.\n\nValidation: 448 tests passed.