### PR TITLE
Reject retired DeepSeek low assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,16 +183,16 @@ Pier 退出后立即删除。该本地文件存在时优先使用，避免桌面
 
 运行前 CLI 会校验随包发布的 DeepSeek 官方 Codex `models.json` 的 SHA-256，并由一个
 很窄的公开 Pier 子类把它上传到任务容器隔离的 `/tmp/codex-home/models.json`。文件缺失、
-被修改或不含 `none`/`low`/`high`/`max` 档位时，能力不会上报、`doctor` 会失败，任务也会在发出任何
+被修改或不含 `none`/`low`/`high`/`max` 上游档位时，能力不会上报、`doctor` 会失败，任务也会在发出任何
 付费模型请求前终止。目录启用后，上下文、自动压缩、推理摘要、并行工具和补丁工具等
 元数据均由目录决定，不再用本地 TOML 重复覆盖。
 
 当前公开边界：
 
-- 模型固定为 `deepseek-v4-flash` 或 `deepseek-v4-pro`，两者的产品档位都是
-  `off`、`low`、`high` 和 `max`。`off` 在 Codex Responses API 链路上严格转换为
-  `reasoning.effort=none`，其余三档原样传递；DeepSeek 接受的
-  `medium`、`xhigh` 都映射到 `high`，不建立重复实验格。
+- 模型固定为 `deepseek-v4-flash` 或 `deepseek-v4-pro`，两者公开启用的产品档位都是
+  `off`、`high` 和 `max`。`off` 在 Codex Responses API 链路上严格转换为
+  `reasoning.effort=none`，其余两档原样传递。上游目录中的 `low` 仅为完整性校验保留，
+  不可领取或运行；`medium`、`xhigh` 也不建立重复实验格。
 - 使用已验证的正式版 Codex `0.147.0`、Responses API，以及官方目录声明的
   1,048,576 token 上下文和 95% 有效上下文比例。
 - 基于公开 `datacurve-pier==0.3.0` 的标准 `codex` agent；附加代码只负责校验并上传

--- a/src/dradar/providers.py
+++ b/src/dradar/providers.py
@@ -33,7 +33,9 @@ DEEPSEEK_FLASH_OFF_CAPABILITY = "codex-deepseek-v4-flash-off-v1"
 DEEPSEEK_PRO_OFF_CAPABILITY = "codex-deepseek-v4-pro-off-v1"
 DEEPSEEK_CODEX_VERSION = "0.147.0"
 DEEPSEEK_MIN_CODEX_VERSION = "0.144.0"
-DEEPSEEK_SUPPORTED_EFFORTS = frozenset({"off", "low", "high", "max"})
+# The bundled upstream catalog still describes ``low`` for integrity and
+# compatibility checks, but DRadar's public DeepSeek Codex lane retires it.
+DEEPSEEK_SUPPORTED_EFFORTS = frozenset({"off", "high", "max"})
 DEEPSEEK_CATALOG_EFFORTS = frozenset({"none", "low", "high", "max"})
 DEEPSEEK_CATALOG_FILENAME = "deepseek_codex_models.json"
 DEEPSEEK_CATALOG_SHA256 = (

--- a/tests/test_deepseek_provider.py
+++ b/tests/test_deepseek_provider.py
@@ -327,13 +327,13 @@ def test_command_fails_before_paid_run_when_catalog_is_modified(
     assert not (tmp_path / "home" / runner.DEEPSEEK_AGENT_MODULE_FILENAME).exists()
 
 
-@pytest.mark.parametrize("effort", ["medium", "xhigh"])
-def test_compatibility_aliases_are_not_duplicate_benchmark_cells(
+@pytest.mark.parametrize("effort", ["low", "medium", "xhigh"])
+def test_retired_or_compatibility_efforts_are_not_benchmark_cells(
     tmp_path: Path,
     monkeypatch,
     effort: str,
 ):
-    with pytest.raises(RunnerError, match="effort must be one of high, low, max"):
+    with pytest.raises(RunnerError, match="effort must be one of high, max, off"):
         _command(tmp_path, monkeypatch, _assignment(effort=effort))
 
 


### PR DESCRIPTION
## Summary
- reject DeepSeek Codex low assignments in the public runner
- retain upstream catalog low metadata solely for integrity validation
- update public provider documentation and regression coverage

## Tests
- pytest -q (523 passed, 1 skipped)