### PR TITLE
Fix portable image export cleanup

### DIFF
--- a/.github/workflows/publish-egress-proxy.yml
+++ b/.github/workflows/publish-egress-proxy.yml
@@ -102,7 +102,9 @@ jobs:
               > "dist/dradar-egress-proxy-linux-${arch}.image-id"
             docker save "${portable_ref}" \
               | gzip -9 > "dist/dradar-egress-proxy-linux-${arch}.tar.gz"
-            docker image rm "${portable_ref}" "${source_ref}"
+            # Removing the portable tag also removes the digest-only reference
+            # when both are the last references to the same platform image.
+            docker image rm "${portable_ref}"
           done
           (cd dist && sha256sum *.tar.gz > SHA256SUMS)
 


### PR DESCRIPTION
The export already removes the digest-only reference when it removes the last portable tag. Remove that single tag only so the amd64 export can complete and the arm64 pull can begin. The build, Trivy scan, signing, and first archive creation all passed before this cleanup-only failure.