### PR TITLE
Refresh installed managed benchmark packs

### DIFF
--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -1694,7 +1694,7 @@ def cmd_go(args) -> int:
         # can take minutes on a fresh machine. The heartbeat lets operators
         # distinguish that from an abandoned claim without inspecting the host.
         try:
-            if cfg["benchmark"] != DEFAULT_BENCHMARK and not tasks_root.is_dir():
+            if cfg["benchmark"] != DEFAULT_BENCHMARK:
                 try:
                     ensure_benchmark_task_pack(
                         client, cfg["benchmark"], tasks_root)
@@ -1924,7 +1924,7 @@ def _run_worker_pool(args) -> int:
         client, cfg, phase="before worker pool",
     )
     try:
-        if cfg["benchmark"] != DEFAULT_BENCHMARK and not tasks_root.is_dir():
+        if cfg["benchmark"] != DEFAULT_BENCHMARK:
             try:
                 ensure_benchmark_task_pack(client, cfg["benchmark"], tasks_root)
             except TaskPackError as exc:


### PR DESCRIPTION
Always run the idempotent checksum check for non-default managed task packs, so existing users atomically receive a newly advertised Pompeii bundle. Validation: 448 tests passed.