### PR TITLE
fix: align ZCode timeout and failure diagnostics

### DIFF
--- a/src/dradar/api_client.py
+++ b/src/dradar/api_client.py
@@ -310,6 +310,7 @@ class ApiClient:
         defer_seconds: int = 300,
         resume_generation: int | None = None,
         failure_kind: str | None = None,
+        failure_diagnostic: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """The counterpart of mark_started: this trial died client-side
         (build flake, agent crash, abandonment) with nothing uploaded, so the
@@ -325,6 +326,10 @@ class ApiClient:
             data["resume_generation"] = str(resume_generation)
         if failure_kind:
             data["failure_kind"] = failure_kind
+        if failure_diagnostic is not None:
+            data["failure_diagnostic"] = json.dumps(
+                failure_diagnostic, separators=(",", ":"), sort_keys=True,
+            )
         return self._post(
             "/api/v1/assignment/stopped",
             # A cross-session cooldown keeps a second `--parallel` process

--- a/src/dradar/pier_zcode.py
+++ b/src/dradar/pier_zcode.py
@@ -92,7 +92,16 @@ class ProtocolError(RuntimeError):
     pass
 
 
-node, cli, key_path, instruction_path, effort, outcome_path, events_path, stderr_path = sys.argv[1:]
+(
+    node, cli, key_path, instruction_path, effort, session_timeout_raw,
+    outcome_path, events_path, stderr_path, diagnostic_path,
+) = sys.argv[1:]
+try:
+    session_timeout_sec = int(session_timeout_raw)
+except ValueError as exc:
+    raise ProtocolError("ZCode session timeout is invalid") from exc
+if not 60 <= session_timeout_sec <= 24 * 60 * 60:
+    raise ProtocolError("ZCode session timeout is outside the safe range")
 key_file = Path(key_path)
 key = key_file.read_text(encoding="utf-8").strip()
 if not key or any(character.isspace() for character in key):
@@ -110,6 +119,39 @@ def redact(value):
     if isinstance(value, dict):
         return {name: redact(item) for name, item in value.items()}
     return value
+
+
+def write_runtime_diagnostic(status, turn_count, seen_running, terminal_observed):
+    """Persist only bounded lifecycle facts; never messages, paths or ids."""
+    safe_status = status if status in {
+        "idle", "running", "error", "failed", "stopped",
+    } else "unknown"
+    safe_turn_count = (
+        turn_count
+        if isinstance(turn_count, int) and not isinstance(turn_count, bool)
+        else 0
+    )
+    payload = {
+        "schema": "dradar-zcode-runtime-v1",
+        "status": safe_status,
+        "turn_count": max(0, min(safe_turn_count, 100000)),
+        "seen_running": bool(seen_running),
+        "terminal_observed": bool(terminal_observed),
+    }
+    path = Path(diagnostic_path)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(payload, separators=(",", ":")) + "\n",
+            encoding="utf-8",
+        )
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+    except OSError:
+        try:
+            temporary.unlink()
+        except OSError:
+            pass
 
 
 def collect_rollout_usage(
@@ -424,9 +466,10 @@ try:
     key_file.unlink()
     call("session/send", {"sessionId": session_id, "content": instruction}, timeout=120.0)
 
-    deadline = time.monotonic() + 90 * 60
+    deadline = time.monotonic() + session_timeout_sec
     seen_running = False
     final_state = None
+    write_runtime_diagnostic(None, 0, False, False)
     while time.monotonic() < deadline:
         state = call("session/read", {"sessionId": session_id}, timeout=60.0)
         projection = state.get("projection") if isinstance(state, dict) else None
@@ -434,6 +477,13 @@ try:
         turns = projection.get("turnCount", 0) if isinstance(projection, dict) else 0
         if status not in {None, "idle"}:
             seen_running = True
+        terminal_observed = (
+            (isinstance(turns, int) and turns > 0 and status == "idle")
+            or status in {"error", "failed", "stopped"}
+        )
+        write_runtime_diagnostic(
+            status, turns, seen_running, terminal_observed,
+        )
         if isinstance(turns, int) and turns > 0 and status == "idle":
             final_state = state
             break
@@ -442,7 +492,9 @@ try:
             break
         time.sleep(1.0)
     if final_state is None:
-        raise ProtocolError("ZCode session did not finish within 90 minutes")
+        raise ProtocolError(
+            f"ZCode session did not finish within {session_timeout_sec} seconds"
+        )
     enabled_tools = set()
     state_messages = final_state.get("messages") if isinstance(final_state, dict) else None
     if isinstance(state_messages, list):
@@ -752,6 +804,7 @@ class ZCodeBigModel(BaseInstalledAgent):
     _OUTCOME_FILE = "zcode-outcome.json"
     _EVENTS_FILE = "zcode-protocol-events.json"
     _STDERR_FILE = "zcode-stderr.log"
+    _DIAGNOSTIC_FILE = "zcode-runtime-diagnostic.json"
     _STREAM_FILE = "zcode-protocol.log"
     _USAGE_FILE = "provider-usage.json"
 
@@ -765,6 +818,7 @@ class ZCodeBigModel(BaseInstalledAgent):
         api_key_file: str,
         zcode_cli_file: str,
         reasoning_effort: str,
+        session_timeout_sec: str | int,
         model_name: str | None = None,
         version: str | None = ZCODE_CLI_VERSION,
         **kwargs: Any,
@@ -793,6 +847,12 @@ class ZCodeBigModel(BaseInstalledAgent):
             raise ValueError("ZCode adapter enables only glm-5.3")
         if reasoning_effort not in SUPPORTED_EFFORTS:
             raise ValueError("ZCode reasoning_effort must be low, high, or max")
+        try:
+            resolved_session_timeout = int(session_timeout_sec)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("ZCode session_timeout_sec must be an integer") from exc
+        if not 60 <= resolved_session_timeout <= 24 * 60 * 60:
+            raise ValueError("ZCode session_timeout_sec is outside the safe range")
         resolved_version = version or ZCODE_CLI_VERSION
         if resolved_version != ZCODE_CLI_VERSION:
             raise ValueError(f"ZCode adapter requires exact CLI {ZCODE_CLI_VERSION}")
@@ -810,6 +870,7 @@ class ZCodeBigModel(BaseInstalledAgent):
         self._api_key_file = key_file
         self._zcode_cli_file = cli_file
         self._reasoning_effort = reasoning_effort
+        self._session_timeout_sec = resolved_session_timeout
         self._credential_value = key_value
         self._instruction = ""
         run_secret_dir = self._REMOTE_SECRET_ROOT / uuid.uuid4().hex
@@ -861,6 +922,7 @@ class ZCodeBigModel(BaseInstalledAgent):
         outcome = f"/logs/agent/{self._OUTCOME_FILE}"
         events = f"/logs/agent/{self._EVENTS_FILE}"
         stderr = f"/logs/agent/{self._STDERR_FILE}"
+        diagnostic = f"/logs/agent/{self._DIAGNOSTIC_FILE}"
         stream = f"/logs/agent/{self._STREAM_FILE}"
         instruction_path = f"{remote_secret}/instruction.txt"
         env = self.build_process_env({
@@ -922,7 +984,8 @@ class ZCodeBigModel(BaseInstalledAgent):
             shlex.quote(item)
             for item in (
                 "node", remote_cli, remote_key, instruction_path,
-                self._reasoning_effort, outcome, events, stderr,
+                self._reasoning_effort, str(self._session_timeout_sec),
+                outcome, events, stderr, diagnostic,
             )
         )
         command = (

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -1332,6 +1332,16 @@ def _mark_stopped_quietly(
             return True
         except ApiError as exc:
             last_error = exc
+            if (
+                failure_diagnostic is not None
+                and exc.status_code == 422
+                and "failure_diagnostic" in str(exc)
+            ):
+                # A rolling/older server may reject only the optional
+                # diagnostic schema. Retry cleanup once without telemetry;
+                # never generalize this to unrelated 4xx responses.
+                failure_diagnostic = None
+                continue
             if exc.status_code is not None and exc.status_code < 500:
                 break
         except Exception as exc:

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -1303,6 +1303,7 @@ def _mark_stopped_quietly(
     *,
     defer_seconds: int = 300,
     failure_kind: str | None = None,
+    failure_diagnostic: dict[str, object] | None = None,
 ) -> bool:
     """Best-effort checkout cleanup with bounded retry and visible failure.
 
@@ -1325,6 +1326,8 @@ def _mark_stopped_quietly(
                 stop_kwargs["resume_generation"] = resume_generation
             if failure_kind is not None:
                 stop_kwargs["failure_kind"] = failure_kind
+            if failure_diagnostic is not None:
+                stop_kwargs["failure_diagnostic"] = failure_diagnostic
             client.mark_stopped(assignment_id, **stop_kwargs)
             return True
         except ApiError as exc:
@@ -1513,6 +1516,11 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
                 client,
                 assignment,
                 failure_kind=failure_kind or "runner_failed",
+                failure_diagnostic=(
+                    exc.failure_diagnostic
+                    if (failure_kind or "runner_failed") == "runner_failed"
+                    else None
+                ),
             )
             return terminal_outcome or "failed"
         except (KeyboardInterrupt, EOFError):

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -235,7 +235,11 @@ class TrialArtifacts:
 
 
 class RunnerError(RuntimeError):
-    pass
+    def __init__(
+        self, *args: object, failure_diagnostic: dict[str, object] | None = None,
+    ) -> None:
+        super().__init__(*args)
+        self.failure_diagnostic = failure_diagnostic
 
 
 class LiveAccountTerminalError(RunnerError):
@@ -1065,6 +1069,7 @@ def build_pier_command(
             "--ak", f"reasoning_effort={assignment['effort']}",
             "--ak", f"api_key_file={provider_auth_path}",
             "--ak", f"zcode_cli_file={provider_cli_path}",
+            "--ak", f"session_timeout_sec={_zcode_session_timeout_sec(assignment)}",
             "--ak", f"prompt_template_path={submission_prompt}",
             "--ak", f"version={ZCODE_CLI_VERSION}",
         ]
@@ -2133,6 +2138,73 @@ def _trial_timeout_sec(assignment: dict) -> int:
     return max(3600, int(est_min) * 60 * 4)
 
 
+def _zcode_session_timeout_sec(assignment: dict) -> int:
+    """Keep ZCode behind Pier's watchdog; DRadar's outer cap stays authoritative."""
+    return _trial_timeout_sec(assignment) + 60
+
+
+def _zcode_runtime_diagnostic(jobs_dir: Path, job_name: str) -> dict[str, object]:
+    """Read the adapter's allowlisted lifecycle snapshot, never its raw logs."""
+    try:
+        paths = list(
+            (jobs_dir / job_name).glob("*/agent/zcode-runtime-diagnostic.json")
+        )
+    except OSError:
+        return {}
+    if len(paths) != 1:
+        return {}
+    try:
+        payload = json.loads(paths[0].read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, dict) or payload.get("schema") != "dradar-zcode-runtime-v1":
+        return {}
+    status = payload.get("status")
+    turns = payload.get("turn_count")
+    if status not in {"idle", "running", "error", "failed", "stopped", "unknown"}:
+        status = "unknown"
+    if not isinstance(turns, int) or isinstance(turns, bool) or not 0 <= turns <= 100000:
+        turns = 0
+    return {
+        "zcode_last_status": status,
+        "zcode_turn_count": turns,
+        "zcode_seen_running": payload.get("seen_running") is True,
+        "zcode_terminal_observed": payload.get("terminal_observed") is True,
+    }
+
+
+def _zcode_failure_diagnostic(
+    assignment: dict,
+    task_path: Path,
+    jobs_dir: Path,
+    job_name: str,
+    failure_code: str,
+) -> dict[str, object] | None:
+    """Build a bounded numeric/enum-only diagnostic for assignment/stopped."""
+    if assignment.get("agent") != ZCODE_AGENT:
+        return None
+    base_timeout = _task_agent_timeout_sec(task_path)
+    multiplier = _agent_timeout_multiplier(assignment, task_path)
+    diagnostic: dict[str, object] = {
+        "schema": "dradar-runner-failure-v1",
+        "failure_code": failure_code,
+        "trial_timeout_sec": _trial_timeout_sec(assignment),
+        "zcode_session_timeout_sec": _zcode_session_timeout_sec(assignment),
+    }
+    est_minutes = assignment.get("est_minutes")
+    if (
+        isinstance(est_minutes, (int, float))
+        and not isinstance(est_minutes, bool)
+        and 0 < est_minutes <= 1440
+    ):
+        diagnostic["est_minutes"] = float(est_minutes)
+    if isinstance(base_timeout, (int, float)) and base_timeout > 0:
+        diagnostic["task_agent_timeout_sec"] = int(base_timeout)
+        diagnostic["pier_agent_timeout_sec"] = int(math.ceil(base_timeout * multiplier))
+    diagnostic.update(_zcode_runtime_diagnostic(jobs_dir, job_name))
+    return diagnostic
+
+
 @contextmanager
 def _dsh_tasks_overlay(
     assignment: dict,
@@ -2433,7 +2505,15 @@ def run_trial(
                         raise RunnerError(
                             f"trial exceeded {timeout_sec // 60} min and was aborted "
                             f"(see {log_path}); docker/agent likely wedged\n"
-                            f"last lines of the log:\n{_tail(log_path)}")
+                            f"last lines of the log:\n{_tail(log_path)}",
+                            failure_diagnostic=_zcode_failure_diagnostic(
+                                effective_assignment,
+                                tasks_root / assignment["task_id"],
+                                jobs_dir,
+                                job_name,
+                                "trial_timeout",
+                            ),
+                        )
                     if now >= next_beat:
                         next_beat = now + HEARTBEAT_SEC
                         print(f"  … {int((now - started) / 60)} min elapsed — "
@@ -2491,6 +2571,10 @@ def run_trial(
         job_dir, trial_dir = locate_artifacts(jobs_dir, job_name)
     except RunnerError:
         if terminal_error is not None:
+            if terminal_error.failure_diagnostic is not None:
+                terminal_error.failure_diagnostic.update(
+                    _zcode_runtime_diagnostic(jobs_dir, job_name)
+                )
             raise terminal_error
         if _looks_like_build_flake(tail):
             raise BuildFlakeError(
@@ -2540,7 +2624,14 @@ def run_trial(
                 f"build diagnostic:\n{_diagnostic_tail(diagnostic)}")
         raise RunnerError(
             f"model.patch missing (agent likely failed; see {log_path} and {trial_dir})\n"
-            f"last lines of the log:\n{tail}"
+            f"last lines of the log:\n{tail}",
+            failure_diagnostic=_zcode_failure_diagnostic(
+                effective_assignment,
+                tasks_root / assignment["task_id"],
+                jobs_dir,
+                job_name,
+                "agent_no_artifact",
+            ),
         )
     returncode = proc.returncode
     if terminal_error is not None and returncode in (None, 0):

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -759,7 +759,12 @@ def _agent_timeout_multiplier(assignment: dict, task_path: Path) -> float:
         # so unusual task defaults can stop a fraction early, never after 90m.
         raw = POMPEII_AGENT_TIMEOUT_SEC / base
         return math.floor(raw * 1_000_000) / 1_000_000
-    raw = (_trial_timeout_sec(assignment) + 60) / base
+    watchdog_sec = (
+        _zcode_session_timeout_sec(assignment)
+        if assignment.get("agent") == ZCODE_AGENT
+        else _trial_timeout_sec(assignment) + 60
+    )
+    raw = watchdog_sec / base
     if raw <= 1.0:
         return 1.0
     # Round UP to 3 decimals: --agent-timeout-multiplier is formatted to the
@@ -2140,7 +2145,12 @@ def _trial_timeout_sec(assignment: dict) -> int:
 
 def _zcode_session_timeout_sec(assignment: dict) -> int:
     """Keep ZCode behind Pier's watchdog; DRadar's outer cap stays authoritative."""
-    return _trial_timeout_sec(assignment) + 60
+    return _zcode_trial_timeout_sec(assignment) + 60
+
+
+def _zcode_trial_timeout_sec(assignment: dict) -> int:
+    """Leave one minute before ZCode's protocol-safe 24-hour ceiling."""
+    return min(_trial_timeout_sec(assignment), 24 * 60 * 60 - 60)
 
 
 def _zcode_runtime_diagnostic(jobs_dir: Path, job_name: str) -> dict[str, object]:
@@ -2188,7 +2198,7 @@ def _zcode_failure_diagnostic(
     diagnostic: dict[str, object] = {
         "schema": "dradar-runner-failure-v1",
         "failure_code": failure_code,
-        "trial_timeout_sec": _trial_timeout_sec(assignment),
+        "trial_timeout_sec": _zcode_trial_timeout_sec(assignment),
         "zcode_session_timeout_sec": _zcode_session_timeout_sec(assignment),
     }
     est_minutes = assignment.get("est_minutes")
@@ -2369,7 +2379,11 @@ def run_trial(
     # A mid-task rate-limit death just ends the run (no sleep-and-resume) --
     # it surfaces as a nonzero pier rc, which _run_and_submit reports as
     # `interrupted` -> the server marks it invalid and the cell reopens.
-    timeout_sec = _trial_timeout_sec(effective_assignment)
+    timeout_sec = (
+        _zcode_trial_timeout_sec(effective_assignment)
+        if effective_assignment.get("agent") == ZCODE_AGENT
+        else _trial_timeout_sec(effective_assignment)
+    )
     terminal_error: RunnerError | None = None
     live_error_offsets: dict[Path, int] = {}
     live_error_counts: dict[str, int] = {}

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -3,6 +3,7 @@ attached to ApiError (the 409/410 pending-ledger pruning branches on it),
 the submit() multipart shape, and the Authorization header rules."""
 
 import json
+import urllib.parse
 
 import httpx
 import pytest
@@ -294,6 +295,26 @@ def test_mark_stopped_can_allow_immediate_user_resume():
     assert b"defer_seconds=0" in seen["body"]
     assert b"resume_generation" not in seen["body"]
     assert b"failure_kind" not in seen["body"]
+
+
+def test_mark_stopped_encodes_bounded_failure_diagnostic():
+    seen = {}
+
+    def handler(request):
+        seen["body"] = request.read()
+        return httpx.Response(200, json={"ok": True})
+
+    diagnostic = {
+        "schema": "dradar-runner-failure-v1",
+        "failure_code": "trial_timeout",
+        "trial_timeout_sec": 3600,
+        "zcode_session_timeout_sec": 3660,
+    }
+    _client(handler).mark_stopped(
+        "a1", failure_kind="runner_failed", failure_diagnostic=diagnostic,
+    )
+    body = urllib.parse.parse_qs(seen["body"].decode())
+    assert json.loads(body["failure_diagnostic"][0]) == diagnostic
 
 
 def test_checkpoint_protocol_sends_id_generation_and_runner_session():

--- a/tests/test_diagnosis.py
+++ b/tests/test_diagnosis.py
@@ -355,3 +355,42 @@ def test_mark_stopped_surfaces_nonretryable_cleanup_failure(capsys):
     assert "could not confirm checkout cleanup" in out
     assert "assignment-2" in out
     assert "retry `dradar resume`" in out
+
+
+def test_mark_stopped_downgrades_only_diagnostic_422(capsys):
+    attempts = []
+
+    class Client:
+        def mark_stopped(self, assignment_id, **kwargs):
+            attempts.append((assignment_id, kwargs))
+            if len(attempts) == 1:
+                raise ApiError(
+                    "server returned 422: unsupported failure_diagnostic schema",
+                    status_code=422,
+                )
+            return {"ok": True}
+
+    assert runloop._mark_stopped_quietly(
+        Client(), "assignment-3", failure_kind="runner_failed",
+        failure_diagnostic={"schema": "dradar-runner-failure-v1"},
+    ) is True
+    assert len(attempts) == 2
+    assert "failure_diagnostic" in attempts[0][1]
+    assert "failure_diagnostic" not in attempts[1][1]
+    assert capsys.readouterr().out == ""
+
+
+def test_mark_stopped_does_not_downgrade_unrelated_422(capsys):
+    attempts = []
+
+    class Client:
+        def mark_stopped(self, assignment_id, **kwargs):
+            attempts.append((assignment_id, kwargs))
+            raise ApiError("server returned 422: stale fence", status_code=422)
+
+    assert runloop._mark_stopped_quietly(
+        Client(), "assignment-4", failure_kind="runner_failed",
+        failure_diagnostic={"schema": "dradar-runner-failure-v1"},
+    ) is False
+    assert len(attempts) == 1
+    assert "could not confirm checkout cleanup" in capsys.readouterr().out

--- a/tests/test_diagnosis.py
+++ b/tests/test_diagnosis.py
@@ -255,6 +255,30 @@ def test_failed_trial_reports_stopped_to_server(monkeypatch, tmp_path):
     )]
 
 
+def test_failed_trial_reports_only_structured_failure_diagnostic(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
+    diagnostic = {
+        "schema": "dradar-runner-failure-v1",
+        "failure_code": "trial_timeout",
+        "trial_timeout_sec": 3600,
+        "zcode_session_timeout_sec": 3660,
+    }
+
+    def always_fails(*args, **kwargs):
+        raise RunnerError("secret must remain local", failure_diagnostic=diagnostic)
+
+    monkeypatch.setattr(runloop, "run_trial", always_fails)
+    stopped = []
+    client = SubmitClient({})
+    client.mark_stopped = lambda aid, **kw: stopped.append((aid, kw))
+    assert runloop._run_and_submit(
+        client, ASSIGNMENT, tmp_path, _args(), "abc",
+    ) == "failed"
+    assert stopped[0][1]["failure_diagnostic"] == diagnostic
+    assert "secret" not in json.dumps(stopped[0][1])
+
+
 def test_user_interrupt_without_checkpoint_reports_stopped_to_server(
         monkeypatch, tmp_path):
     monkeypatch.setattr(runloop, "HOME", tmp_path / "home")

--- a/tests/test_zcode_coding_plan.py
+++ b/tests/test_zcode_coding_plan.py
@@ -317,6 +317,27 @@ def test_zcode_session_deadline_tracks_long_assignment_budget(
     assert "session_timeout_sec=9660" in command
 
 
+@pytest.mark.parametrize("est_minutes", [360, 1440])
+def test_zcode_session_deadline_clamps_below_protocol_ceiling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, est_minutes: int,
+) -> None:
+    monkeypatch.setattr(runner.shutil, "which", lambda _name: "/usr/bin/pier")
+    tasks = tmp_path / "tasks"
+    (tasks / "task-1").mkdir(parents=True)
+    home = tmp_path / "home"
+    home.mkdir()
+    cli = tmp_path / "zcode.cjs"
+    cli.write_text("pinned", encoding="utf-8")
+    assignment = _assignment(est_minutes=est_minutes)
+    command = runner.build_pier_command(
+        assignment, tasks, tmp_path / "jobs", "job", home,
+        provider_auth_path=_private(tmp_path / "key"), provider_cli_path=cli,
+    )
+    assert "session_timeout_sec=86400" in command
+    assert runner._zcode_trial_timeout_sec(assignment) == 86340
+    assert runner._zcode_session_timeout_sec(assignment) == 86400
+
+
 def test_zcode_runtime_diagnostic_reads_only_allowlisted_lifecycle_facts(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_zcode_coding_plan.py
+++ b/tests/test_zcode_coding_plan.py
@@ -221,6 +221,7 @@ def test_pier_command_uses_private_zcode_adapter_without_secret(
     assert f"reasoning_effort={effort}" in cmd
     assert f"api_key_file={key}" in cmd
     assert f"zcode_cli_file={cli}" in cmd
+    assert "session_timeout_sec=3660" in cmd
     assert f"version={ZCODE_CLI_VERSION}" in cmd
     assert "must-not-leak" not in joined
     assert (home / runner.ZCODE_AGENT_MODULE_FILENAME).read_bytes() == (
@@ -292,6 +293,49 @@ def test_zcode_adapter_source_has_fixed_security_contract() -> None:
     assert 'message.get("content") or message.get("parts")' in source
     assert 'info.get("role") if isinstance(info, dict) else None' in source
     assert "[REDACTED_ZCODE_CREDENTIAL]" in source
+    assert "deadline = time.monotonic() + session_timeout_sec" in source
+    assert "90 * 60" not in source
+    assert "dradar-zcode-runtime-v1" in source
+
+
+def test_zcode_session_deadline_tracks_long_assignment_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(runner.shutil, "which", lambda _name: "/usr/bin/pier")
+    tasks = tmp_path / "tasks"
+    (tasks / "task-1").mkdir(parents=True)
+    home = tmp_path / "home"
+    home.mkdir()
+    cli = tmp_path / "zcode.cjs"
+    cli.write_text("pinned", encoding="utf-8")
+    command = runner.build_pier_command(
+        _assignment(est_minutes=40), tasks, tmp_path / "jobs", "job", home,
+        provider_auth_path=_private(tmp_path / "key"), provider_cli_path=cli,
+    )
+    # DRadar outer cap is 40m * 4 = 160m. The adapter gets one extra minute
+    # so the outer watchdog remains the authoritative termination path.
+    assert "session_timeout_sec=9660" in command
+
+
+def test_zcode_runtime_diagnostic_reads_only_allowlisted_lifecycle_facts(
+    tmp_path: Path,
+) -> None:
+    diagnostic = tmp_path / "job" / "trial" / "agent"
+    diagnostic.mkdir(parents=True)
+    (diagnostic / "zcode-runtime-diagnostic.json").write_text(json.dumps({
+        "schema": "dradar-zcode-runtime-v1",
+        "status": "running",
+        "turn_count": 7,
+        "seen_running": True,
+        "terminal_observed": False,
+        "prompt": "must never leave the machine",
+    }), encoding="utf-8")
+    assert runner._zcode_runtime_diagnostic(tmp_path, "job") == {
+        "zcode_last_status": "running",
+        "zcode_turn_count": 7,
+        "zcode_seen_running": True,
+        "zcode_terminal_observed": False,
+    }
 
 
 def _zcode_usage(payload: dict) -> dict:


### PR DESCRIPTION
## Summary
- align ZCode session timeout with the assignment budget
- emit bounded lifecycle diagnostics on runner failure
- preserve safe stopped cleanup against older servers

## Tests
- `pytest -q` — 696 passed, 1 skipped
- `git diff --check`