### PR TITLE
fix: keep live refill target aligned with workers

### DIFF
--- a/src/dradar/cli.py
+++ b/src/dradar/cli.py
@@ -325,8 +325,8 @@ def main(argv: list[str] | None = None) -> int:
         p.add_argument(
             "--worker-target-file", metavar="PATH",
             help="dynamically resize a fixed worker pool by atomically writing "
-                 "a number from 1 through --workers to PATH; scale-down lets "
-                 "in-flight tasks finish",
+                 "a number from 0 through --workers to PATH; 0 drains the pool, "
+                 "and scale-down lets in-flight tasks finish",
         )
         p.add_argument("--worker-child", action="store_true", help=argparse.SUPPRESS)
         p.add_argument(

--- a/src/dradar/refill.py
+++ b/src/dradar/refill.py
@@ -99,6 +99,35 @@ def load(home: Path) -> dict | None:
         return _load_unlocked(home)
 
 
+def resize_target(home: Path, refill_to: int) -> dict | None:
+    """Atomically align a live refill queue with its worker-pool target.
+
+    Runtime scale-down may use zero to drain without replacing completed work;
+    initial plan creation remains positive-only.  The durable total-task cap
+    always wins over a larger worker target.
+    """
+
+    if (
+        isinstance(refill_to, bool)
+        or not isinstance(refill_to, int)
+        or refill_to < 0
+    ):
+        raise RefillError("live refill target must be a non-negative integer")
+    with _locked(home):
+        plan = _load_unlocked(home)
+        if not plan or plan.get("status") not in RUNNING_STATES:
+            return None
+        try:
+            max_tasks = int(plan["max_tasks"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise RefillError("saved refill plan has no valid task cap") from exc
+        target = min(refill_to, max_tasks)
+        if plan.get("refill_to") != target:
+            plan["refill_to"] = target
+            _save_unlocked(home, plan)
+        return dict(plan)
+
+
 def _save_unlocked(home: Path, plan: dict) -> None:
     plan["updated_at"] = _now()
     path = _path(home)

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -350,6 +350,26 @@ def _worker_slot_is_enabled() -> bool:
     return slot <= target
 
 
+def _sync_worker_refill_target() -> int | None:
+    """Make a worker's shared refill plan follow the latest live pool size."""
+
+    path = _pool_target_file()
+    if path is None:
+        return None
+    try:
+        maximum = int(os.environ.get("DRADAR_POOL_MAX_SIZE", "40"))
+        previous = int(os.environ.get("DRADAR_POOL_SIZE", str(maximum)))
+    except ValueError as exc:
+        raise refill_plan.RefillError(
+            "worker pool size environment is invalid"
+        ) from exc
+    previous = _POOL_TARGET_CACHE.get(path, previous)
+    target = _read_pool_target(path, default=previous, maximum=maximum)
+    _POOL_TARGET_CACHE[path] = target
+    refill_plan.resize_target(HOME, target)
+    return target
+
+
 def _announce_account_stop(outcome: str) -> None:
     messages = {
         "auth-failure": "agent authentication failed",
@@ -3758,6 +3778,25 @@ def _run_worker_pool(args) -> int:
             if new_target != target:
                 direction = "up" if new_target > target else "down"
                 print(f"scaling worker pool {direction}: {target} -> {new_target}")
+                if getattr(args, "refill", False):
+                    try:
+                        resized = refill_plan.resize_target(HOME, new_target)
+                        if resized is not None:
+                            print(
+                                "live refill queue target: "
+                                f"{resized['refill_to']}"
+                            )
+                            if new_target > target:
+                                refill_plan.refill_once(HOME, client)
+                    except (refill_plan.RefillError, ApiError) as exc:
+                        refill_plan.stop(
+                            HOME, f"live resize failed: {type(exc).__name__}",
+                        )
+                        backfill_disabled = True
+                        print(
+                            "continuous refill stopped after a live resize "
+                            f"failure ({exc}); active workers will finish"
+                        )
                 target = new_target
             if pool_abort_file.is_file():
                 if abort_reason is None:
@@ -3867,11 +3906,29 @@ def _align_refill_target_with_workers(args) -> None:
     workers = getattr(args, "workers", 1)
     if not isinstance(workers, int) or workers <= 1:
         return
-    floor = workers
+    target_file = _pool_target_file(args)
+    if target_file is not None:
+        floor = _read_pool_target(
+            target_file, default=workers, maximum=workers,
+        )
+        if floor == 0:
+            sys.exit(
+                "a refill pool cannot start with worker target 0; start at 1 "
+                "or higher, then write 0 to drain it live"
+            )
+    else:
+        floor = workers
     if getattr(args, "max_tasks", None) is not None:
         floor = min(floor, int(args.max_tasks))
     current = getattr(args, "refill_to", None)
-    if current is None or current < floor:
+    if target_file is not None:
+        if current != floor:
+            args.refill_to = floor
+            print(
+                f"refill queue target synchronized to live worker target {floor}; "
+                "quota/task caps remain unchanged"
+            )
+    elif current is None or current < floor:
         args.refill_to = floor
         print(f"refill queue target raised to {floor} so {workers} worker(s) can stay busy; "
               "quota/task caps remain unchanged")
@@ -4105,6 +4162,14 @@ def _run_checkout_loop(args, client: ApiClient, tasks_root: Path,
                 results.append(outcome)
                 break
             refill_plan.mark_submitted(HOME, assignment["assignment_id"])
+            try:
+                _sync_worker_refill_target()
+            except refill_plan.RefillError as exc:
+                refill_plan.stop(HOME, "live worker target synchronization failed")
+                print(
+                    "continuous refill stopped because the live worker target "
+                    f"could not be synchronized ({exc})"
+                )
             replenished = None
             runtime_cfg = _load_config()
             maintenance_allows_refill = True

--- a/tests/test_refill.py
+++ b/tests/test_refill.py
@@ -100,6 +100,27 @@ def test_plan_persists_only_bounded_public_metadata(tmp_path: Path):
         assert secret not in raw
 
 
+def test_live_resize_updates_refill_target_without_resetting_budget(
+        tmp_path: Path):
+    original = _configure(tmp_path, [], refill_to=3, max_tasks=5)
+
+    drained = refill.resize_target(tmp_path, 0)
+    assert drained["refill_to"] == 0
+    assert drained["plan_id"] == original["plan_id"]
+    assert drained["assignments"] == original["assignments"]
+
+    capped = refill.resize_target(tmp_path, 40)
+    assert capped["refill_to"] == 5
+    assert capped["max_tasks"] == 5
+
+
+@pytest.mark.parametrize("target", (-1, True, 1.5))
+def test_live_resize_rejects_invalid_targets(tmp_path: Path, target):
+    _configure(tmp_path, [])
+    with pytest.raises(refill.RefillError, match="non-negative integer"):
+        refill.resize_target(tmp_path, target)
+
+
 def test_selected_batch_must_all_submit_before_refill(tmp_path: Path):
     initial = [_assignment("a1"), _assignment("a2"), _assignment("a3")]
     client = RefillClient(initial)

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -125,6 +125,34 @@ def test_manual_workers_raise_too_small_refill_queue(monkeypatch):
     assert seen == [(3, 3)]
 
 
+def test_dynamic_worker_target_controls_initial_refill_queue(
+        tmp_path, monkeypatch):
+    target = tmp_path / "workers"
+    target.write_text("2")
+    seen = []
+    monkeypatch.setattr(
+        runloop, "_run_worker_pool",
+        lambda args: seen.append(args.refill_to) or 0,
+    )
+    args = _args(
+        workers=4, worker_target_file=str(target), refill=True,
+        refill_to=40, max_tasks=100, max_estimated_quota_pct=5,
+    )
+
+    assert runloop.cmd_go(args) == 0
+    assert seen == [2]
+
+
+def test_refill_pool_cannot_start_at_zero_workers(tmp_path):
+    target = tmp_path / "workers"
+    target.write_text("0")
+    with pytest.raises(SystemExit, match="cannot start with worker target 0"):
+        runloop.cmd_go(_args(
+            workers=4, worker_target_file=str(target), refill=True,
+            refill_to=4, max_tasks=100, max_estimated_quota_pct=5,
+        ))
+
+
 def test_refill_without_any_limit_is_rejected_before_setup():
     with pytest.raises(SystemExit, match="requires --max-estimated-quota-pct"):
         runloop.cmd_go(_args(refill=True))
@@ -472,6 +500,60 @@ def test_pool_live_target_scales_up_without_restarting_existing_workers(
     assert [p.env["DRADAR_WORKER_INDEX"] for p in calls] == ["1", "2", "3", "4"]
     assert calls[0].signals == [] if hasattr(calls[0], "signals") else True
     assert "scaling worker pool up: 2 -> 4" in capsys.readouterr().out
+
+
+def test_pool_live_scale_up_refills_to_new_worker_target(
+        tmp_path, monkeypatch):
+    _patch_pool_setup(monkeypatch, active_count=4)
+    target = tmp_path / "workers"
+    target.write_text("2")
+    monkeypatch.setattr(runloop.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(runloop, "_pool_ready_work_count", lambda _client: 2)
+    resized = []
+    replenished = []
+    monkeypatch.setattr(
+        runloop.refill_plan, "resize_target",
+        lambda _home, value: resized.append(value) or {"refill_to": value},
+    )
+    monkeypatch.setattr(
+        runloop.refill_plan, "refill_once",
+        lambda _home, _client: replenished.append(True) or {"claimed": 2},
+    )
+    calls = []
+
+    def popen(command, env, **kwargs):
+        if len(calls) == 1:
+            target.write_text("4")
+        polls = [None, 0] if len(calls) < 2 else [0]
+        process = _ScriptedProcess(command, env, polls, **kwargs)
+        calls.append(process)
+        return process
+
+    monkeypatch.setattr(runloop.subprocess, "Popen", popen)
+    assert runloop._run_worker_pool(_args(
+        workers=4, worker_target_file=str(target), refill=True,
+        max_tasks=100, max_estimated_quota_pct=5,
+    )) == 0
+    assert resized == [4]
+    assert replenished == [True]
+
+
+def test_worker_syncs_refill_target_before_replenishing(
+        tmp_path, monkeypatch):
+    target = tmp_path / "workers"
+    target.write_text("1")
+    monkeypatch.setenv("DRADAR_POOL_TARGET_FILE", str(target))
+    monkeypatch.setenv("DRADAR_POOL_MAX_SIZE", "4")
+    monkeypatch.setenv("DRADAR_POOL_SIZE", "4")
+    resized = []
+    monkeypatch.setattr(
+        runloop.refill_plan, "resize_target",
+        lambda home, value: resized.append((home, value)) or {"refill_to": value},
+    )
+    runloop._POOL_TARGET_CACHE.clear()
+
+    assert runloop._sync_worker_refill_target() == 1
+    assert resized == [(runloop.HOME, 1)]
 
 
 def test_pool_live_target_scales_down_without_signalling_inflight_workers(


### PR DESCRIPTION
## Summary
- synchronize refill target with the live worker target file
- refill immediately on live scale-up and drain safely at target zero
- keep refill plan, budget, and ledger intact while resizing

## Tests
- targeted: 121 passed
- full: 1055 passed, 5 skipped