### PR TITLE
Fail closed on incomplete no-network tasks

### DIFF
--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -452,6 +452,24 @@ def build_pier_command(
     if not task_path.is_dir():
         raise RunnerError(f"task not found locally: {task_path}")
 
+    # Pier's enforceable egress switch lives under [environment]. Merely
+    # declaring [agent].network_mode="no-network" is descriptive and can
+    # otherwise leave the Docker container on its ordinary network.
+    task_toml_path = task_path / "task.toml"
+    try:
+        with task_toml_path.open("rb") as stream:
+            task_config = tomllib.load(stream)
+    except FileNotFoundError:
+        task_config = {}
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise RunnerError(f"task.toml is unreadable: {exc}") from exc
+    if task_config.get("agent", {}).get("network_mode") == "no-network":
+        if task_config.get("environment", {}).get("allow_internet") is not False:
+            raise RunnerError(
+                "task requests no-network but does not set "
+                "[environment].allow_internet=false; refusing an unsafe run"
+            )
+
     agent = dev_agent or assignment["agent"]
     provider = assignment_codex_provider(assignment) if agent == "codex" else None
     if agent == "codex" and provider is None:

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -925,3 +925,17 @@ def test_run_trial_registry_failure_starts_nothing(tmp_path, monkeypatch):
     assert started == []
     assert marked_started == []
     assert not (tmp_path / "jobs").exists()
+
+
+def test_no_network_task_requires_enforceable_environment_switch(
+        tmp_path, monkeypatch):
+    _stub_pier(monkeypatch)
+    task = tmp_path / "abs-module-cache-flags"
+    task.mkdir()
+    (task / "task.toml").write_text(
+        '[agent]\nnetwork_mode = "no-network"\n[environment]\n'
+    )
+    with pytest.raises(RunnerError, match="allow_internet=false"):
+        build_pier_command(
+            _assignment("codex"), tmp_path, tmp_path / "jobs", "j",
+            tmp_path / "home")


### PR DESCRIPTION
Refuses to start a task that declares no-network without Pier environment.allow_internet=false. Tests: 449 passed.