### PR TITLE
Prefer configured DeepSeek keys and recover user interrupts

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,9 @@ dradar go --pick TASK_ID:deepseek-v4-pro:high
 key 保存在 `~/.dradar/secrets/deepseek_api_key`，POSIX 系统权限固定为 `0600`，
 不会进入 `config.json`、命令参数、复制提示词或 DRadar 服务端。运行时 CLI 生成短期
 Codex `auth.json`，通过公开 Pier 的 `CODEX_AUTH_JSON_PATH` 文件上传机制送入容器；
-Pier 退出后立即删除。自动化环境也可临时设置 `DEEPSEEK_API_KEY`，CLI 会先写入短期
-auth 文件，再从 Pier 的继承环境中移除该变量。
+Pier 退出后立即删除。该本地文件存在时优先使用，避免桌面应用或 shell 遗留的旧
+`DEEPSEEK_API_KEY` 静默覆盖用户刚配置的新 key；没有本地文件的自动化环境仍可临时
+设置 `DEEPSEEK_API_KEY`，CLI 会先写入短期 auth 文件，再从 Pier 的继承环境中移除该变量。
 
 运行前 CLI 会校验随包发布的 DeepSeek 官方 Codex `models.json` 的 SHA-256，并由一个
 很窄的公开 Pier 子类把它上传到任务容器隔离的 `/tmp/codex-home/models.json`。文件缺失、

--- a/src/dradar/api_client.py
+++ b/src/dradar/api_client.py
@@ -303,7 +303,9 @@ class ApiClient:
         """Close a runner session without releasing any held lease."""
         return self._post("/api/v1/runner/close", json=payload, timeout=3.0)
 
-    def mark_stopped(self, assignment_id: str) -> dict[str, Any]:
+    def mark_stopped(
+        self, assignment_id: str, *, defer_seconds: int = 300,
+    ) -> dict[str, Any]:
         """The counterpart of mark_started: this trial died client-side
         (build flake, agent crash, abandonment) with nothing uploaded, so the
         server should stop showing the cell as 解题中. Same best-effort
@@ -313,8 +315,13 @@ class ApiClient:
             "/api/v1/assignment/stopped",
             # A cross-session cooldown keeps a second `--parallel` process
             # from immediately taking the same cell that just failed here.
-            # Older servers ignore the extra form field harmlessly.
-            data={"assignment_id": assignment_id, "defer_seconds": "300"},
+            # A user-initiated Ctrl-C passes zero because the process exits
+            # and an immediate explicit `dradar resume` must work. Older
+            # servers ignore the extra form field harmlessly.
+            data={
+                "assignment_id": assignment_id,
+                "defer_seconds": str(defer_seconds),
+            },
         )
 
     def checkpoint_pause(

--- a/src/dradar/providers.py
+++ b/src/dradar/providers.py
@@ -208,15 +208,24 @@ def deepseek_api_key(
     *,
     home: Path | None = None,
 ) -> str | None:
-    """Resolve the key from the environment first, then the private file."""
+    """Resolve the private file first, then fall back to the environment.
+
+    ``provider setup deepseek`` is an explicit local credential selection. A
+    stale environment variable inherited from the desktop app or shell must
+    not silently shadow the key the user just configured. Callers that pass
+    an explicit ``environ`` without ``home`` still get a hermetic,
+    environment-only lookup for tests and automation probes.
+    """
 
     env = os.environ if environ is None else environ
+    if environ is None or home is not None:
+        value = _deepseek_key_from_file(deepseek_secret_path(home))
+        if value:
+            return value
     value = env.get(DEEPSEEK_API_KEY_ENV)
     if isinstance(value, str) and value.strip():
         return value.strip()
-    if environ is not None and home is None:
-        return None
-    return _deepseek_key_from_file(deepseek_secret_path(home))
+    return None
 
 
 def deepseek_credential_source(
@@ -227,12 +236,13 @@ def deepseek_credential_source(
     """Return the active credential source without exposing its value."""
 
     env = os.environ if environ is None else environ
+    if environ is None or home is not None:
+        if _deepseek_key_from_file(deepseek_secret_path(home)):
+            return "file"
     value = env.get(DEEPSEEK_API_KEY_ENV)
     if isinstance(value, str) and value.strip():
         return "environment"
-    if environ is not None and home is None:
-        return None
-    return "file" if _deepseek_key_from_file(deepseek_secret_path(home)) else None
+    return None
 
 
 def deepseek_opted_in(environ: Mapping[str, str] | None = None) -> bool:

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -953,12 +953,17 @@ def _upload_trial(
     return "interrupted" if outcome == "interrupted" else "submitted"
 
 
-def _mark_stopped_quietly(client: ApiClient, assignment: dict | str) -> None:
+def _mark_stopped_quietly(
+    client: ApiClient,
+    assignment: dict | str,
+    *,
+    defer_seconds: int = 300,
+) -> None:
     try:
         assignment_id = (
             assignment if isinstance(assignment, str) else assignment["assignment_id"]
         )
-        client.mark_stopped(assignment_id)
+        client.mark_stopped(assignment_id, defer_seconds=defer_seconds)
     except Exception:
         pass
 
@@ -1120,7 +1125,14 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
             _mark_stopped_quietly(client, assignment)
             return terminal_outcome or "failed"
         except (KeyboardInterrupt, EOFError):
-            _pause_checkpoint_quietly(client, assignment)
+            # A user can interrupt before an agent has produced a resumable
+            # checkpoint (notably DSH minimal mode). In that case there is no
+            # local recovery path, so undo the checkout stamp before bubbling
+            # the interrupt up. Otherwise the UI reports a resumable lease
+            # while every later ``dradar resume`` sees it as already checked
+            # out and has nothing it can start.
+            if _pause_checkpoint_quietly(client, assignment) is None:
+                _mark_stopped_quietly(client, assignment, defer_seconds=0)
             raise
 
     # Make the authoritative source copy immediately after Pier returns,

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -278,6 +278,18 @@ def test_mark_stopped_requests_cross_session_cooldown():
     assert b"defer_seconds=300" in seen["body"]
 
 
+def test_mark_stopped_can_allow_immediate_user_resume():
+    seen = {}
+
+    def handler(request):
+        seen["body"] = request.read()
+        return httpx.Response(200, json={"ok": True, "retry_after": None})
+
+    _client(handler).mark_stopped("a1", defer_seconds=0)
+    assert b"assignment_id=a1" in seen["body"]
+    assert b"defer_seconds=0" in seen["body"]
+
+
 def test_checkpoint_protocol_sends_id_generation_and_runner_session():
     seen = []
 

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -31,7 +31,7 @@ class CheckoutClient(FakeClient):
             raise result
         return result
 
-    def mark_stopped(self, assignment_id):
+    def mark_stopped(self, assignment_id, **_kwargs):
         self.stopped.append(assignment_id)
         return {"ok": True}
 

--- a/tests/test_diagnosis.py
+++ b/tests/test_diagnosis.py
@@ -229,7 +229,45 @@ def test_failed_trial_reports_stopped_to_server(monkeypatch, tmp_path):
     monkeypatch.setattr(runloop, "run_trial", always_fails)
     stopped = []
     client = SubmitClient({})
-    client.mark_stopped = lambda aid: stopped.append(aid)
+    client.mark_stopped = lambda aid, **kw: stopped.append((aid, kw))
     tag = runloop._run_and_submit(client, ASSIGNMENT, tmp_path, _args(), "abc")
     assert tag == "failed"
-    assert stopped == [ASSIGNMENT["assignment_id"]]
+    assert stopped == [(ASSIGNMENT["assignment_id"], {"defer_seconds": 300})]
+
+
+def test_user_interrupt_without_checkpoint_reports_stopped_to_server(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
+    monkeypatch.setattr(
+        runloop, "run_trial",
+        lambda *a, **kw: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+    monkeypatch.setattr(runloop, "_pause_checkpoint_quietly", lambda *a, **kw: None)
+    stopped = []
+    client = SubmitClient({})
+    client.mark_stopped = lambda aid, **kw: stopped.append((aid, kw))
+
+    with pytest.raises(KeyboardInterrupt):
+        runloop._run_and_submit(client, ASSIGNMENT, tmp_path, _args(), "abc")
+
+    assert stopped == [(ASSIGNMENT["assignment_id"], {"defer_seconds": 0})]
+
+
+def test_user_interrupt_with_checkpoint_keeps_server_paused(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
+    monkeypatch.setattr(
+        runloop, "run_trial",
+        lambda *a, **kw: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+    checkpoint = object()
+    monkeypatch.setattr(
+        runloop, "_pause_checkpoint_quietly", lambda *a, **kw: checkpoint)
+    stopped = []
+    client = SubmitClient({})
+    client.mark_stopped = lambda aid, **kw: stopped.append((aid, kw))
+
+    with pytest.raises(KeyboardInterrupt):
+        runloop._run_and_submit(client, ASSIGNMENT, tmp_path, _args(), "abc")
+
+    assert stopped == []

--- a/tests/test_dsh_integration.py
+++ b/tests/test_dsh_integration.py
@@ -80,6 +80,10 @@ def test_dsh_temporary_key_file_is_private_and_rejects_whitespace(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # The product deliberately prefers an explicitly configured private file
+    # over a stale environment variable. Keep this env-fallback test hermetic
+    # so a developer's real ~/.dradar credential cannot shadow its sentinel.
+    monkeypatch.setenv("DRADAR_HOME", str(tmp_path / "dradar-home"))
     monkeypatch.setenv(DEEPSEEK_API_KEY_ENV, "one-line-key")
     key_file = runner.create_deepseek_api_key_file(tmp_path)
     assert key_file.read_text(encoding="utf-8") == "one-line-key\n"

--- a/tests/test_pending_upload.py
+++ b/tests/test_pending_upload.py
@@ -88,7 +88,7 @@ class FakeClient:
                            resume_generation, reason):
         self.discarded = (assignment_id, checkpoint_id, resume_generation, reason)
 
-    def mark_stopped(self, assignment_id):
+    def mark_stopped(self, assignment_id, **_kwargs):
         self.stopped.append(assignment_id)
 
 

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -20,11 +20,12 @@ from dradar.providers import (
 
 
 @pytest.fixture(autouse=True)
-def _isolate_provider_environment(monkeypatch):
+def _isolate_provider_environment(monkeypatch, tmp_path):
     monkeypatch.delenv(DEEPSEEK_API_KEY_ENV, raising=False)
+    monkeypatch.setenv("DRADAR_HOME", str(tmp_path / "dradar-home"))
 
 
-def test_file_backed_key_is_atomic_private_and_environment_can_override(
+def test_file_backed_key_is_atomic_private_and_overrides_stale_environment(
     tmp_path,
     monkeypatch,
 ):
@@ -40,6 +41,17 @@ def test_file_backed_key_is_atomic_private_and_environment_can_override(
     assert deepseek_credential_source() == "file"
 
     monkeypatch.setenv(DEEPSEEK_API_KEY_ENV, "environment-secret")
+    assert deepseek_api_key() == "file-secret"
+    assert deepseek_credential_source() == "file"
+
+
+def test_environment_key_is_the_fallback_when_no_private_file(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("DRADAR_HOME", str(tmp_path))
+    monkeypatch.setenv(DEEPSEEK_API_KEY_ENV, "environment-secret")
+
     assert deepseek_api_key() == "environment-secret"
     assert deepseek_credential_source() == "environment"
 
@@ -130,6 +142,31 @@ def test_setup_uses_hidden_input_and_never_echoes_key(
     assert rc == 0
     assert deepseek_api_key() == "sentinel-provider-secret"
     assert "sentinel-provider-secret" not in capsys.readouterr().out
+
+
+def test_setup_key_is_active_even_with_a_stale_inherited_environment(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    monkeypatch.setenv("DRADAR_HOME", str(tmp_path))
+    monkeypatch.setenv(DEEPSEEK_API_KEY_ENV, "stale-environment-secret")
+    monkeypatch.setattr(
+        provider_config.sys, "stdin", SimpleNamespace(isatty=lambda: True))
+    monkeypatch.setattr(
+        provider_config.getpass,
+        "getpass",
+        lambda _prompt: "new-file-secret",
+    )
+
+    rc = provider_config.cmd_provider_setup(SimpleNamespace(provider="deepseek"))
+
+    assert rc == 0
+    assert deepseek_api_key() == "new-file-secret"
+    assert deepseek_credential_source() == "file"
+    output = capsys.readouterr().out
+    assert "stale-environment-secret" not in output
+    assert "new-file-secret" not in output
 
 
 def test_status_reports_source_without_secret(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

- Make `dradar provider setup deepseek`'s private file override a stale inherited environment variable, while preserving environment-only fallback for clean automation.
- Return a checkpoint-free Ctrl-C run to immediately resumable waiting state instead of leaving a permanently checked-out lease.
- Retain the existing five-minute cooldown for genuine trial failures.
- Isolate credential tests from a developer's real home.

## Real production validation

- A stale environment key and newly configured private key were present together.
- Live DeepSeek authentication and V4 availability passed using the private file.
- An interrupted DSH lease was repaired and resumed.
- DSH Minimal completed a real 28-minute task, uploaded, and reached server grading.

## Tests

- `uv run pytest -q` — 522 passed, 1 skipped.
