### PR TITLE
fix: retry ZCode network failures and preserve assignment boundary

### DIFF
--- a/src/dradar/assignment_boundary.py
+++ b/src/dradar/assignment_boundary.py
@@ -1,0 +1,351 @@
+"""Persistent assignment-set integrity for one benchmark campaign.
+
+The web-selected assignment IDs are the campaign boundary.  A runner may
+submit an assignment or keep holding it for a later resume, but an unresolved
+ID must never disappear silently between retries.  The state contains public
+assignment metadata and bounded outcome tags only; it never stores nonces,
+credentials, prompts, patches, or trajectories.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
+
+
+SCHEMA_VERSION = 1
+STATE_DIR = "assignment-boundaries"
+SETTLED_OUTCOMES = frozenset({"submitted", "interrupted"})
+_PROCESS_LOCK = threading.Lock()
+
+
+class BoundaryError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class BoundaryReport:
+    expected_ids: frozenset[str]
+    settled_ids: frozenset[str]
+    active_ids: frozenset[str]
+    missing_ids: frozenset[str]
+    unexpected_ids: frozenset[str]
+    outcomes: dict[str, str]
+
+    @property
+    def complete(self) -> bool:
+        return bool(self.expected_ids) and self.expected_ids <= self.settled_ids
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_assignment_id(value: object) -> str | None:
+    if not isinstance(value, str) or not 1 <= len(value) <= 128:
+        return None
+    if any(ch not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:-" for ch in value):
+        return None
+    return value
+
+
+def state_path(home: Path, benchmark_id: str) -> Path:
+    if not isinstance(benchmark_id, str) or not benchmark_id:
+        raise BoundaryError("assignment boundary requires a benchmark ID")
+    digest = hashlib.sha256(benchmark_id.encode("utf-8")).hexdigest()[:20]
+    return home / STATE_DIR / f"{digest}.json"
+
+
+@contextmanager
+def _locked(path: Path) -> Iterator[None]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(
+        path.with_name(f"{path.name}.lock"), os.O_RDWR | os.O_CREAT, 0o600,
+    )
+    if os.fstat(fd).st_size == 0:
+        os.write(fd, b"\0")
+    os.lseek(fd, 0, os.SEEK_SET)
+    windows_lock = False
+    try:
+        try:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        except ImportError:  # pragma: no cover - Windows CI
+            import msvcrt
+
+            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+            windows_lock = True
+        yield
+    finally:
+        if windows_lock:  # pragma: no cover - Windows CI
+            try:
+                import msvcrt
+
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            except OSError:
+                pass
+        else:
+            try:
+                import fcntl
+
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except (ImportError, OSError):
+                pass
+        os.close(fd)
+
+
+def _load(path: Path) -> dict | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(value, dict) or value.get("schema_version") != SCHEMA_VERSION:
+        return None
+    expected = value.get("expected")
+    outcomes = value.get("outcomes")
+    if not isinstance(expected, dict) or not isinstance(outcomes, dict):
+        return None
+    if value.get("strict") not in (None, True, False):
+        return None
+    if any(
+        _safe_assignment_id(key) is None or not isinstance(metadata, dict)
+        for key, metadata in expected.items()
+    ):
+        return None
+    if any(
+        _safe_assignment_id(key) is None
+        or not isinstance(outcome, dict)
+        or not isinstance(outcome.get("outcome"), str)
+        for key, outcome in outcomes.items()
+    ):
+        return None
+    return value
+
+
+def _save(path: Path, state: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    state["updated_at"] = _now()
+    fd, raw_tmp = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp",
+    )
+    tmp = Path(raw_tmp)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(state, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def _entry(assignment: dict) -> tuple[str, dict] | None:
+    assignment_id = _safe_assignment_id(assignment.get("assignment_id"))
+    if assignment_id is None:
+        return None
+    metadata = {}
+    for name in ("task_id", "model", "effort"):
+        value = assignment.get(name)
+        if isinstance(value, str) and 0 < len(value) <= 256:
+            metadata[name] = value
+    return assignment_id, metadata
+
+
+def _active_entries(assignments: list[dict]) -> dict[str, dict]:
+    entries = {}
+    for assignment in assignments:
+        if not isinstance(assignment, dict):
+            continue
+        item = _entry(assignment)
+        if item is not None:
+            entries[item[0]] = item[1]
+    return entries
+
+
+def _report(state: dict, active_ids: set[str]) -> BoundaryReport:
+    expected_ids = frozenset(
+        assignment_id for assignment_id in state.get("expected", {})
+        if _safe_assignment_id(assignment_id) is not None
+    )
+    outcomes = {
+        assignment_id: value.get("outcome")
+        for assignment_id, value in state.get("outcomes", {}).items()
+        if (
+            _safe_assignment_id(assignment_id) is not None
+            and isinstance(value, dict)
+            and isinstance(value.get("outcome"), str)
+        )
+    }
+    settled_ids = frozenset(
+        assignment_id for assignment_id, outcome in outcomes.items()
+        if outcome in SETTLED_OUTCOMES
+    )
+    active = frozenset(active_ids)
+    return BoundaryReport(
+        expected_ids=expected_ids,
+        settled_ids=settled_ids,
+        active_ids=active,
+        missing_ids=frozenset(expected_ids - settled_ids - active),
+        unexpected_ids=frozenset(active - expected_ids),
+        outcomes=outcomes,
+    )
+
+
+def prepare(
+    home: Path,
+    benchmark_id: str,
+    active_assignments: list[dict],
+    *,
+    expected_ids: list[str] | None = None,
+    forget_existing: bool = False,
+) -> Path | None:
+    """Open or create a campaign boundary and reject any unresolved loss."""
+    path = state_path(home, benchmark_id)
+    active = _active_entries(active_assignments)
+    explicit = None
+    if expected_ids is not None:
+        explicit = []
+        for value in expected_ids:
+            assignment_id = _safe_assignment_id(value)
+            if assignment_id is None:
+                raise BoundaryError(f"invalid expected assignment ID: {value!r}")
+            if assignment_id not in explicit:
+                explicit.append(assignment_id)
+    with _PROCESS_LOCK:
+        with _locked(path):
+            if forget_existing:
+                path.unlink(missing_ok=True)
+            state = _load(path)
+            if state is None and path.exists():
+                raise BoundaryError(
+                    "saved assignment boundary is unreadable or has an unsupported schema"
+                )
+            if state is not None and state.get("benchmark_id") != benchmark_id:
+                raise BoundaryError("saved assignment boundary has a benchmark mismatch")
+            if state is not None:
+                report = _report(state, set(active))
+                if report.complete:
+                    path.unlink(missing_ok=True)
+                    state = None
+                else:
+                    if explicit is not None and set(explicit) != set(report.expected_ids):
+                        raise BoundaryError(
+                            "expected assignment IDs differ from the unfinished saved boundary"
+                        )
+                    if report.missing_ids:
+                        missing = ", ".join(sorted(report.missing_ids))
+                        raise BoundaryError(
+                            "unfinished assignment(s) disappeared from active leases: "
+                            f"{missing}"
+                        )
+                    if report.unexpected_ids:
+                        unexpected = ", ".join(sorted(report.unexpected_ids))
+                        raise BoundaryError(
+                            "active assignment(s) are outside the unfinished "
+                            f"boundary: {unexpected}"
+                        )
+                    return path
+            selected = explicit if explicit is not None else list(active)
+            if not selected:
+                return None
+            missing = sorted(set(selected) - set(active))
+            if missing:
+                raise BoundaryError(
+                    "expected assignment(s) are not active: " + ", ".join(missing)
+                )
+            unexpected = sorted(set(active) - set(selected))
+            if explicit is not None and unexpected:
+                raise BoundaryError(
+                    "active assignment(s) are outside the explicit boundary: "
+                    + ", ".join(unexpected)
+                )
+            now = _now()
+            state = {
+                "schema_version": SCHEMA_VERSION,
+                "benchmark_id": benchmark_id,
+                "created_at": now,
+                "updated_at": now,
+                "strict": explicit is not None,
+                "expected": {assignment_id: active[assignment_id] for assignment_id in selected},
+                "outcomes": {},
+            }
+            _save(path, state)
+            return path
+
+
+def add_expected(path: Path | None, assignments: list[dict]) -> None:
+    if path is None:
+        return
+    entries = _active_entries(assignments)
+    if not entries:
+        return
+    with _PROCESS_LOCK:
+        with _locked(path):
+            state = _load(path)
+            if state is None:
+                raise BoundaryError("assignment boundary state is missing or invalid")
+            unexpected = sorted(set(entries) - set(state["expected"]))
+            if state.get("strict") is True and unexpected:
+                raise BoundaryError(
+                    "assignment(s) are outside the explicit boundary: "
+                    + ", ".join(unexpected)
+                )
+            state["expected"].update(entries)
+            _save(path, state)
+
+
+def record_outcome(path: Path | None, assignment: dict, outcome: str) -> None:
+    if path is None:
+        return
+    item = _entry(assignment)
+    if item is None or not isinstance(outcome, str) or not 1 <= len(outcome) <= 64:
+        raise BoundaryError("cannot record an invalid assignment outcome")
+    assignment_id, metadata = item
+    with _PROCESS_LOCK:
+        with _locked(path):
+            state = _load(path)
+            if state is None:
+                raise BoundaryError("assignment boundary state is missing or invalid")
+            if assignment_id not in state["expected"]:
+                raise BoundaryError(
+                    f"assignment {assignment_id} is outside the saved boundary"
+                )
+            state["outcomes"][assignment_id] = {
+                "outcome": outcome,
+                "updated_at": _now(),
+            }
+            _save(path, state)
+
+
+def reconcile(path: Path | None, active_assignments: list[dict]) -> BoundaryReport | None:
+    if path is None:
+        return None
+    active = set(_active_entries(active_assignments))
+    with _PROCESS_LOCK:
+        with _locked(path):
+            state = _load(path)
+            if state is None:
+                raise BoundaryError("assignment boundary state is missing or invalid")
+            return _report(state, active)
+
+
+def finish_if_complete(path: Path | None, report: BoundaryReport | None) -> None:
+    if path is None or report is None or not report.complete:
+        return
+    with _PROCESS_LOCK:
+        with _locked(path):
+            current = _load(path)
+            if current is not None and _report(current, set()).complete:
+                path.unlink(missing_ok=True)

--- a/src/dradar/cli.py
+++ b/src/dradar/cli.py
@@ -310,6 +310,16 @@ def main(argv: list[str] | None = None) -> int:
             "--allow-task-drift", action="store_true",
             help="run even if your deep-swe checkout differs from the server's pinned version",
         )
+        p.add_argument(
+            "--expect-assignment", action="append", metavar="ID",
+            help="require this assignment ID to be present before any model starts "
+                 "(repeatable; the set is persisted across resume)",
+        )
+        p.add_argument(
+            "--forget-assignment-boundary", action="store_true",
+            help="explicitly discard a saved missing-assignment guard before "
+                 "starting a new boundary",
+        )
         p.add_argument("--dev-agent", help=argparse.SUPPRESS)  # oracle/nop for pipeline tests
         p.add_argument(
             "--parallel", action="store_true",

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -24,8 +24,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from . import (
-    __version__, artifact_staging, checkpoints, egress, failure_circuit,
-    image_cache, pending, refill as refill_plan,
+    __version__, artifact_staging, assignment_boundary, checkpoints, egress,
+    failure_circuit, image_cache, pending, refill as refill_plan,
 )
 from .api_client import ApiClient, ApiError
 from .identity import _client
@@ -96,6 +96,7 @@ _ACCOUNT_TERMINAL_OUTCOMES = {
 _POOL_ABORT_ENV = "DRADAR_POOL_ABORT_FILE"
 _POOL_TARGET_FILE_ENV = "DRADAR_POOL_TARGET_FILE"
 _REPEAT_FAILURE_STATE_ENV = "DRADAR_REPEAT_FAILURE_STATE_FILE"
+_ASSIGNMENT_BOUNDARY_ENV = "DRADAR_ASSIGNMENT_BOUNDARY_FILE"
 _POOL_DRAIN_PREFIX = "drain:"
 _POOL_SUPERVISOR_POLL_SECONDS = 0.2
 _POOL_BACKFILL_REFRESH_SECONDS = 2.0
@@ -107,6 +108,17 @@ _CHECKPOINT_BACKOFF_BASE_SECONDS = 30.0
 _CHECKPOINT_BACKOFF_MAX_SECONDS = 600.0
 _CHECKPOINT_RESUME_REPLAY_ATTEMPTS = 3
 _CHECKPOINT_RESUME_REPLAY_DELAY_SECONDS = 0.25
+_ZCODE_NETWORK_RETRY_DELAY_SECONDS = 2.0
+
+
+def _retryable_zcode_network_failure(assignment: dict, exc: RunnerError) -> bool:
+    diagnostic = exc.failure_diagnostic
+    return bool(
+        assignment.get("agent") == ZCODE_AGENT
+        and isinstance(diagnostic, dict)
+        and diagnostic.get("schema") == "dradar-runner-failure-v1"
+        and diagnostic.get("zcode_provider_failure_reason") == "network_error"
+    )
 
 
 @dataclass(frozen=True)
@@ -2232,6 +2244,26 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
                       f"checkpoint {item.checkpoint_id} was kept; `dradar resume` "
                       "continues the same workspace/session")
                 return terminal_outcome or "paused"
+            if attempt == 1 and _retryable_zcode_network_failure(assignment, exc):
+                stopped = _mark_stopped_quietly(
+                    client,
+                    assignment,
+                    defer_seconds=0,
+                    failure_kind="provider-transport",
+                    failure_diagnostic=exc.failure_diagnostic,
+                )
+                if stopped:
+                    print(
+                        "ZCode reported a structured transient network failure; "
+                        "retrying this assignment once in the same runner..."
+                    )
+                    time.sleep(_ZCODE_NETWORK_RETRY_DELAY_SECONDS)
+                    continue
+                print(
+                    "ZCode reported a transient network failure, but checkout "
+                    "cleanup was not confirmed; refusing an unsafe retry"
+                )
+                return "failed"
             print(f"trial failed: {exc}\n"
                   "use `dradar resume` to retry later, or `dradar release` to "
                   "give the cell back")
@@ -2592,6 +2624,110 @@ def _active_by_id(client: ApiClient) -> dict[str, dict]:
     return {a["assignment_id"]: a for a in active if a}
 
 
+def _assignment_boundary_path(args) -> Path | None:
+    value = getattr(args, "_assignment_boundary_path", None)
+    if value:
+        return Path(value)
+    value = os.environ.get(_ASSIGNMENT_BOUNDARY_ENV)
+    return Path(value) if value else None
+
+
+def _prepare_assignment_boundary(
+    args,
+    client: ApiClient,
+    benchmark_id: str,
+    active: list[dict] | None = None,
+) -> Path | None:
+    """Validate/create the immutable non-refill assignment campaign set."""
+    inherited = _assignment_boundary_path(args)
+    if inherited is not None:
+        args._assignment_boundary_path = str(inherited)
+        return inherited
+    if getattr(args, "refill", False):
+        return None
+    if active is None:
+        try:
+            active = list(_active_by_id(client).values())
+        except ApiError as exc:
+            _exit_for(exc)
+    try:
+        path = assignment_boundary.prepare(
+            HOME,
+            benchmark_id,
+            active,
+            expected_ids=getattr(args, "expect_assignment", None),
+            forget_existing=getattr(args, "forget_assignment_boundary", False),
+        )
+    except (assignment_boundary.BoundaryError, OSError) as exc:
+        sys.exit(
+            f"assignment boundary check failed: {exc}. No model was started. "
+            "Inspect `dradar leases`; use --forget-assignment-boundary only "
+            "after intentionally accepting the missing assignment(s)."
+        )
+    if path is not None:
+        args._assignment_boundary_path = str(path)
+    return path
+
+
+def _record_assignment_boundary(args, assignment: dict, outcome: str) -> bool:
+    path = _assignment_boundary_path(args)
+    if path is None:
+        return True
+    try:
+        assignment_boundary.record_outcome(path, assignment, outcome)
+    except (assignment_boundary.BoundaryError, OSError) as exc:
+        # The model has already stopped at this point. Fail closed on the next
+        # checkout by opening the same pool drain used for other local faults.
+        _signal_pool_abort(
+            f"assignment boundary state could not be updated ({exc})",
+            interrupt_siblings=False,
+        )
+        print(f"assignment boundary update failed ({exc}); no later task will start")
+        return False
+    return True
+
+
+def _finish_assignment_boundary(
+    client: ApiClient, path: Path | None,
+) -> bool:
+    """Reconcile after a run; False means the campaign lost an assignment."""
+    if path is None:
+        return True
+    try:
+        active = list(_active_by_id(client).values())
+        report = assignment_boundary.reconcile(path, active)
+    except (ApiError, assignment_boundary.BoundaryError, OSError) as exc:
+        print(
+            f"could not verify the assignment boundary after the run ({exc}); "
+            "the boundary was kept and the next resume will re-check it"
+        )
+        return False
+    if report is None:
+        return True
+    if report.missing_ids:
+        print("assignment boundary violation: unresolved assignment(s) disappeared:")
+        for assignment_id in sorted(report.missing_ids):
+            print(f"  {assignment_id}")
+        print("no replacement task was claimed or started")
+        return False
+    if report.unexpected_ids:
+        print("assignment boundary violation: active assignment(s) are outside the campaign:")
+        for assignment_id in sorted(report.unexpected_ids):
+            print(f"  {assignment_id}")
+        print("no out-of-bound assignment was started")
+        return False
+    if report.complete:
+        try:
+            assignment_boundary.finish_if_complete(path, report)
+        except OSError as exc:
+            print(
+                f"could not remove the completed assignment boundary ({exc}); "
+                "the next resume will verify it again"
+            )
+            return False
+    return True
+
+
 def _checkpoint_upload_entry(
     item: checkpoints.Checkpoint, assignment: dict, args, local_commit: str | None,
 ) -> dict:
@@ -2949,7 +3085,17 @@ def _resume_local_checkpoints(
         )
         if outcome == "busy":
             continue
+        boundary_recorded = _record_assignment_boundary(
+            args,
+            active.get(item.assignment_id) or {
+                "assignment_id": item.assignment_id,
+                "task_id": getattr(item, "task_id", "unknown"),
+            },
+            outcome,
+        )
         results.append(outcome)
+        if not boundary_recorded:
+            break
         if outcome == "submitted" and getattr(args, "refill", False):
             refill_plan.mark_submitted(HOME, item.assignment_id)
         if outcome in _ACCOUNT_TERMINAL_OUTCOMES:
@@ -3268,6 +3414,8 @@ def cmd_go(args) -> int:
         workers != 1
         or not getattr(args, "parallel", False)
         or not getattr(args, "resume", False)
+        or getattr(args, "expect_assignment", None)
+        or getattr(args, "forget_assignment_boundary", False)
     ):
         sys.exit("invalid internal worker invocation")
     if (auto_workers or workers > 1) and getattr(args, "parallel", False):
@@ -3291,6 +3439,11 @@ def cmd_go(args) -> int:
     if any(value is not None for value in refill_options) and not getattr(args, "refill", False):
         sys.exit("refill limits and scope filters require --refill")
     if getattr(args, "refill", False):
+        if (
+            getattr(args, "expect_assignment", None)
+            or getattr(args, "forget_assignment_boundary", False)
+        ):
+            sys.exit("assignment boundary options cannot be combined with --refill")
         if getattr(args, "assignment", None):
             sys.exit("continuous refill cannot be combined with --assignment")
         if (getattr(args, "refill_harness", None) is None
@@ -3394,6 +3547,10 @@ def cmd_go(args) -> int:
         if not getattr(args, "worker_child", False):
             _retry_pending_uploads(client)
 
+        boundary_path = _prepare_assignment_boundary(
+            args, client, cfg["benchmark"],
+        )
+
         recovered, found_checkpoints = _resume_local_checkpoints(
             client, args, tasks_root, telemetry,
         )
@@ -3403,9 +3560,11 @@ def cmd_go(args) -> int:
         )
         if getattr(args, "assignment", None):
             close_reason = "completed" if recovery_ok and recovered else "paused"
-            return 0 if recovery_ok and recovered else 1
+            rc = 0 if recovery_ok and recovered else 1
+            return rc if _finish_assignment_boundary(client, boundary_path) else 1
         if recovered and not recovery_ok:
             close_reason = "paused"
+            _finish_assignment_boundary(client, boundary_path)
             return 1
         if found_checkpoints and getattr(args, "resume", False) and not recovered:
             # Every matching checkpoint is already owned by another local
@@ -3420,11 +3579,14 @@ def cmd_go(args) -> int:
                       "checking for a different waiting task")
             else:
                 close_reason = "paused"
+                _finish_assignment_boundary(client, boundary_path)
                 return 1
 
         rc = _go_menu(args, cfg, client, tasks_root, telemetry=telemetry)
         if not getattr(args, "parallel", False):
             _maintain_image_cache(client, cfg, phase="after run")
+        if not _finish_assignment_boundary(client, _assignment_boundary_path(args)):
+            rc = 1
         close_reason = "completed" if rc == 0 else "paused"
         return rc
     except (KeyboardInterrupt, EOFError):
@@ -3692,6 +3854,11 @@ def _run_worker_pool(args) -> int:
     active, _free_pick = _prepare_batch(args, client)
     if not active:
         return 0
+    boundary_path = _assignment_boundary_path(args)
+    if cfg.get("benchmark"):
+        boundary_path = _prepare_assignment_boundary(
+            args, client, cfg["benchmark"], active,
+        )
     maximum = args.workers
     target_file = _pool_target_file(args)
     target = _read_pool_target(target_file, default=maximum, maximum=maximum)
@@ -3739,6 +3906,8 @@ def _run_worker_pool(args) -> int:
             env[_POOL_TARGET_FILE_ENV] = str(target_file)
         env[_POOL_ABORT_ENV] = str(pool_abort_file)
         env[_REPEAT_FAILURE_STATE_ENV] = str(repeat_failure_state_file)
+        if boundary_path is not None:
+            env[_ASSIGNMENT_BOUNDARY_ENV] = str(boundary_path)
         process = subprocess.Popen(command, env=env, **popen_kwargs)
         processes.append(process)
         active_processes[slot] = process
@@ -3874,6 +4043,9 @@ def _run_worker_pool(args) -> int:
     cleanup_abort_file()
     failed = [(slot, rc) for slot, rc in returncodes if rc != 0]
     _maintain_image_cache(client, cfg, phase="after worker pool")
+    boundary_safe = _finish_assignment_boundary(client, boundary_path)
+    if not boundary_safe:
+        return 1
     if abort_reason is not None:
         if abort_interrupts_siblings:
             print(f"worker pool stopped cleanly by circuit breaker: {abort_reason}")
@@ -4007,9 +4179,12 @@ def _run_batch(args, client: ApiClient, tasks_root: Path, active: list[dict],
             telemetry.flush()
         outcome = _run_and_submit(
             client, assignment, tasks_root, args, local_commit, telemetry=telemetry)
+        boundary_recorded = _record_assignment_boundary(args, assignment, outcome)
         results.append(outcome)
         if telemetry:
             telemetry.set_phase("queued")
+        if not boundary_recorded:
+            break
         if outcome in _ACCOUNT_TERMINAL_OUTCOMES:
             _announce_account_stop(outcome)
             break
@@ -4111,6 +4286,21 @@ def _run_checkout_loop(args, client: ApiClient, tasks_root: Path,
                   "it already failed in this session. `dradar resume` retries it "
                   "later; `dradar release` gives it back.")
             break
+        try:
+            assignment_boundary.add_expected(
+                _assignment_boundary_path(args), [assignment],
+            )
+        except (assignment_boundary.BoundaryError, OSError) as exc:
+            _mark_stopped_quietly(
+                client, assignment, defer_seconds=0,
+                failure_kind="runner_failed",
+            )
+            print(
+                f"refusing to start {assignment['assignment_id']}: {exc}. "
+                "The checkout stamp was returned and the worker is stopping."
+            )
+            results.append("assignment-boundary-failed")
+            break
         extra = data.get("unstarted")
         if telemetry:
             telemetry.bind_batch(assignment.get("batch_id"))
@@ -4128,8 +4318,12 @@ def _run_checkout_loop(args, client: ApiClient, tasks_root: Path,
                   "the cell just reopens for someone else and nothing is counted.")
         outcome = _run_and_submit(
             client, assignment, tasks_root, args, local_commit, telemetry=telemetry)
+        boundary_recorded = _record_assignment_boundary(args, assignment, outcome)
         if telemetry:
             telemetry.set_phase("queued")
+        if not boundary_recorded:
+            results.append(outcome)
+            break
         if outcome in _ACCOUNT_TERMINAL_OUTCOMES:
             if getattr(args, "refill", False):
                 refill_plan.stop(HOME, f"account stop: {outcome}")
@@ -4469,6 +4663,16 @@ def _go_menu(args, cfg: dict, client: ApiClient, tasks_root: Path,
     active, free_pick = _prepare_batch(args, client)
     if not active:
         return 0
+    boundary_path = _assignment_boundary_path(args)
+    if cfg.get("benchmark"):
+        boundary_path = _prepare_assignment_boundary(
+            args, client, cfg["benchmark"], active,
+        )
+        try:
+            assignment_boundary.add_expected(boundary_path, active)
+        except (assignment_boundary.BoundaryError, OSError) as exc:
+            print(f"assignment boundary check failed: {exc}. No model was started.")
+            return 1
     if telemetry:
         telemetry.bind_batch(active[0].get("batch_id"))
     # Non-interactive free-pick runs go through the parallel-safe checkout
@@ -4498,6 +4702,14 @@ def _go_menu(args, cfg: dict, client: ApiClient, tasks_root: Path,
         if not fresh:
             break
         seen.update(a["assignment_id"] for a in fresh)
+        try:
+            assignment_boundary.add_expected(boundary_path, fresh)
+        except (assignment_boundary.BoundaryError, OSError) as exc:
+            print(
+                f"could not extend the assignment boundary ({exc}); "
+                "the newly claimed task(s) were left untouched"
+            )
+            return 1
         print(f"\n{len(fresh)} more cell(s) were claimed while that batch ran — continuing:")
         rc = _run_batch(args, client, tasks_root, fresh, telemetry=telemetry)
     return rc

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -2603,6 +2603,46 @@ def _zcode_runtime_diagnostic(jobs_dir: Path, job_name: str) -> dict[str, object
     }
 
 
+def _zcode_provider_failure_facts(outcome_path: Path | None) -> dict[str, object]:
+    """Return bounded transport facts from the last structured ZCode failure.
+
+    Provider messages and request identifiers may contain private data, so the
+    runner exposes only the small enum/number/bool set needed for retry policy.
+    """
+    payload = _read_capped_json_object(
+        outcome_path, _ZCODE_TERMINAL_ARTIFACT_MAX_BYTES,
+    )
+    if payload.get("schema") != "dradar-zcode-outcome-v1":
+        return {}
+    events_object = payload.get("events")
+    events = events_object.get("events") if isinstance(events_object, dict) else None
+    if not isinstance(events, list) or len(events) > 5000:
+        return {}
+    result: dict[str, object] = {}
+    for event in events:
+        if not isinstance(event, dict) or event.get("type") != "session.updated":
+            continue
+        value = event.get("payload")
+        if not isinstance(value, dict) or value.get("type") != "model_request_failed":
+            continue
+        # Only the latest structured model failure controls retry policy. Do
+        # not accidentally combine fields from two different requests.
+        result = {}
+        reason = value.get("reason")
+        if reason in {
+            "network_error", "rate_limited", "authentication_error",
+            "permission_denied", "provider_error", "unknown",
+        }:
+            result["zcode_provider_failure_reason"] = reason
+        status = value.get("statusCode")
+        if isinstance(status, int) and not isinstance(status, bool) and 0 <= status <= 999:
+            result["zcode_provider_status_code"] = status
+        retryable = value.get("retryable")
+        if isinstance(retryable, bool):
+            result["zcode_provider_retryable"] = retryable
+    return result
+
+
 def _zcode_failure_diagnostic(
     assignment: dict,
     task_path: Path,
@@ -2632,6 +2672,12 @@ def _zcode_failure_diagnostic(
         diagnostic["task_agent_timeout_sec"] = int(base_timeout)
         diagnostic["pier_agent_timeout_sec"] = int(math.ceil(base_timeout * multiplier))
     diagnostic.update(_zcode_runtime_diagnostic(jobs_dir, job_name))
+    try:
+        outcomes = list((jobs_dir / job_name).glob("*/agent/zcode-outcome.json"))
+    except OSError:
+        outcomes = []
+    if len(outcomes) == 1:
+        diagnostic.update(_zcode_provider_failure_facts(outcomes[0]))
     return diagnostic
 
 

--- a/tests/test_assignment_boundary.py
+++ b/tests/test_assignment_boundary.py
@@ -1,0 +1,146 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from dradar import assignment_boundary
+from dradar import runloop
+
+
+def _assignment(assignment_id: str, task_id: str | None = None) -> dict:
+    return {
+        "assignment_id": assignment_id,
+        "task_id": task_id or f"task-{assignment_id}",
+        "model": "glm-5.3-flash",
+        "effort": "low",
+    }
+
+
+def test_boundary_detects_unresolved_assignment_disappearing(tmp_path):
+    active = [_assignment("a1"), _assignment("a2")]
+    path = assignment_boundary.prepare(tmp_path, "bench", active)
+
+    with pytest.raises(
+        assignment_boundary.BoundaryError,
+        match="disappeared.*a2",
+    ):
+        assignment_boundary.prepare(tmp_path, "bench", [active[0]])
+
+    assert path is not None and path.is_file()
+
+
+def test_submitted_assignment_may_leave_active_leases(tmp_path):
+    active = [_assignment("a1"), _assignment("a2")]
+    path = assignment_boundary.prepare(tmp_path, "bench", active)
+    assignment_boundary.record_outcome(path, active[0], "submitted")
+
+    report = assignment_boundary.reconcile(path, [active[1]])
+
+    assert report is not None
+    assert report.missing_ids == frozenset()
+    assert report.settled_ids == frozenset({"a1"})
+    assert not report.complete
+
+
+def test_complete_boundary_is_removed(tmp_path):
+    active = [_assignment("a1"), _assignment("a2")]
+    path = assignment_boundary.prepare(tmp_path, "bench", active)
+    assignment_boundary.record_outcome(path, active[0], "submitted")
+    assignment_boundary.record_outcome(path, active[1], "interrupted")
+    report = assignment_boundary.reconcile(path, [])
+
+    assert report is not None and report.complete
+    assignment_boundary.finish_if_complete(path, report)
+    assert path is not None and not path.exists()
+
+
+def test_explicit_boundary_requires_every_expected_id(tmp_path):
+    with pytest.raises(
+        assignment_boundary.BoundaryError,
+        match="not active.*a2",
+    ):
+        assignment_boundary.prepare(
+            tmp_path,
+            "bench",
+            [_assignment("a1")],
+            expected_ids=["a1", "a2"],
+        )
+
+
+def test_explicit_boundary_rejects_unlisted_active_assignment(tmp_path):
+    with pytest.raises(
+        assignment_boundary.BoundaryError,
+        match="outside the explicit boundary.*a2",
+    ):
+        assignment_boundary.prepare(
+            tmp_path,
+            "bench",
+            [_assignment("a1"), _assignment("a2")],
+            expected_ids=["a1"],
+        )
+
+
+def test_strict_boundary_cannot_be_extended_after_creation(tmp_path):
+    path = assignment_boundary.prepare(
+        tmp_path,
+        "bench",
+        [_assignment("a1")],
+        expected_ids=["a1"],
+    )
+
+    with pytest.raises(
+        assignment_boundary.BoundaryError,
+        match="outside the explicit boundary.*a2",
+    ):
+        assignment_boundary.add_expected(path, [_assignment("a2")])
+
+
+def test_forget_replaces_only_the_named_benchmark_boundary(tmp_path):
+    old = [_assignment("old")]
+    path = assignment_boundary.prepare(tmp_path, "bench", old)
+    replacement = [_assignment("new")]
+
+    new_path = assignment_boundary.prepare(
+        tmp_path,
+        "bench",
+        replacement,
+        expected_ids=["new"],
+        forget_existing=True,
+    )
+
+    assert new_path == path
+    payload = json.loads(path.read_text())
+    assert set(payload["expected"]) == {"new"}
+    assert "nonce" not in path.read_text()
+
+
+def test_corrupt_boundary_fails_closed_without_explicit_forget(tmp_path):
+    path = assignment_boundary.state_path(tmp_path, "bench")
+    path.parent.mkdir(parents=True)
+    path.write_text("not-json")
+
+    with pytest.raises(assignment_boundary.BoundaryError, match="unreadable"):
+        assignment_boundary.prepare(tmp_path, "bench", [_assignment("a1")])
+
+
+def test_runloop_reconciliation_reports_a_lost_assignment(
+        tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    active = [_assignment("a1"), _assignment("a2")]
+    args = SimpleNamespace(
+        refill=False,
+        expect_assignment=None,
+        forget_assignment_boundary=False,
+    )
+
+    class Client:
+        def get_assignment(self):
+            return {"active": [active[0]]}
+
+    path = runloop._prepare_assignment_boundary(
+        args, Client(), "bench", active,
+    )
+
+    assert runloop._finish_assignment_boundary(Client(), path) is False
+    assert "a2" in capsys.readouterr().out
+    assert path is not None and path.is_file()

--- a/tests/test_diagnosis.py
+++ b/tests/test_diagnosis.py
@@ -497,6 +497,73 @@ def test_failed_trial_reports_only_structured_failure_diagnostic(
     assert "secret" not in json.dumps(stopped[0][1])
 
 
+def test_zcode_structured_network_failure_retries_once_serially(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
+    monkeypatch.setattr(runloop, "_ZCODE_NETWORK_RETRY_DELAY_SECONDS", 0)
+    assignment = {**ASSIGNMENT, "agent": "zcode"}
+    diagnostic = {
+        "schema": "dradar-runner-failure-v1",
+        "failure_code": "agent_no_artifact",
+        "zcode_provider_failure_reason": "network_error",
+        "zcode_provider_retryable": False,
+    }
+    art = _fake_art(tmp_path, rc=0)
+    calls = []
+
+    def transient_then_success(*args, **kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            raise RunnerError(
+                "redacted ZCode terminal failure",
+                failure_diagnostic=diagnostic,
+            )
+        return art
+
+    monkeypatch.setattr(runloop, "run_trial", transient_then_success)
+    stopped = []
+    client = SubmitClient({})
+    client.mark_stopped = lambda aid, **kw: stopped.append((aid, kw))
+
+    assert runloop._run_and_submit(
+        client, assignment, tmp_path, _args(), "abc",
+    ) == "submitted"
+    assert len(calls) == 2
+    assert stopped == [(assignment["assignment_id"], {
+        "defer_seconds": 0,
+        "failure_kind": "provider-transport",
+        "failure_diagnostic": diagnostic,
+    })]
+
+
+def test_zcode_network_retry_is_bounded_to_two_total_attempts(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
+    monkeypatch.setattr(runloop, "_ZCODE_NETWORK_RETRY_DELAY_SECONDS", 0)
+    assignment = {**ASSIGNMENT, "agent": "zcode"}
+    diagnostic = {
+        "schema": "dradar-runner-failure-v1",
+        "failure_code": "agent_no_artifact",
+        "zcode_provider_failure_reason": "network_error",
+    }
+    calls = []
+
+    def always_fails(*args, **kwargs):
+        calls.append(1)
+        raise RunnerError("redacted failure", failure_diagnostic=diagnostic)
+
+    monkeypatch.setattr(runloop, "run_trial", always_fails)
+    stopped = []
+    client = SubmitClient({})
+    client.mark_stopped = lambda aid, **kw: stopped.append((aid, kw))
+
+    assert runloop._run_and_submit(
+        client, assignment, tmp_path, _args(), "abc",
+    ) == "failed"
+    assert len(calls) == 2
+    assert [entry[1]["defer_seconds"] for entry in stopped] == [0, 300]
+
+
 def test_user_interrupt_without_checkpoint_reports_stopped_to_server(
         monkeypatch, tmp_path):
     monkeypatch.setattr(runloop, "HOME", tmp_path / "home")

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -1089,6 +1089,65 @@ def test_zcode_terminal_reader_rejects_oversized_json_without_loading_it(
     ) == {}
 
 
+def test_zcode_provider_failure_reader_exposes_only_bounded_network_facts(
+        tmp_path):
+    outcome = tmp_path / "zcode-outcome.json"
+    outcome.write_text(json.dumps({
+        "schema": "dradar-zcode-outcome-v1",
+        "events": {"events": [{
+            "type": "session.updated",
+            "payload": {
+                "type": "model_request_failed",
+                "reason": "network_error",
+                "statusCode": 0,
+                "retryable": False,
+                "message": "secret provider message",
+                "requestId": "secret-request-id",
+            },
+        }]},
+    }))
+
+    assert runner_mod._zcode_provider_failure_facts(outcome) == {
+        "zcode_provider_failure_reason": "network_error",
+        "zcode_provider_status_code": 0,
+        "zcode_provider_retryable": False,
+    }
+
+
+def test_zcode_failure_diagnostic_carries_structured_network_reason(
+        tmp_path):
+    task = tmp_path / "task"
+    task.mkdir()
+    outcome = tmp_path / "jobs" / "job" / "trial" / "agent" / "zcode-outcome.json"
+    outcome.parent.mkdir(parents=True)
+    outcome.write_text(json.dumps({
+        "schema": "dradar-zcode-outcome-v1",
+        "events": {"events": [{
+            "type": "session.updated",
+            "payload": {
+                "type": "model_request_failed",
+                "reason": "network_error",
+                "statusCode": 0,
+                "retryable": False,
+            },
+        }]},
+    }))
+    assignment = {
+        "agent": runner_mod.ZCODE_AGENT,
+        "model": runner_mod.ZCODE_MODEL,
+        "effort": "low",
+        "est_minutes": 30,
+    }
+
+    diagnostic = runner_mod._zcode_failure_diagnostic(
+        assignment, task, tmp_path / "jobs", "job", "agent_no_artifact",
+    )
+
+    assert diagnostic is not None
+    assert diagnostic["zcode_provider_failure_reason"] == "network_error"
+    assert diagnostic["zcode_provider_retryable"] is False
+
+
 def test_zcode_real_redacted_1308_fixture_is_account_quota_terminal() -> None:
     fixture = Path(__file__).with_name("fixtures") / "zcode_quota_1308_outcome.json"
 

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -16,6 +16,14 @@ def _enable_checkpoint_runtime_for_worker_mechanics(monkeypatch):
     monkeypatch.setattr(
         runloop, "durable_checkpoint_rollout_enabled", lambda: True,
     )
+    # Pool mechanics tests use clients intentionally stripped of API methods.
+    # Boundary integration has its own state/reconciliation coverage.
+    monkeypatch.setattr(
+        runloop, "_prepare_assignment_boundary", lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        runloop, "_finish_assignment_boundary", lambda *_a, **_k: True,
+    )
 
 
 def _args(**overrides):
@@ -50,6 +58,18 @@ def test_cli_parses_archive_session_as_explicit_opt_in(monkeypatch):
     monkeypatch.setattr(cli, "cmd_go", lambda args: seen.append(args) or 0)
     assert cli.main(["go", "--archive-session", "-y"]) == 0
     assert seen[0].archive_session is True
+
+
+def test_cli_parses_repeatable_expected_assignment_boundary(monkeypatch):
+    seen = []
+    monkeypatch.setattr(cli, "cmd_go", lambda args: seen.append(args) or 0)
+
+    assert cli.main([
+        "resume", "-y",
+        "--expect-assignment", "a1",
+        "--expect-assignment", "a2",
+    ]) == 0
+    assert seen[0].expect_assignment == ["a1", "a2"]
 
 
 @pytest.mark.parametrize("workers", [0, 41])
@@ -156,6 +176,15 @@ def test_refill_pool_cannot_start_at_zero_workers(tmp_path):
 def test_refill_without_any_limit_is_rejected_before_setup():
     with pytest.raises(SystemExit, match="requires --max-estimated-quota-pct"):
         runloop.cmd_go(_args(refill=True))
+
+
+def test_refill_rejects_fixed_assignment_boundary_options():
+    with pytest.raises(SystemExit, match="cannot be combined with --refill"):
+        runloop.cmd_go(_args(
+            refill=True,
+            max_tasks=2,
+            expect_assignment=["a1"],
+        ))
 
 
 def test_worker_command_never_forwards_auto_selection():
@@ -391,6 +420,14 @@ def _patch_pool_setup(monkeypatch, active_count=5):
         runloop, "_prepare_batch",
         lambda _args, _client: ([{"assignment_id": str(i)} for i in range(active_count)], True),
     )
+    monkeypatch.setattr(
+        runloop, "_prepare_assignment_boundary",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        runloop, "_finish_assignment_boundary",
+        lambda *_args, **_kwargs: True,
+    )
 
 
 def test_auto_workers_use_capacity_recommendation(monkeypatch, capsys):
@@ -413,6 +450,31 @@ def test_auto_workers_use_capacity_recommendation(monkeypatch, capsys):
     assert runloop._run_worker_pool(_args(workers="auto")) == 0
     assert len(calls) == 2
     assert "auto=2" in capsys.readouterr().out
+
+
+def test_worker_parent_passes_one_shared_assignment_boundary_to_children(
+        monkeypatch, tmp_path):
+    _patch_pool_setup(monkeypatch, active_count=2)
+    boundary = tmp_path / "boundary.json"
+    monkeypatch.setattr(
+        runloop, "_prepare_assignment_boundary",
+        lambda *_args, **_kwargs: boundary,
+    )
+    calls = []
+    monkeypatch.setattr(
+        runloop.subprocess,
+        "Popen",
+        lambda command, env, **kwargs: (
+            calls.append(_Process(command, env, **kwargs)) or calls[-1]
+        ),
+    )
+
+    assert runloop._run_worker_pool(_args(workers=2)) == 0
+    assert len(calls) == 2
+    assert {
+        process.env[runloop._ASSIGNMENT_BOUNDARY_ENV]
+        for process in calls
+    } == {str(boundary)}
 
 
 def test_one_claim_auto_workers_refill_to_detected_concurrency(monkeypatch):


### PR DESCRIPTION
修复两个相关的运行可靠性问题：对 ZCode 的结构化 network_error 在同一父级 resume 内执行一次有界重试；持久化并校验明确的 assignment 边界，避免异常释放后任务静默丢失或混入旧 waiting。新增 --expect-assignment 与边界恢复控制，保持不启动第二个父级 resume。验证：1097 passed, 5 skipped；git diff --check 通过。