### PR TITLE
Fix ZCode recovered tool error false failure

### DIFF
--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -2739,11 +2739,13 @@ def _zcode_false_success_reason(
     answer.
 
     Incomplete token telemetry alone is deliberately *not* a failure: the
-    accounting path already fails closed, and a real patch must still be
-    gradeable when the provider merely omitted usage.  A positive provider
-    model-error counter is different only when the session never recovered to
-    a complete, reconciled provider terminal: that combination is the known
-    false-success signature.
+    accounting path already records its own evidence tier, and a real patch
+    must still be gradeable when the per-request ledger is unavailable or
+    unreconciled.  ``complete`` here means ZCode emitted a provider-backed
+    ``turn.completed`` aggregate; request-ledger completeness only controls
+    accounting confidence.  A positive provider model-error counter is a
+    false-success signature only when the session never recovered to such a
+    completed provider turn.
     """
     result = _read_capped_json_object(
         result_path, _ZCODE_TERMINAL_ARTIFACT_MAX_BYTES,
@@ -2770,14 +2772,11 @@ def _zcode_false_success_reason(
     provider_usage = sidecar_usage or embedded_usage
 
     request_count = provider_usage.get("request_count")
-    provider_terminal = (
+    provider_turn_completed = (
         provider_usage.get("schema") == "dradar-subscription-provider-usage-v1"
         and provider_usage.get("provider") == "zcode"
         and provider_usage.get("model") == expected_model
         and provider_usage.get("complete") is True
-        and provider_usage.get("request_usage_complete") is True
-        and provider_usage.get("request_usage_observed") is True
-        and provider_usage.get("usage_evidence_tier") == "complete_reconciled"
         and isinstance(request_count, int)
         and not isinstance(request_count, bool)
         and request_count > 0
@@ -2799,9 +2798,9 @@ def _zcode_false_success_reason(
     status = runtime_diagnostic.get("zcode_last_status")
     if status in {"error", "failed", "stopped"}:
         return "terminal_status"
-    if explicit_model_error and not provider_terminal:
+    if explicit_model_error and not provider_turn_completed:
         return "provider_model_error"
-    if not meaningful_agent_result and not provider_terminal:
+    if not meaningful_agent_result and not provider_turn_completed:
         return "empty_agent_result"
     return None
 

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -1325,6 +1325,121 @@ def test_run_trial_accepts_recovered_zcode_model_error_with_valid_patch(
     assert summarize_result(artifact.result)["n_agent_steps"] == 18
 
 
+def test_run_trial_accepts_recovered_zcode_tool_error_with_aggregate_usage(
+        tmp_path, monkeypatch):
+    """A recoverable tool failure must not poison a successful final turn.
+
+    This mirrors the retained ZCode case where ``File has been modified since
+    read`` incremented ``model_error_count``, but the agent recovered, emitted
+    a valid patch, and finished with a provider ``turn.completed`` aggregate.
+    The missing per-request reconciliation lowers usage confidence to
+    ``aggregate_only``; it does not invalidate the answer.
+    """
+    _prepare_fake_zcode(monkeypatch, tmp_path)
+    _fake_pier(
+        monkeypatch,
+        tmp_path,
+        result={
+            "agent_result": {
+                "n_agent_steps": 47,
+                "metadata": {"provider_usage": {
+                    "schema": "dradar-subscription-provider-usage-v1",
+                    "provider": "zcode",
+                    "model": runner_mod.ZCODE_MODEL,
+                    "complete": True,
+                    "request_count": 93,
+                    "request_usage_complete": False,
+                    "request_usage_observed": False,
+                    "usage_evidence_tier": "aggregate_only",
+                }},
+            },
+        },
+        trajectory_payload={
+            "steps": [{"source": "agent", "message": "completed patch"}],
+            "final_metrics": {"extra": {"model_error_count": 1}},
+        },
+        zcode_outcome={
+            "schema": "dradar-zcode-outcome-v1",
+            "sessionId": "sess_recovered_tool_error",
+            "state": {"projection": {"status": "idle", "turnCount": 1}},
+            "usage": {"modelErrorCount": 1, "modelRequestCount": 94},
+            "notifications": [{
+                "method": "v4/telemetry/event",
+                "params": {"kind": "turn.terminal", "status": "success"},
+            }],
+        },
+        provider_usage_sidecar={
+            "schema": "dradar-subscription-provider-usage-v1",
+            "provider": "zcode",
+            "model": runner_mod.ZCODE_MODEL,
+            "complete": True,
+            "request_count": 93,
+            "request_usage_complete": False,
+            "request_usage_observed": False,
+            "usage_evidence_tier": "aggregate_only",
+            "model_error_count": 1,
+        },
+        runtime_diagnostic={
+            "schema": "dradar-zcode-runtime-v1",
+            "status": "idle",
+            "turn_count": 1,
+            "seen_running": True,
+            "terminal_observed": True,
+        },
+        rc=0,
+    )
+
+    artifact = run_trial(_zcode_assignment_for_trial(), tmp_path, tmp_path)
+
+    assert artifact.returncode == 0
+    assert artifact.patch.read_text(encoding="utf-8") == "diff"
+    assert summarize_result(artifact.result)["n_agent_steps"] == 47
+
+
+def test_run_trial_rejects_zcode_failed_status_despite_completed_usage(
+        tmp_path, monkeypatch):
+    _prepare_fake_zcode(monkeypatch, tmp_path)
+    _fake_pier(
+        monkeypatch,
+        tmp_path,
+        result={"agent_result": {
+            "n_agent_steps": 47,
+            "metadata": {"provider_usage": {
+                "schema": "dradar-subscription-provider-usage-v1",
+                "provider": "zcode",
+                "model": runner_mod.ZCODE_MODEL,
+                "complete": True,
+                "request_count": 93,
+                "request_usage_complete": False,
+                "request_usage_observed": False,
+                "usage_evidence_tier": "aggregate_only",
+            }},
+        }},
+        provider_usage_sidecar={
+            "schema": "dradar-subscription-provider-usage-v1",
+            "provider": "zcode",
+            "model": runner_mod.ZCODE_MODEL,
+            "complete": True,
+            "request_count": 93,
+            "request_usage_complete": False,
+            "request_usage_observed": False,
+            "usage_evidence_tier": "aggregate_only",
+            "model_error_count": 1,
+        },
+        runtime_diagnostic={
+            "schema": "dradar-zcode-runtime-v1",
+            "status": "failed",
+            "turn_count": 1,
+            "seen_running": True,
+            "terminal_observed": True,
+        },
+        rc=0,
+    )
+
+    with pytest.raises(RunnerError, match="terminal_status"):
+        run_trial(_zcode_assignment_for_trial(), tmp_path, tmp_path)
+
+
 def test_run_trial_keeps_zcode_patch_gradeable_when_only_usage_is_incomplete(
         tmp_path, monkeypatch):
     _prepare_fake_zcode(monkeypatch, tmp_path)


### PR DESCRIPTION
## Summary
- accept a ZCode run when a provider-backed turn completed after a recoverable tool error
- keep rejecting terminal failed/error/stopped states
- add regression coverage for both paths

## Tests
- 1077 passed, 5 skipped