### PR TITLE
Report structured runner failure causes

### DIFF
--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -1194,6 +1194,12 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
         "dsh_version": art.dsh_version,
         **stats,
     }
+    if failure_kind:
+        # Keep Pier's raw exception_type for debugging, but also upload the
+        # recovery-oriented cause that the CLI already derived from the
+        # provider error.  The authenticated status view can then say
+        # "insufficient-balance" instead of the opaque wrapper exception.
+        meta["failure_kind"] = failure_kind
     if assignment_codex_provider(assignment) == DEEPSEEK_PROVIDER:
         # Server-side audit/gating can distinguish corrected official-catalog
         # runs from the earlier fallback-metadata benchmark without deleting

--- a/tests/test_diagnosis.py
+++ b/tests/test_diagnosis.py
@@ -189,6 +189,8 @@ def test_interrupted_insufficient_balance_returns_batch_terminal_outcome(
     out = capsys.readouterr().out
     assert "insufficient balance" in out.lower()
     assert client.submissions[0]["outcome"] == "interrupted"
+    assert client.submissions[0]["meta"]["failure_kind"] == "insufficient-balance"
+    assert client.submissions[0]["meta"]["exception_type"] == "AgentError"
 
 
 def test_interrupted_model_capacity_advice_is_not_a_quota_guess(


### PR DESCRIPTION
## Summary
- upload the already-classified runner failure kind alongside the raw Pier exception type
- preserve raw exception metadata for debugging and compatibility
- cover insufficient-balance uploads with a regression test

## Test
- uv run pytest -q: 517 passed, 1 skipped