### PR TITLE
fix: allow ZCode control-plane egress

### DIFF
--- a/src/dradar/pier_zcode.py
+++ b/src/dradar/pier_zcode.py
@@ -470,7 +470,12 @@ class ZCodeBigModel(BaseInstalledAgent):
         )
 
     def network_allowlist(self) -> NetworkAllowlist:
-        return NetworkAllowlist(domains=["open.bigmodel.cn"])
+        # The domestic Coding Plan model traffic uses open.bigmodel.cn, while
+        # the official ZCode runtime also reads its control-plane metadata
+        # from zcode.z.ai before starting a full agent turn.  Keep this list
+        # exact: telemetry, web search, and arbitrary network access remain
+        # blocked by the adapter and Pier egress proxy.
+        return NetworkAllowlist(domains=["open.bigmodel.cn", "zcode.z.ai"])
 
     @with_prompt_template
     async def run(

--- a/tests/test_zcode_coding_plan.py
+++ b/tests/test_zcode_coding_plan.py
@@ -273,7 +273,10 @@ def test_zcode_checkpoint_resume_is_rejected(
 
 def test_zcode_adapter_source_has_fixed_security_contract() -> None:
     source = Path(providers.__file__).with_name("pier_zcode.py").read_text()
-    assert 'return NetworkAllowlist(domains=["open.bigmodel.cn"])' in source
+    assert (
+        'return NetworkAllowlist(domains=["open.bigmodel.cn", "zcode.z.ai"])'
+        in source
+    )
     assert '"baseURL": "https://open.bigmodel.cn/api/anthropic"' in source
     assert '"apiKey": {"source": "inline", "value": key}' in source
     assert 'key_file.unlink()' in source


### PR DESCRIPTION
## Summary
- allow the official domestic ZCode runtime to reach its required zcode.z.ai control plane
- keep the Coding Plan model endpoint allowlisted and all other egress blocked
- update the fixed security-contract regression test

## Validation
- focused ZCode tests: 19 passed
- full isolated ds0 suite: 598 passed, 1 skipped
- discovered from an ordinary-user DeepSWE full run: the previous egress policy denied CONNECT zcode.z.ai with 403

Merge is intentionally held until the repaired full ZCode claim/run/upload flow completes.