### PR TITLE
fix: list leases across benchmark channels

### DIFF
--- a/src/dradar/leases.py
+++ b/src/dradar/leases.py
@@ -24,6 +24,62 @@ def _active(client) -> list[dict]:
     return active
 
 
+def _all_active(client) -> list[dict]:
+    """Return held assignments across every benchmark visible to this user.
+
+    Assignment lookup is intentionally benchmark-scoped for the run loop, but
+    ``leases`` and the interactive release picker are account-wide inventory
+    commands.  Query each advertised benchmark without changing the saved
+    benchmark or the scope used by a later ``resume``.
+
+    Servers old enough to lack the benchmark catalog keep the legacy current-
+    benchmark behavior.  A 403 for one catalog entry means that channel is not
+    runnable by this identity and is skipped; other errors must remain visible
+    rather than presenting a misleading partial inventory.
+    """
+    original_benchmark = getattr(client, "benchmark_id", None)
+    try:
+        try:
+            catalog = client.benchmarks()
+        except ApiError as exc:
+            if exc.status_code == 404:
+                return _active(client)
+            raise
+
+        benchmark_ids = [
+            item.get("id")
+            for item in (catalog.get("benchmarks") or [])
+            if isinstance(item, dict) and item.get("id")
+        ]
+        if original_benchmark and original_benchmark not in benchmark_ids:
+            benchmark_ids.insert(0, original_benchmark)
+        if not benchmark_ids:
+            return _active(client)
+
+        active: list[dict] = []
+        seen: set[str] = set()
+        for benchmark_id in benchmark_ids:
+            client.benchmark_id = benchmark_id
+            try:
+                scoped = _active(client)
+            except ApiError as exc:
+                if exc.status_code == 403:
+                    continue
+                raise
+            for item in scoped:
+                assignment_id = item.get("assignment_id")
+                if assignment_id and assignment_id in seen:
+                    continue
+                copy = dict(item)
+                copy.setdefault("benchmark_id", benchmark_id)
+                active.append(copy)
+                if assignment_id:
+                    seen.add(assignment_id)
+        return active
+    finally:
+        client.benchmark_id = original_benchmark
+
+
 def _expiry(iso: str | None) -> str:
     if not iso:
         return "unknown"
@@ -40,9 +96,12 @@ def _state(assignment: dict) -> str:
 
 def _print_active(active: list[dict]) -> None:
     for index, item in enumerate(active, 1):
+        benchmark = item.get("benchmark_id")
+        benchmark_label = f"  [{benchmark}]" if benchmark else ""
         print(
             f"  {index:>2}. {_state(item):9s}  "
-            f"{item['task_id']}  {item['model']}@{item['effort']}\n"
+            f"{item['task_id']}  {item['model']}@{item['effort']}"
+            f"{benchmark_label}\n"
             f"      {item['assignment_id']}  expires {_expiry(item.get('expires_at'))}"
         )
 
@@ -52,7 +111,7 @@ def cmd_leases(args) -> int:
     cfg = _load_config()
     client = _client(cfg)
     try:
-        active = _active(client)
+        active = _all_active(client)
     except ApiError as exc:
         sys.exit(f"lease check failed: {exc}")
     if not active:
@@ -107,7 +166,7 @@ def cmd_release(args) -> int:
 
     if not explicit and not args.all:
         try:
-            active = _active(client)
+            active = _all_active(client)
         except ApiError as exc:
             sys.exit(f"lease check failed: {exc}")
         if not active:

--- a/tests/test_leases.py
+++ b/tests/test_leases.py
@@ -17,9 +17,13 @@ def _cell(aid, *, started=False):
 
 
 class FakeClient:
-    def __init__(self, active):
+    def __init__(self, active, *, benchmark_id="deep-swe"):
         self.active = active
+        self.benchmark_id = benchmark_id
         self.release_calls = []
+
+    def benchmarks(self):
+        return {"benchmarks": [{"id": self.benchmark_id}]}
 
     def get_assignment(self):
         return {"active": self.active, "free_pick": True}
@@ -76,6 +80,88 @@ def test_started_history_without_healthy_runner_is_resumable_not_running(
     assert "1 running, 1 paused, 1 stale" in out
     assert "a1" in out and "stale" in out
     assert "not actually resumable" in out
+
+
+def test_leases_lists_and_labels_assignments_across_benchmarks(
+    monkeypatch, capsys,
+):
+    class MultiBenchmarkClient(FakeClient):
+        def __init__(self):
+            super().__init__([], benchmark_id="deep-swe")
+            self.by_benchmark = {
+                "deep-swe": [_cell("deep")],
+                "pompeii-adjacency": [{
+                    **_cell("pompeii"),
+                    "task_id": "pompeii-adjacency-rp-044",
+                    "model": "glm-5.3-flash",
+                    "effort": "high",
+                }],
+            }
+
+        def benchmarks(self):
+            return {"benchmarks": [
+                {"id": "deep-swe"}, {"id": "pompeii-adjacency"},
+            ]}
+
+        def get_assignment(self):
+            return {"active": self.by_benchmark[self.benchmark_id]}
+
+    client = MultiBenchmarkClient()
+    _wire(monkeypatch, client)
+
+    assert leases.cmd_leases(Namespace()) == 0
+
+    out = capsys.readouterr().out
+    assert "holding 2 cell(s)" in out
+    assert "task-deep" in out and "[deep-swe]" in out
+    assert "pompeii-adjacency-rp-044" in out
+    assert "glm-5.3-flash@high" in out
+    assert "[pompeii-adjacency]" in out
+    assert client.benchmark_id == "deep-swe"
+
+
+def test_cross_benchmark_inventory_deduplicates_assignment_ids(monkeypatch):
+    class DuplicateClient(FakeClient):
+        def benchmarks(self):
+            return {"benchmarks": [{"id": "deep-swe"}, {"id": "mirror"}]}
+
+        def get_assignment(self):
+            return {"active": [_cell("same")]}
+
+    client = DuplicateClient([_cell("same")])
+    _wire(monkeypatch, client)
+
+    assert len(leases._all_active(client)) == 1
+    assert client.benchmark_id == "deep-swe"
+
+
+def test_cross_benchmark_inventory_skips_inaccessible_channel(monkeypatch):
+    class RestrictedClient(FakeClient):
+        def benchmarks(self):
+            return {"benchmarks": [{"id": "deep-swe"}, {"id": "private"}]}
+
+        def get_assignment(self):
+            if self.benchmark_id == "private":
+                raise leases.ApiError("forbidden", status_code=403)
+            return {"active": [_cell("deep")]}
+
+    client = RestrictedClient([_cell("deep")])
+    _wire(monkeypatch, client)
+
+    assert [item["assignment_id"] for item in leases._all_active(client)] == ["deep"]
+    assert client.benchmark_id == "deep-swe"
+
+
+def test_cross_benchmark_inventory_falls_back_for_legacy_server(monkeypatch):
+    class LegacyClient(FakeClient):
+        def benchmarks(self):
+            raise leases.ApiError("not found", status_code=404)
+
+    client = LegacyClient([_cell("legacy")])
+    _wire(monkeypatch, client)
+
+    assert [item["assignment_id"] for item in leases._all_active(client)] == ["legacy"]
+    assert client.benchmark_id == "deep-swe"
 
 
 def test_release_all_protects_running_without_force(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- make leases aggregate held assignments across every accessible benchmark
- label each lease with its benchmark while preserving the saved resume scope
- use the same account-wide inventory for interactive release selection
- keep compatibility with legacy servers and inaccessible channels

## Verification
- pytest -q
- 1081 passed, 5 skipped