### PR TITLE
修复 DSH 在 Pier 受限出网下无法访问 DeepSeek API

### DIFF
--- a/src/dradar/pier_dsh.py
+++ b/src/dradar/pier_dsh.py
@@ -421,6 +421,7 @@ class DshMinimal(BaseInstalledAgent):
                 "DSH_TELEMETRY_MODE": "DISABLED",
                 "DSH_TOOLS_MODE": "native",
                 "DSH_CREDENTIALS_FILE": remote_credentials,
+                "NODE_USE_ENV_PROXY": "1",
             }
         )
         runtime_dirs = (remote_home, remote_config_dir, remote_secret_dir)

--- a/tests/test_pier_dsh.py
+++ b/tests/test_pier_dsh.py
@@ -226,5 +226,5 @@ def test_run_supports_model_effort_matrix_without_logging_secret(
     assert dsh_call["cwd"] == "/app"
     assert (dsh_call.get("env") or {})["DSH_MODEL"] == RUNTIME_MODELS[model]
     assert (dsh_call.get("env") or {})["DSH_REASONING_EFFORT"] == effort
-    assert "NODE_USE_ENV_PROXY" not in (dsh_call.get("env") or {})
+    assert (dsh_call.get("env") or {})["NODE_USE_ENV_PROXY"] == "1"
     assert agent.SUPPORTS_ATIF is False


### PR DESCRIPTION
## 修改内容

- 为 DSH 启用 `NODE_USE_ENV_PROXY=1`
- 让 Node 正确使用 Pier 注入的 `HTTP_PROXY/HTTPS_PROXY`
- 更新对应测试

## 问题原因

Pier 的 filtered egress 依赖代理出网，但 DSH 使用的 Node 默认不会读取这些代理环境变量，导致请求 DeepSeek API 时出现 `TRANSPORT` 错误。

开启 `NODE_USE_ENV_PROXY=1` 后即可正常通过 Pier 代理访问 `api.deepseek.com`。