### PR TITLE
fix: warn when Docker resources risk benchmark drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ dradar login --server https://api.codexradar.com --token <YOUR_TOKEN> \
 - Codex CLI + `auth.json`、Claude CLI + OAuth Token，或可选的 DeepSeek API key 与
   官方 Codex `models.json` 完整性；
 - 当前 benchmark 的任务仓库（主站目前为 DeepSWE），缺失时会尝试克隆；
+- Docker daemon 实际可用的 CPU/内存（不足时告警，不读取宿主机宣传配置）；
 - 可用磁盘和服务端登录。
 
 ```bash
@@ -217,6 +218,11 @@ dradar capacity
 当前保守规则包括：每个 worker 至少预留 2 CPU、6 GiB 内存，Docker 额外预留 2 GiB；
 第一个 worker 预留 20 GiB 磁盘，每增加一个再预留 12 GiB。普通自动推荐最多 4，最终
 结果还会被账号并发上限和可运行题目数限制。检测失败时回退到 1。
+
+`doctor` 会按同一内存/CPU预算检查单 worker；手工指定 `--workers N` 时也会在领取任务前
+比较 N 与 Docker 实际资源。资源不足只告警，不会偷偷修改 Docker 配置或替用户降低显式
+指定的 N，但 CPU/内存压力可能改变 agent 的重试路径和最终测量结果，建议改用
+`--workers auto` 或先调整 Docker VM。
 
 ### `dradar link-github`、`rename` 与 `status`
 
@@ -602,6 +608,11 @@ rename 自动重建；若两份文件摘要冲突，则保留两份现场并拒�
 推荐 OrbStack，也支持 Docker Desktop。OrbStack 第一次安装后通常需要打开一次 GUI 完成
 初始化。如果某个 `.venv` 被 macOS 标记为 hidden，Python 可能跳过 editable 安装依赖的
 `.pth` 文件；`doctor` 会识别并提示使用 `chflags -R nohidden <目录>`。
+
+使用 Colima 时，建议建立 DRadar 专用 profile（例如先执行
+`colima start --profile dradar --cpu 4 --memory 8`），再确认当前 Docker context 指向该
+profile。这样可以提高任务资源而不改变其他项目正在使用的默认 Colima VM；DRadar 本身
+不会创建、切换或修改任何 Colima profile。
 
 ### Windows 与 WSL2
 

--- a/src/dradar/capacity.py
+++ b/src/dradar/capacity.py
@@ -63,6 +63,49 @@ def _docker_resources() -> tuple[int | None, float | None, tuple[str, ...]]:
     return cpus, memory, ()
 
 
+def docker_resources() -> tuple[int | None, float | None, tuple[str, ...]]:
+    """Read the capacity exposed by Docker, not the host headline specs."""
+
+    return _docker_resources()
+
+
+def worker_resource_warnings(
+    workers: int,
+    docker_cpus: int | None,
+    docker_memory_gib: float | None,
+) -> tuple[str, ...]:
+    """Explain when a requested worker count exceeds the published budget.
+
+    These are warnings rather than hard failures: task footprints vary, and a
+    user may deliberately accept slower execution.  Surfacing the shortfall is
+    still important because memory/CPU pressure can change an agent's retry
+    path even when the trial eventually completes.
+    """
+
+    if workers < 1:
+        raise ValueError("workers must be positive")
+    if docker_cpus is None or docker_memory_gib is None:
+        return ()
+
+    required_cpus = workers * CPU_PER_WORKER
+    required_memory_gib = (
+        DOCKER_MEM_RESERVE_GIB + workers * MEM_GIB_PER_WORKER
+    )
+    warnings = []
+    if docker_cpus < required_cpus:
+        warnings.append(
+            f"{workers} worker(s) reserve {required_cpus} Docker CPU, but "
+            f"the daemon exposes {docker_cpus}"
+        )
+    if docker_memory_gib < required_memory_gib:
+        warnings.append(
+            f"{workers} worker(s) reserve {required_memory_gib:.0f} GiB Docker "
+            f"memory (including {DOCKER_MEM_RESERVE_GIB} GiB daemon reserve), "
+            f"but the daemon exposes {docker_memory_gib:.1f} GiB"
+        )
+    return tuple(warnings)
+
+
 def inspect_capacity(client, requested_tasks: int | None = None) -> CapacityReport:
     """Inspect Docker + disk + server limits without claiming any task."""
     me = client.whoami()
@@ -75,7 +118,7 @@ def inspect_capacity(client, requested_tasks: int | None = None) -> CapacityRepo
         me.get("concurrent_limit") or me.get("claim_limit") or 1))
     task_limit = max(1, int(requested_tasks or held or account_limit))
 
-    cpus, memory_gib, warnings = _docker_resources()
+    cpus, memory_gib, warnings = docker_resources()
     disk_gib = shutil.disk_usage(Path.home()).free / (1024 ** 3)
     if cpus is None or memory_gib is None:
         cpu_limit = memory_limit = 1
@@ -167,4 +210,7 @@ def cmd_capacity(args) -> int:
     return 0
 
 
-__all__ = ["CapacityReport", "cmd_capacity", "inspect_capacity", "print_report"]
+__all__ = [
+    "CapacityReport", "cmd_capacity", "docker_resources", "inspect_capacity",
+    "print_report", "worker_resource_warnings",
+]

--- a/src/dradar/doctor.py
+++ b/src/dradar/doctor.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 from . import __version__, runner
+from .capacity import docker_resources, worker_resource_warnings
 from .identity import _client
 from .local_config import _load_config, tasks_root_from_config
 from .providers import (
@@ -29,6 +30,12 @@ def _check(label: str, ok: bool, hint: str = "") -> bool:
 def _skip(label: str, reason: str) -> None:
     """Report a dependency that was deliberately not installed or downloaded."""
     print(f"  [skip] {label}  -> {reason}")
+
+
+def _warn(label: str, reason: str) -> None:
+    """Report a measurement risk without claiming the machine cannot run."""
+
+    print(f"  [warn] {label}  -> {reason}")
 
 
 def _platform(proc_version: Path = Path("/proc/version")) -> str:
@@ -159,6 +166,32 @@ def cmd_doctor(args) -> int:
         all_ok &= _check("docker daemon", daemon_ready, daemon_hint)
         compose = _probe([docker, "compose", "version"])
         all_ok &= _check("docker compose plugin", compose, hints["compose"])
+        if daemon_ready:
+            cpus, memory_gib, probe_warnings = docker_resources()
+            if cpus is not None and memory_gib is not None:
+                resource_label = (
+                    f"docker resources ({cpus} CPU / {memory_gib:.1f} GiB memory)"
+                )
+                resource_warnings = worker_resource_warnings(
+                    1, cpus, memory_gib,
+                )
+                if resource_warnings:
+                    detail = "; ".join(resource_warnings)
+                    detail += (
+                        "; low Docker VM resources can trigger agent retries "
+                        "and distort benchmark results"
+                    )
+                    if plat == "macos":
+                        detail += (
+                            "; Colima users should prefer a dedicated DRadar "
+                            "profile instead of resizing another project's VM"
+                        )
+                    _warn(resource_label, detail)
+                else:
+                    _check(resource_label, True)
+            else:
+                for warning in probe_warnings:
+                    _warn("docker resources", warning)
 
     # Native Windows cannot run a task until Docker Desktop's Linux engine is
     # healthy. Avoid installing Pier or cloning the benchmark repository while
@@ -271,6 +304,6 @@ def cmd_doctor(args) -> int:
 
 
 __all__ = [
-    "cmd_doctor", "_platform", "_check", "_probe", "_DOCKER_HINTS",
+    "cmd_doctor", "_platform", "_check", "_warn", "_probe", "_DOCKER_HINTS",
     "_CODEX_HINTS", "_windows_virtualization_state",
 ]

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -1899,6 +1899,26 @@ def _run_worker_pool(args) -> int:
         print_report(report)
         args.workers = report.recommended_workers
         _align_refill_target_with_workers(args)
+    else:
+        from .capacity import docker_resources, worker_resource_warnings
+
+        cpus, memory_gib, probe_warnings = docker_resources()
+        resource_warnings = worker_resource_warnings(
+            args.workers, cpus, memory_gib,
+        )
+        for warning in (*probe_warnings, *resource_warnings):
+            print(f"warning: {warning}")
+        if resource_warnings:
+            print(
+                "  CPU/memory pressure can change agent retry paths and "
+                "benchmark results; use `--workers auto`, reduce N, or "
+                "increase the Docker VM resources before continuing."
+            )
+            if sys.platform == "darwin":
+                print(
+                    "  Colima users should prefer a dedicated DRadar profile "
+                    "instead of resizing another project's VM."
+                )
     if not args.yes:
         answer = input(
             f"start {args.workers} local workers? They share this machine's "

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -68,6 +68,17 @@ def test_missing_docker_fails_closed_to_one_worker(monkeypatch):
     assert "falling back to 1 worker" in report.warnings[0]
 
 
+def test_worker_resource_warnings_cover_cpu_and_memory_shortfalls():
+    warnings = capacity.worker_resource_warnings(3, 4, 12)
+
+    assert any("reserve 6 Docker CPU" in warning for warning in warnings)
+    assert any("reserve 20 GiB Docker memory" in warning for warning in warnings)
+
+
+def test_worker_resource_warnings_accept_exact_published_budget():
+    assert capacity.worker_resource_warnings(2, 4, 14) == ()
+
+
 def test_low_disk_space_never_recommends_zero(monkeypatch):
     _docker(monkeypatch, cpus=64, memory_gib=128)
     monkeypatch.setattr(capacity.shutil, "disk_usage", lambda _path: Disk(5))

--- a/tests/test_doctor_platform.py
+++ b/tests/test_doctor_platform.py
@@ -196,6 +196,9 @@ def test_windows_healthy_docker_preserves_existing_bootstrap(
     monkeypatch.setattr(doctor.shutil, "which", which)
     monkeypatch.setattr(doctor, "_probe", lambda _cmd: True)
     monkeypatch.setattr(
+        doctor, "docker_resources", lambda: (8, 16.0, ()),
+    )
+    monkeypatch.setattr(
         doctor,
         "_windows_virtualization_state",
         lambda: pytest.fail("healthy Docker must not run the fallback probe"),
@@ -215,9 +218,44 @@ def test_windows_healthy_docker_preserves_existing_bootstrap(
     assert rc == 1  # no agent auth or server login in this isolated test
     assert state == {"pier_ready": True, "pier_calls": 1, "task_calls": 1}
     assert "[ok ] docker daemon" in out
+    assert "[ok ] docker resources (8 CPU / 16.0 GiB memory)" in out
     assert "[ok ] pier" in out
     assert "[ok ] tasks_root" in out
     assert "[skip]" not in out
+
+
+def test_doctor_warns_when_docker_vm_memory_can_distort_results(
+    monkeypatch, capsys, tmp_path,
+):
+    tasks_root = tmp_path / "tasks"
+    tasks_root.mkdir()
+    monkeypatch.setattr(doctor, "_platform", lambda: "macos")
+    monkeypatch.setattr(doctor, "_load_config", lambda: {})
+    monkeypatch.setattr(doctor, "tasks_root_from_config", lambda _cfg: tasks_root)
+    monkeypatch.setattr(doctor, "deepseek_opted_in", lambda: False)
+    monkeypatch.setattr(
+        doctor.shutil, "which",
+        lambda name: f"/usr/bin/{name}" if name in {"docker", "pier"} else None,
+    )
+    monkeypatch.setattr(doctor, "_probe", lambda _cmd: True)
+    monkeypatch.setattr(
+        doctor, "docker_resources", lambda: (2, 4.0, ()),
+    )
+    monkeypatch.setattr(doctor.runner, "ensure_pier", lambda: None)
+    monkeypatch.setattr(
+        doctor.runner, "_pier_version", lambda _path: doctor.runner.PIER_VERSION,
+    )
+    monkeypatch.setattr(
+        doctor.runner, "_pier_version_compatible", lambda _version: True,
+    )
+
+    doctor.cmd_doctor(SimpleNamespace())
+    out = capsys.readouterr().out
+
+    assert "[warn] docker resources (2 CPU / 4.0 GiB memory)" in out
+    assert "reserve 8 GiB Docker memory" in out
+    assert "distort benchmark results" in out
+    assert "dedicated DRadar profile" in out
 
 
 def test_doctor_blocks_deepseek_when_official_catalog_is_invalid(

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -209,6 +209,10 @@ def _patch_pool_setup(monkeypatch, active_count=5):
     monkeypatch.setattr(runloop, "sweep_orphan_compose", lambda _home, _yes: None)
     monkeypatch.setattr(runloop, "ensure_tasks_root", lambda _root: None)
     monkeypatch.setattr(runloop, "ensure_pier", lambda: None)
+    monkeypatch.setattr(
+        "dradar.capacity.docker_resources",
+        lambda: (64, 128.0, ()),
+    )
     monkeypatch.setattr(runloop, "_retry_pending_uploads", lambda _client: None)
     monkeypatch.setattr(
         runloop, "_maintain_image_cache",
@@ -301,6 +305,30 @@ def test_pool_prepares_once_then_starts_requested_resume_workers(monkeypatch):
     assert len(abort_files) == 1
     assert not runloop.Path(abort_files.pop()).exists()
     assert all("resume" in p.command and "--auto" not in p.command for p in calls)
+
+
+def test_manual_workers_warn_before_starting_on_small_docker_vm(
+    monkeypatch, capsys,
+):
+    _patch_pool_setup(monkeypatch, active_count=3)
+    monkeypatch.setattr(
+        "dradar.capacity.docker_resources",
+        lambda: (2, 4.0, ()),
+    )
+    calls = []
+    monkeypatch.setattr(
+        runloop.subprocess, "Popen",
+        lambda command, env, **kwargs: calls.append(
+            _Process(command, env, **kwargs)
+        ) or calls[-1],
+    )
+
+    assert runloop._run_worker_pool(_args(workers=3)) == 0
+    out = capsys.readouterr().out
+    assert "reserve 6 Docker CPU" in out
+    assert "reserve 20 GiB Docker memory" in out
+    assert "use `--workers auto`" in out
+    assert len(calls) == 3
 
 
 def test_pool_does_not_start_more_workers_than_held_tasks(monkeypatch, capsys):


### PR DESCRIPTION
## What\n\n- reuse the existing Docker capacity probe in `dradar doctor` and show the daemon CPU/memory actually available to task containers\n- warn when the single-worker budget is below the published 2 CPU + 6 GiB/worker + 2 GiB Docker reserve\n- check explicit `--workers N` before task selection and warn when N exceeds the same CPU/memory budget\n- keep manual N advisory-only; no Docker/Colima settings are changed and no explicit worker count is silently reduced\n- document a dedicated Colima profile so macOS users can raise DRadar resources without resizing another project\n\nThe warning explains that resource pressure can change the agent retry path even when a task eventually completes, which is the measurement-integrity risk reported in #5.\n\n## Verification\n\n- `uv run pytest -q` — 458 passed\n- `git diff --check`\n- branch is based on current `origin/main` (715ac25)\n\nCloses #5