### PR TITLE
Allow live worker pools to scale down to zero

### DIFF
--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -324,9 +324,9 @@ def _read_pool_target(path: Path | None, *, default: int, maximum: int) -> int:
             f"keeping {default} worker(s)", file=sys.stderr,
         )
         return default
-    if not 1 <= value <= maximum:
+    if not 0 <= value <= maximum:
         print(
-            f"worker target {value} is outside 1..{maximum}; "
+            f"worker target {value} is outside 0..{maximum}; "
             f"keeping {default} worker(s)", file=sys.stderr,
         )
         return default
@@ -3680,7 +3680,7 @@ def _run_worker_pool(args) -> int:
         print(f"only {len(active)} task(s) are currently held; starting {count} worker(s)")
     print(f"starting {count} worker(s); server-side checkout assigns each task exactly once")
     if target_file is not None:
-        print(f"live worker target: {target_file} (range 1..{maximum})")
+        print(f"live worker target: {target_file} (range 0..{maximum})")
     command = _worker_command(args)
     pool_abort_file = configured_abort_file or (
         Path(tempfile.gettempdir())

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -518,6 +518,32 @@ def test_worker_above_live_target_retires_before_next_checkout(
     assert runloop._worker_slot_is_enabled() is True
 
 
+def test_worker_target_zero_retires_every_slot_before_next_checkout(
+        tmp_path, monkeypatch):
+    target = tmp_path / "workers"
+    target.write_text("0")
+    monkeypatch.setenv("DRADAR_POOL_TARGET_FILE", str(target))
+    monkeypatch.setenv("DRADAR_WORKER_INDEX", "1")
+    monkeypatch.setenv("DRADAR_POOL_MAX_SIZE", "4")
+    monkeypatch.setenv("DRADAR_POOL_SIZE", "4")
+    runloop._POOL_TARGET_CACHE.clear()
+    assert runloop._worker_slot_is_enabled() is False
+
+
+def test_pool_can_start_at_zero_without_spawning_workers(
+        tmp_path, monkeypatch):
+    _patch_pool_setup(monkeypatch, active_count=4)
+    target = tmp_path / "workers"
+    target.write_text("0")
+    monkeypatch.setattr(
+        runloop.subprocess, "Popen",
+        lambda *_args, **_kwargs: pytest.fail("zero target must not spawn workers"),
+    )
+    assert runloop._run_worker_pool(
+        _args(workers=4, worker_target_file=str(target)),
+    ) == 0
+
+
 def test_worker_keeps_last_valid_target_during_atomic_file_replacement(
         tmp_path, monkeypatch):
     target = tmp_path / "workers"


### PR DESCRIPTION
## Summary
- accept 0 in live worker target files while keeping the initial --workers bound unchanged
- let every slot retire before its next checkout without signalling in-flight work
- cover zero-target startup and slot retirement

## Validation
- 1046 passed, 5 skipped