### PR TITLE
fix: claim cheapest scoped refill cells first

### DIFF
--- a/src/dradar/refill.py
+++ b/src/dradar/refill.py
@@ -8,6 +8,7 @@ All workers under one DRADAR_HOME serialize plan updates through an OS lock.
 from __future__ import annotations
 
 import json
+import math
 import os
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -485,7 +486,35 @@ def _scoped_candidates(table: dict, plan: dict) -> list[dict]:
         ):
             candidate["est_quota_pct"] = float(cost) / float(plus_window) * 100
         candidates.append(candidate)
-    return candidates
+    def price_key(candidate: dict) -> tuple[int, float, str, str, str]:
+        """Cheapest authoritative estimate first, with deterministic ties.
+
+        A missing or malformed estimate must never jump ahead of priced work.
+        ``est_quota_pct`` is a useful secondary estimate when a provider cell
+        has no dollar-equivalent cost, but it is intentionally ranked after
+        every directly priced candidate because the units are not comparable.
+        """
+
+        cost = candidate.get("cost")
+        if (isinstance(cost, (int, float)) and not isinstance(cost, bool)
+                and math.isfinite(float(cost)) and float(cost) >= 0):
+            bucket, price = 0, float(cost)
+        else:
+            quota = candidate.get("est_quota_pct")
+            if (isinstance(quota, (int, float)) and not isinstance(quota, bool)
+                    and math.isfinite(float(quota)) and float(quota) >= 0):
+                bucket, price = 1, float(quota)
+            else:
+                bucket, price = 2, 0.0
+        return (
+            bucket,
+            price,
+            str(candidate.get("task_id", "")),
+            str(candidate.get("model", "")),
+            str(candidate.get("effort", "")),
+        )
+
+    return sorted(candidates, key=price_key)
 
 
 def mark_submitted(home: Path, assignment_id: str) -> int:

--- a/tests/test_refill_scope.py
+++ b/tests/test_refill_scope.py
@@ -121,6 +121,28 @@ def test_kimi_low_scoped_refill_claims_only_kimi_low(tmp_path: Path):
     assert client.suggest_calls == []
 
 
+def test_scoped_refill_claims_cheapest_candidates_first(tmp_path: Path):
+    board = _table(
+        ("expensive", KIMI_AGENT, "k3", "low", "open"),
+        ("unpriced", KIMI_AGENT, "k3", "low", "open"),
+        ("cheap", KIMI_AGENT, "k3", "low", "open"),
+        ("middle", KIMI_AGENT, "k3", "low", "open"),
+    )
+    board["cells"]["expensive|k3|low"]["cost"] = 3.0
+    board["cells"]["unpriced|k3|low"].pop("cost")
+    board["cells"]["cheap|k3|low"]["cost"] = 0.1
+    board["cells"]["middle|k3|low"]["cost"] = 1.0
+    client = ScopedClient(board)
+    _configure(tmp_path, refill_to=4)
+
+    result = refill.refill_once(tmp_path, client)
+
+    assert result["claimed"] == 4
+    assert [task_id for task_id, _model, _effort in client.claimed] == [
+        "cheap", "middle", "expensive", "unpriced",
+    ]
+
+
 def test_no_kimi_inventory_never_falls_back_to_codex(tmp_path: Path):
     client = ScopedClient(_table(
         ("k-busy", KIMI_AGENT, "k3", "low", "leased"),


### PR DESCRIPTION
## Summary
- order scoped refill candidates by finite estimated cost
- use quota percentage only as a secondary estimate
- place unpriced cells last with deterministic ties

## Verification
- targeted refill/worker suite: 113 passed
- full suite: 1047 passed, 5 skipped