### PR TITLE
Fix dynamic worker target propagation

### DIFF
--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -1797,7 +1797,9 @@ def cmd_go(args) -> int:
     if getattr(args, "refill_to", None) is not None:
         args.refill = True
     target_file = _pool_target_file(args)
-    if target_file is not None and (auto_workers or workers <= 1):
+    if (target_file is not None
+            and not getattr(args, "worker_child", False)
+            and (auto_workers or workers <= 1)):
         sys.exit("--worker-target-file requires a fixed --workers N greater than 1")
     refill_options = (
         getattr(args, "max_tasks", None),

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -56,6 +56,21 @@ def test_dynamic_target_requires_a_fixed_multi_worker_pool():
         runloop.cmd_go(_args(workers="auto", worker_target_file="target"))
 
 
+def test_internal_worker_child_accepts_parent_dynamic_target_env(
+        tmp_path, monkeypatch):
+    target = tmp_path / "workers"
+    target.write_text("3")
+    monkeypatch.setenv("DRADAR_POOL_TARGET_FILE", str(target))
+    monkeypatch.setattr(runloop, "_load_config", lambda: pytest.fail(
+        "validation passed; stop before runtime setup",
+    ))
+
+    with pytest.raises(pytest.fail.Exception, match="validation passed"):
+        runloop.cmd_go(_args(
+            workers=1, worker_child=True, parallel=True, resume=True,
+        ))
+
+
 def test_workers_cannot_mix_with_manual_parallel():
     with pytest.raises(SystemExit, match="already manages parallel"):
         runloop.cmd_go(_args(parallel=True))


### PR DESCRIPTION
## Summary
- allow internal worker children to inherit the parent dynamic target file
- retain parent-only validation for user-facing single-worker invocations
- keep child live scale-down checks functional

## Tests
- `pytest -q tests/test_workers.py` (43 passed)
- `pytest -q` (492 passed)