### PR TITLE
build: publish prebuilt Pier egress proxy

### DIFF
--- a/.github/workflows/publish-egress-proxy.yml
+++ b/.github/workflows/publish-egress-proxy.yml
@@ -1,0 +1,82 @@
+name: Publish egress proxy image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docker/egress-proxy/**
+      - .github/workflows/publish-egress-proxy.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+env:
+  IMAGE: ghcr.io/codex-radar/dradar-egress-proxy
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build the native image for vulnerability scanning
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: docker/egress-proxy
+          load: true
+          platforms: linux/amd64
+          provenance: false
+          push: false
+          sbom: false
+          tags: dradar-egress-proxy:scan
+
+      - name: Scan fixable high and critical vulnerabilities
+        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # v0.30.0
+        with:
+          image-ref: dradar-egress-proxy:scan
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
+          exit-code: 1
+
+      - name: Sign in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: metadata
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=v1
+            type=sha,format=long
+
+      - name: Build and publish the multi-architecture image
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: docker/egress-proxy
+          platforms: linux/amd64,linux/arm64
+          provenance: mode=max
+          push: true
+          sbom: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
+
+      - name: Sign the immutable image digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"

--- a/docker/egress-proxy/.dockerignore
+++ b/docker/egress-proxy/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!start-squid.sh

--- a/docker/egress-proxy/Dockerfile
+++ b/docker/egress-proxy/Dockerfile
@@ -1,0 +1,20 @@
+ARG UBUNTU_IMAGE=docker.io/library/ubuntu:24.04@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea
+FROM ${UBUNTU_IMAGE}
+
+LABEL org.opencontainers.image.title="DRadar Pier egress proxy" \
+      org.opencontainers.image.description="Credentialed Squid sidecar for filtered Pier agent egress" \
+      org.opencontainers.image.source="https://github.com/codex-radar/dradar" \
+      org.opencontainers.image.licenses="MIT"
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        apache2-utils \
+        ca-certificates \
+        squid \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --chmod=0755 start-squid.sh /usr/local/bin/start-squid.sh
+
+USER proxy
+EXPOSE 8080
+CMD ["/usr/local/bin/start-squid.sh"]

--- a/docker/egress-proxy/start-squid.sh
+++ b/docker/egress-proxy/start-squid.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${PROXY_TOKEN:?PROXY_TOKEN is required}"
+: "${ALLOWLIST_DOMAINS:?ALLOWLIST_DOMAINS is required}"
+
+umask 077
+allowed_domains=/tmp/allowed_domains.txt
+password_file=/tmp/squid.passwd
+
+printf '%s' "$ALLOWLIST_DOMAINS" \
+  | tr ',' '\n' \
+  | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;/^$/d' \
+  > "$allowed_domains"
+
+if [[ ! -s "$allowed_domains" ]]; then
+  echo "ALLOWLIST_DOMAINS did not contain any domains" >&2
+  exit 2
+fi
+
+while IFS= read -r domain; do
+  if ! printf '%s\n' "$domain" | grep -Eq '^\.?[A-Za-z0-9][A-Za-z0-9._:-]*$'; then
+    echo "ALLOWLIST_DOMAINS contains an invalid domain" >&2
+    exit 2
+  fi
+done < "$allowed_domains"
+
+# -i reads the password from stdin, keeping the short-lived credential out of
+# process arguments. Squid only needs the resulting htpasswd file.
+printf '%s\n' "$PROXY_TOKEN" | htpasswd -ci "$password_file" agent >/dev/null
+unset PROXY_TOKEN
+
+upstream_config=
+if [[ -n "${UPSTREAM_PROXY_HOST:-}" ]]; then
+  if ! printf '%s\n' "$UPSTREAM_PROXY_HOST" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._:-]*$'; then
+    echo "UPSTREAM_PROXY_HOST is invalid" >&2
+    exit 2
+  fi
+  if ! printf '%s\n' "${UPSTREAM_PROXY_PORT:-}" | grep -Eq '^[0-9]{1,5}$' \
+      || (( UPSTREAM_PROXY_PORT < 1 || UPSTREAM_PROXY_PORT > 65535 )); then
+    echo "UPSTREAM_PROXY_PORT is invalid" >&2
+    exit 2
+  fi
+  upstream_config="cache_peer ${UPSTREAM_PROXY_HOST} parent ${UPSTREAM_PROXY_PORT} 0 no-query default"
+  if [[ -n "${UPSTREAM_PROXY_USERNAME:-}" || -n "${UPSTREAM_PROXY_PASSWORD:-}" ]]; then
+    if [[ "${UPSTREAM_PROXY_USERNAME:-}" == *[[:space:]#]* \
+        || "${UPSTREAM_PROXY_PASSWORD:-}" == *[[:space:]#]* ]]; then
+      echo "upstream proxy credentials contain unsupported characters" >&2
+      exit 2
+    fi
+    upstream_config+=" login=${UPSTREAM_PROXY_USERNAME:-}:${UPSTREAM_PROXY_PASSWORD:-}"
+  fi
+  upstream_config+=$'\nnever_direct allow all'
+fi
+
+cat > /tmp/squid.conf <<'EOF'
+http_port 0.0.0.0:8080
+pid_filename /tmp/squid.pid
+coredump_dir /tmp
+
+auth_param basic program /usr/lib/squid/basic_ncsa_auth /tmp/squid.passwd
+auth_param basic realm PierPolicyProxy
+acl authenticated proxy_auth REQUIRED
+
+acl SSL_ports port 443
+acl Safe_ports port 80 443
+acl CONNECT method CONNECT
+acl allowed_domains dstdomain "/tmp/allowed_domains.txt"
+
+http_access deny !Safe_ports
+http_access deny CONNECT !SSL_ports
+http_access allow authenticated allowed_domains
+http_access deny all
+
+cache deny all
+access_log stdio:/tmp/squid_access.log
+cache_log /tmp/squid_cache.log
+log_mime_hdrs off
+shutdown_lifetime 1 seconds
+EOF
+
+if [[ -n "$upstream_config" ]]; then
+  printf '\n%s\n' "$upstream_config" >> /tmp/squid.conf
+fi
+
+exec squid -N -f /tmp/squid.conf -d 1


### PR DESCRIPTION
## Summary
- add a minimal, non-root Squid sidecar image for filtered Pier egress
- support an optional host/upstream HTTP proxy without exposing it to the task container
- publish signed amd64/arm64 images with SBOM, provenance, and a fixable high/critical vulnerability gate

## Validation
- local arm64 image build completed
- credentialed allowlist CONNECT reached the allowed endpoint through the host proxy
- non-allowlisted endpoint was denied
- image runs as the unprivileged `proxy` user
- workflow actions are pinned to immutable commits