### PR TITLE
fix: remove generated snakeoil key from egress image

### DIFF
--- a/docker/egress-proxy/Dockerfile
+++ b/docker/egress-proxy/Dockerfile
@@ -11,6 +11,9 @@ RUN apt-get update \
         apache2-utils \
         ca-certificates \
         squid \
+    && rm -f \
+        /etc/ssl/certs/ssl-cert-snakeoil.pem \
+        /etc/ssl/private/ssl-cert-snakeoil.key \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --chmod=0755 start-squid.sh /usr/local/bin/start-squid.sh


### PR DESCRIPTION
Ubuntu ssl-cert creates an unused snakeoil private key while Squid is installed. Remove the generated key/certificate so the secret scanner can remain blocking.

Validation:
- local arm64 image rebuilt
- generated key and certificate are absent
- runtime still uses the unprivileged proxy user
- previous Actions vulnerability result reported 0 fixable HIGH/CRITICAL package vulnerabilities