### PR TITLE
Stop retrying incompatible trajectory uploads forever

### DIFF
--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -127,6 +127,26 @@ def _is_trajectory_bundle_rejection(exc: ApiError) -> bool:
     return "trajectory_bundle" in detail or "trajectory bundle" in detail
 
 
+def _is_trajectory_bundle_required(exc: ApiError) -> bool:
+    """Whether the server rejected a reduced upload for lacking the bundle.
+
+    This is a terminal protocol mismatch for the current payload: the client
+    already tried the bundle (or omitted it because it exceeded the safe body
+    budget), while the server refuses an answer without one.  Keeping such an
+    entry in the pending ledger causes every public worker to retry it forever
+    and gradually consumes all real-concurrency slots.
+    """
+    if exc.status_code != 422:
+        return False
+    if exc.code == "trajectory_bundle_required":
+        return True
+    detail = str(exc).lower()
+    return (
+        "complete trajectory_bundle.json is required" in detail
+        or ("trajectory bundle" in detail and "required" in detail)
+    )
+
+
 def _estimated_upload_body_bytes(
     patch: Path,
     trajectory: Path | None,
@@ -785,6 +805,27 @@ def _upload_trial(
                         "result without it"
                     )
                     continue
+
+                if (submit_bundle is None
+                        and _is_trajectory_bundle_required(exc)):
+                    # An older/strict server can reject the optional bundle
+                    # and then reject the one-shot reduced request for not
+                    # carrying that same bundle.  No retry can change this
+                    # completed payload.  Reopen the cell instead of pinning
+                    # a paid worker slot behind an immortal pending entry.
+                    print(
+                        f"  {task_id}: the server requires a complete trajectory "
+                        "bundle after rejecting/omitting this run's bundle; "
+                        "releasing the incompatible assignment instead of "
+                        "retrying forever"
+                    )
+                    pending.remove(HOME, assignment_id)
+                    settle_terminal_local_failure()
+                    print(
+                        "  rejected artifacts kept for diagnosis: "
+                        f"{patch.parent.parent}"
+                    )
+                    return "rejected"
 
                 if exc.status_code == 409 and "already submitted" in str(exc).lower():
                     # Some earlier attempt actually landed server-side even

--- a/tests/test_pending_upload.py
+++ b/tests/test_pending_upload.py
@@ -959,6 +959,63 @@ def test_bundle_422_retries_completed_result_without_optional_bundle(
     assert client.stopped == []
 
 
+def test_bundle_rejection_then_required_fallback_is_terminal(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    sessions = trial_dir / "agent" / "sessions"
+    _write_codex_session(sessions / "root.jsonl", "root-1", "user", 100)
+
+    class IncompatibleServerClient(FakeClient):
+        def submit(self, assignment_id, nonce, patch, trajectory, result, meta,
+                   outcome="completed", resume_generation=None,
+                   trajectory_bundle=None):
+            self.calls.append(trajectory_bundle is not None)
+            if trajectory_bundle is not None:
+                raise ApiError(
+                    "server returned 422: trajectory_bundle.json is incomplete",
+                    status_code=422,
+                )
+            raise ApiError(
+                "server returned 422: complete trajectory_bundle.json is required",
+                status_code=422,
+            )
+
+    client = IncompatibleServerClient(lambda _aid: None)
+    assert runloop._upload_trial(client, _entry(trial_dir)) == "rejected"
+    assert client.calls == [True, False]
+    assert pending.load(tmp_path) == []
+    assert client.stopped == ["a1"]
+    assert trial_dir.is_dir()
+
+
+def test_persisted_bundle_omission_required_by_server_is_terminal(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    entry = _entry(trial_dir)
+    entry["omit_trajectory_bundle"] = True
+
+    class StrictServerClient(FakeClient):
+        def submit(self, assignment_id, nonce, patch, trajectory, result, meta,
+                   outcome="completed", resume_generation=None,
+                   trajectory_bundle=None):
+            self.calls.append(trajectory_bundle is not None)
+            assert trajectory_bundle is None
+            raise ApiError(
+                "server returned 422: complete trajectory_bundle.json is required",
+                status_code=422,
+            )
+
+    client = StrictServerClient(lambda _aid: None)
+    assert runloop._upload_trial(client, entry) == "rejected"
+    assert client.calls == [False]
+    assert pending.load(tmp_path) == []
+    assert client.stopped == ["a1"]
+
+
 def test_oversized_projected_request_omits_bundle_before_submit(
     tmp_path: Path, monkeypatch, capsys,
 ):


### PR DESCRIPTION
## Summary
- detect strict-server trajectory-bundle protocol mismatches
- release only the incompatible assignment instead of pinning a worker slot forever
- preserve local artifacts and retain retry behavior for unrelated 422/5xx responses

## Tests
- ........................................................................ [ 15%]
........................................................................ [ 30%]
........................................................................ [ 45%]
........................................................................ [ 61%]
........................................................................ [ 76%]
........................................................................ [ 91%]
......................................                                   [100%]
470 passed in 1.47s (470 passed)
