### PR TITLE
build: keep egress image publicly pullable

### DIFF
--- a/.github/workflows/publish-egress-proxy.yml
+++ b/.github/workflows/publish-egress-proxy.yml
@@ -75,6 +75,14 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
 
+      - name: Keep the volunteer runtime anonymously pullable
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          gh api --method PATCH
+          "/orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/dradar-egress-proxy"
+          -f visibility=public
+
       - name: Install cosign
         uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
 


### PR DESCRIPTION
GHCR creates new packages as private by default. Make this credential-free volunteer runtime public in the same least-privilege packages:write workflow, then keep signing the immutable digest. An anonymous pull is the release acceptance check.