### PR TITLE
fix: extend Kimi Pompeii timeout to 180 minutes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dradar"
-version = "0.5.100"
+version = "0.5.101"
 description = "Distributed Radar client — run benchmark tasks locally and submit them for independent server-side grading"
 requires-python = ">=3.11"
 dependencies = ["httpx[socks]>=0.27"]

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -59,7 +59,7 @@ from .providers import (
 )
 from .runner import (
     CODEX_TRAJECTORY_BUNDLE_SCHEMA, DIAG_ADVICE, BuildFlakeError, RunnerError,
-    POMPEII_AGENT_TIMEOUT_SEC, POMPEII_BENCHMARK_ID,
+    POMPEII_BENCHMARK_ID,
     POMPEII_FINALIZATION_RESERVE_SEC, POMPEII_SOFT_BUDGET_SEC,
     POMPEII_TERMINAL_HEAVY_TIMEOUT_SEC,
     build_codex_trajectory_bundle, build_kimi_trajectory_bundle,
@@ -67,7 +67,8 @@ from .runner import (
     check_task_content_hash, classify_exception_message,
     codex_trajectory_bundle_usage,
     diagnose_exception, ensure_pier, ensure_tasks_root,
-    durable_checkpoint_rollout_enabled, local_deep_swe_commit, run_trial,
+    durable_checkpoint_rollout_enabled, local_deep_swe_commit,
+    pompeii_agent_timeout_sec, run_trial,
     summarize_result, sync_deep_swe_commit, trial_artifact_paths,
 )
 from .scrub import (
@@ -2423,7 +2424,7 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
     if assignment.get("benchmark_id") == POMPEII_BENCHMARK_ID:
         meta.update({
             "soft_budget_sec": POMPEII_SOFT_BUDGET_SEC,
-            "hard_budget_sec": POMPEII_AGENT_TIMEOUT_SEC,
+            "hard_budget_sec": pompeii_agent_timeout_sec(assignment),
             "terminal_tool_timeout_cap_sec": POMPEII_TERMINAL_HEAVY_TIMEOUT_SEC,
             "finalization_reserve_sec": POMPEII_FINALIZATION_RESERVE_SEC,
         })

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -228,6 +228,7 @@ not wait for or invoke `/tests/pre_artifacts.sh`, and do not create or inspect
 POMPEII_BENCHMARK_ID = "pompeii-adjacency"
 POMPEII_SOFT_BUDGET_SEC = 90 * 60
 POMPEII_AGENT_TIMEOUT_SEC = 120 * 60
+KIMI_POMPEII_AGENT_TIMEOUT_SEC = 180 * 60
 POMPEII_TERMINAL_HEAVY_TIMEOUT_SEC = 10 * 60
 POMPEII_FINALIZATION_RESERVE_SEC = 10 * 60
 POMPEII_OUTER_WATCHDOG_SLACK_SEC = 15 * 60
@@ -871,28 +872,36 @@ def _task_agent_timeout_sec(task_path: Path) -> float | None:
     return data.get("agent", {}).get("timeout_sec")
 
 
+def pompeii_agent_timeout_sec(assignment: dict) -> int:
+    """Return the hard agent budget for one Pompeii assignment."""
+    if assignment.get("agent") == KIMI_AGENT:
+        return KIMI_POMPEII_AGENT_TIMEOUT_SEC
+    return POMPEII_AGENT_TIMEOUT_SEC
+
+
 def _agent_timeout_multiplier(assignment: dict, task_path: Path) -> float:
     """Resolve Pier's agent watchdog multiplier for one assignment.
 
     Ordinary benchmarks stretch the task timeout to stay behind DRadar's outer
-    watchdog. Pompeii uses one benchmark-wide 120-minute hard budget regardless
-    of whether an installed task pack declares the older 90-minute watchdog or
-    the refreshed two-hour watchdog.
+    watchdog. Pompeii normalizes the installed task timeout to the assignment's
+    hard budget regardless of whether the pack declares the older 90-minute
+    watchdog or the refreshed two-hour watchdog.
     """
     base = _task_agent_timeout_sec(task_path)
     if not base:
         if assignment.get("benchmark_id") == POMPEII_BENCHMARK_ID:
+            hard_budget_sec = pompeii_agent_timeout_sec(assignment)
             raise RunnerError(
                 "Pompeii tasks require a readable [agent].timeout_sec so the "
-                "120-minute execution limit can be enforced"
+                f"{hard_budget_sec // 60}-minute execution limit can be enforced"
             )
         return 1.0
     if assignment.get("benchmark_id") == POMPEII_BENCHMARK_ID:
         # Managed Pompeii packs in the field declare either 5400s or 7200s.
-        # Normalize both at launch so every model receives the same two-hour
-        # hard limit. Floor the serialized ratio so unusual task defaults can
-        # stop a fraction early, never after 120m.
-        raw = POMPEII_AGENT_TIMEOUT_SEC / base
+        # Normalize both at launch to the assignment-specific hard limit. Floor
+        # the serialized ratio so unusual task defaults can stop a fraction
+        # early, never after that limit.
+        raw = pompeii_agent_timeout_sec(assignment) / base
         return math.floor(raw * 1_000_000) / 1_000_000
     watchdog_sec = _effective_trial_timeout_sec(assignment) + 60
     raw = watchdog_sec / base
@@ -2532,7 +2541,7 @@ def _effective_trial_timeout_sec(assignment: dict) -> int:
     if assignment.get("benchmark_id") == POMPEII_BENCHMARK_ID:
         # The outer watchdog starts before image/environment setup while Pier's
         # hard agent deadline starts at agent execution. Keep setup outside the
-        # promised two-hour execution budget instead of undercutting it.
+        # promised execution budget instead of undercutting it.
         ordinary = (
             _subscription_trial_timeout_sec(assignment)
             if assignment.get("agent") in BETA_SUBSCRIPTION_AGENTS
@@ -2540,7 +2549,8 @@ def _effective_trial_timeout_sec(assignment: dict) -> int:
         )
         return max(
             ordinary,
-            POMPEII_AGENT_TIMEOUT_SEC + POMPEII_OUTER_WATCHDOG_SLACK_SEC,
+            pompeii_agent_timeout_sec(assignment)
+            + POMPEII_OUTER_WATCHDOG_SLACK_SEC,
         )
     agent = assignment.get("agent")
     if agent == ZCODE_AGENT:

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -210,11 +210,42 @@ def test_pompeii_multiplier_stretches_90_minute_pack_to_120_minutes(tmp_path):
     assert 7199.0 < multiplier * 5400.0 <= runner_mod.POMPEII_AGENT_TIMEOUT_SEC
 
 
+def test_kimi_pompeii_multiplier_stretches_pack_to_180_minutes(tmp_path):
+    for pack_timeout_sec, expected_multiplier in ((7200.0, 1.5), (5400.0, 2.0)):
+        task = _task_with_toml(
+            tmp_path,
+            task_id=f"kimi-{int(pack_timeout_sec)}",
+            timeout_sec=pack_timeout_sec,
+        )
+        assignment = {
+            "agent": runner_mod.KIMI_AGENT,
+            "benchmark_id": runner_mod.POMPEII_BENCHMARK_ID,
+            "est_minutes": 120,
+        }
+        multiplier = runner_mod._agent_timeout_multiplier(assignment, task)
+        assert multiplier == expected_multiplier
+        assert (
+            multiplier * pack_timeout_sec
+            == runner_mod.KIMI_POMPEII_AGENT_TIMEOUT_SEC
+        )
+
+
 def test_pompeii_timeout_requires_readable_task_config(tmp_path):
     task = tmp_path / "no-toml"
     task.mkdir()
     assignment = {"benchmark_id": runner_mod.POMPEII_BENCHMARK_ID}
     with pytest.raises(RunnerError, match="120-minute execution limit"):
+        runner_mod._agent_timeout_multiplier(assignment, task)
+
+
+def test_kimi_pompeii_timeout_error_reports_180_minute_limit(tmp_path):
+    task = tmp_path / "no-toml-kimi"
+    task.mkdir()
+    assignment = {
+        "agent": runner_mod.KIMI_AGENT,
+        "benchmark_id": runner_mod.POMPEII_BENCHMARK_ID,
+    }
+    with pytest.raises(RunnerError, match="180-minute execution limit"):
         runner_mod._agent_timeout_multiplier(assignment, task)
 
 
@@ -1692,15 +1723,29 @@ def test_pompeii_outer_watchdog_leaves_setup_outside_agent_budget():
         runner_mod.POMPEII_AGENT_TIMEOUT_SEC
         + runner_mod.POMPEII_OUTER_WATCHDOG_SLACK_SEC
     )
-    for agent in (
-        "codex", runner_mod.KIMI_AGENT, runner_mod.GROK_AGENT,
-        runner_mod.ZCODE_AGENT,
-    ):
+    for agent in ("codex", runner_mod.GROK_AGENT, runner_mod.ZCODE_AGENT):
         assert _effective_trial_timeout_sec({
             "agent": agent,
             "benchmark_id": runner_mod.POMPEII_BENCHMARK_ID,
             "est_minutes": 5,
         }) == expected
+
+    kimi_expected = (
+        runner_mod.KIMI_POMPEII_AGENT_TIMEOUT_SEC
+        + runner_mod.POMPEII_OUTER_WATCHDOG_SLACK_SEC
+    )
+    assert _effective_trial_timeout_sec({
+        "agent": runner_mod.KIMI_AGENT,
+        "benchmark_id": runner_mod.POMPEII_BENCHMARK_ID,
+        "est_minutes": 5,
+    }) == kimi_expected
+
+
+def test_kimi_non_pompeii_keeps_subscription_timeout_policy():
+    assert _effective_trial_timeout_sec({
+        "agent": runner_mod.KIMI_AGENT,
+        "est_minutes": 5,
+    }) == 7200
 
 
 def test_summarize_result_exception_info_present(tmp_path):


### PR DESCRIPTION
## Summary
- give Kimi Code Pompeii assignments a 180-minute hard agent budget
- keep the 15-minute setup/watchdog allowance, for a 195-minute outer cap
- preserve the existing 120-minute Pompeii limit for every other agent and existing non-Pompeii subscription behavior
- report the effective assignment-specific hard budget in submission metadata

## Verification
- `pytest -q tests/` (1044 passed, 5 skipped)
- built `dradar-0.5.101-py3-none-any.whl` successfully