### PR TITLE
fix: guard ZCode Pompeii patch uploads

### DIFF
--- a/src/dradar/patch_guard.py
+++ b/src/dradar/patch_guard.py
@@ -1,0 +1,233 @@
+"""Narrow pre-upload checks for schema-only benchmark submissions.
+
+Pompeii tasks declare ``model_answer.json`` as their sole deliverable.  A
+multi-megabyte patch therefore cannot be a legitimate answer: it means an
+agent committed an input image, cache, log, or another intermediate artifact.
+Inspect the patch locally so the volunteer sees the offending files before a
+request reaches the server's body-size limit.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from dataclasses import dataclass
+
+
+POMPEII_DELIVERABLE = "model_answer.json"
+# A valid Pompeii answer has at most 15 tiny edge objects.  Leave two orders of
+# magnitude of headroom for diff metadata and formatting while still catching
+# accidental generated artifacts far below the server's 5 MiB hard limit.
+POMPEII_PATCH_MAX_BYTES = 64 * 1024
+PATCH_REPORT_FILE_LIMIT = 20
+
+
+@dataclass(frozen=True)
+class PatchFile:
+    source_path: str
+    target_path: str
+    patch_bytes: int
+    binary: bool
+    added_lines: int | None = None
+    deleted_lines: int | None = None
+
+    @property
+    def display_path(self) -> str:
+        if self.source_path == self.target_path:
+            return _printable_path(self.target_path)
+        return (
+            f"{_printable_path(self.source_path)} -> "
+            f"{_printable_path(self.target_path)}"
+        )
+
+
+@dataclass(frozen=True)
+class PatchInspection:
+    total_bytes: int
+    files: tuple[PatchFile, ...]
+    parse_error: str | None = None
+
+
+@dataclass(frozen=True)
+class PatchGuardResult:
+    inspection: PatchInspection
+    violations: tuple[str, ...]
+
+    @property
+    def accepted(self) -> bool:
+        return not self.violations
+
+
+def _clean_git_path(value: str, prefix: str) -> str:
+    return value[len(prefix):] if value.startswith(prefix) else value
+
+
+def _printable_path(value: str) -> str:
+    """Keep diagnostics concrete without allowing terminal control bytes."""
+    output: list[str] = []
+    for character in value:
+        if character.isprintable():
+            output.append(character)
+        else:
+            codepoint = ord(character)
+            if codepoint <= 0xFF:
+                output.append(f"\\x{codepoint:02x}")
+            elif codepoint <= 0xFFFF:
+                output.append(f"\\u{codepoint:04x}")
+            else:
+                output.append(f"\\U{codepoint:08x}")
+    return "".join(output)
+
+
+def _diff_header_paths(line: bytes) -> tuple[str, str] | None:
+    try:
+        parts = shlex.split(
+            line.decode("utf-8", errors="surrogateescape"), posix=True,
+        )
+    except ValueError:
+        return None
+    if len(parts) != 4 or parts[:2] != ["diff", "--git"]:
+        return None
+    return _clean_git_path(parts[2], "a/"), _clean_git_path(parts[3], "b/")
+
+
+def _numstat(data: bytes) -> tuple[list[tuple[int | None, int | None]], str | None]:
+    """Return per-section line counts while asking git to validate the diff."""
+    try:
+        proc = subprocess.run(
+            ["git", "apply", "--numstat", "-"],
+            input=data,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except OSError as exc:
+        return [], f"git apply could not start: {exc}"
+    if proc.returncode != 0:
+        detail = proc.stderr.decode("utf-8", errors="replace").strip()
+        return [], f"git could not parse model.patch: {detail or 'unknown error'}"
+
+    stats: list[tuple[int | None, int | None]] = []
+    for line in proc.stdout.decode("utf-8", errors="surrogateescape").splitlines():
+        fields = line.split("\t", 2)
+        if len(fields) != 3:
+            return [], "git returned malformed patch statistics"
+        added = None if fields[0] == "-" else int(fields[0])
+        deleted = None if fields[1] == "-" else int(fields[1])
+        stats.append((added, deleted))
+    return stats, None
+
+
+def inspect_patch(data: bytes) -> PatchInspection:
+    """Inventory changed paths, binary markers, and patch bytes per file."""
+    offsets: list[tuple[int, tuple[str, str] | None]] = []
+    cursor = 0
+    for line in data.splitlines(keepends=True):
+        if line.startswith(b"diff --git "):
+            offsets.append((cursor, _diff_header_paths(line.rstrip(b"\r\n"))))
+        cursor += len(line)
+
+    stats, parse_error = _numstat(data)
+    if not offsets:
+        if parse_error is None:
+            parse_error = "model.patch contains no diff --git sections"
+        return PatchInspection(len(data), (), parse_error)
+    if parse_error is None and len(stats) != len(offsets):
+        parse_error = (
+            "patch section count does not match git's file statistics "
+            f"({len(offsets)} sections, {len(stats)} files)"
+        )
+
+    files: list[PatchFile] = []
+    for index, (start, paths) in enumerate(offsets):
+        end = offsets[index + 1][0] if index + 1 < len(offsets) else len(data)
+        section = data[start:end]
+        if paths is None:
+            source_path = target_path = "<unparseable diff header>"
+            if parse_error is None:
+                parse_error = "one or more diff --git headers are malformed"
+        else:
+            source_path, target_path = paths
+        added = deleted = None
+        if index < len(stats):
+            added, deleted = stats[index]
+        binary = (
+            b"\nGIT binary patch\n" in b"\n" + section
+            or b"\nBinary files " in b"\n" + section
+            or added is None
+            or deleted is None
+        )
+        files.append(PatchFile(
+            source_path=source_path,
+            target_path=target_path,
+            patch_bytes=len(section),
+            binary=binary,
+            added_lines=added,
+            deleted_lines=deleted,
+        ))
+    return PatchInspection(len(data), tuple(files), parse_error)
+
+
+def check_pompeii_patch(data: bytes) -> PatchGuardResult:
+    inspection = inspect_patch(data)
+    violations: list[str] = []
+    if inspection.parse_error:
+        violations.append(inspection.parse_error)
+    if inspection.total_bytes > POMPEII_PATCH_MAX_BYTES:
+        violations.append(
+            f"model.patch is {inspection.total_bytes} bytes; "
+            f"the local Pompeii limit is {POMPEII_PATCH_MAX_BYTES} bytes"
+        )
+    if len(inspection.files) != 1:
+        violations.append(
+            f"patch changes {len(inspection.files)} files; exactly one is allowed"
+        )
+    for item in inspection.files:
+        if (
+            item.source_path != POMPEII_DELIVERABLE
+            or item.target_path != POMPEII_DELIVERABLE
+        ):
+            violations.append(
+                f"unexpected changed path: {item.display_path}"
+            )
+        if item.binary:
+            violations.append(f"binary patch content: {item.display_path}")
+    return PatchGuardResult(inspection, tuple(violations))
+
+
+def _format_bytes(value: int) -> str:
+    if value >= 1024 * 1024:
+        return f"{value / (1024 * 1024):.2f} MiB ({value} bytes)"
+    if value >= 1024:
+        return f"{value / 1024:.1f} KiB ({value} bytes)"
+    return f"{value} bytes"
+
+
+def format_patch_guard_report(result: PatchGuardResult) -> list[str]:
+    """Build bounded, content-free diagnostics safe to print locally."""
+    inspection = result.inspection
+    lines = [
+        f"model.patch: {_format_bytes(inspection.total_bytes)}",
+        f"allowed deliverable: {POMPEII_DELIVERABLE}",
+    ]
+    if result.violations:
+        lines.append("violations:")
+        lines.extend(f"  - {item}" for item in result.violations)
+    lines.append("changed files (largest patch contribution first):")
+    ordered = sorted(
+        inspection.files, key=lambda item: item.patch_bytes, reverse=True,
+    )
+    for item in ordered[:PATCH_REPORT_FILE_LIMIT]:
+        traits = [f"patch {_format_bytes(item.patch_bytes)}"]
+        if item.binary:
+            traits.append("binary")
+        elif item.added_lines is not None and item.deleted_lines is not None:
+            traits.append(f"+{item.added_lines}/-{item.deleted_lines} lines")
+        lines.append(f"  - {item.display_path}: {', '.join(traits)}")
+    if len(ordered) > PATCH_REPORT_FILE_LIMIT:
+        lines.append(
+            f"  - ... {len(ordered) - PATCH_REPORT_FILE_LIMIT} more files omitted"
+        )
+    if not ordered:
+        lines.append("  - <none parsed>")
+    return lines

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -33,6 +33,7 @@ from .local_config import (
     DEFAULT_BENCHMARK, HOME, _load_config, tasks_root_from_config,
 )
 from .machine import acquire_run_lock, sweep_orphan_compose
+from .patch_guard import check_pompeii_patch, format_patch_guard_report
 from .providers import (
     DEEPSEEK_CATALOG_SHA256,
     DEEPSEEK_PROVIDER,
@@ -1539,6 +1540,32 @@ def _upload_trial(
         print(f"patch contained secret-shaped content "
               f"({', '.join(redacted_labels)}); uploading a structurally validated "
               "redacted copy. The raw patch stays local.")
+
+    entry_meta = entry.get("meta") or {}
+    is_zcode_pompeii = (
+        task_id.startswith(f"{POMPEII_BENCHMARK_ID}-")
+        and (
+            entry_meta.get("model_runtime_profile") == ZCODE_RUNTIME_PROFILE
+            or entry_meta.get("zcode_protocol_version") == 1
+        )
+    )
+    if is_zcode_pompeii:
+        guard = check_pompeii_patch(raw_patch)
+        if not guard.accepted:
+            print(
+                f"  {task_id}: ZCode patch preflight blocked upload; the "
+                "declared deliverable boundary was violated"
+            )
+            for line in format_patch_guard_report(guard):
+                print(f"    {line}")
+            print(f"    raw artifact preserved at: {patch}")
+            print(
+                "    assignment reopened for an independent ZCode re-solve; "
+                "no prior model answer is reused"
+            )
+            pending.remove(HOME, assignment_id)
+            settle_terminal_local_failure()
+            return "rejected"
 
     upload_meta = dict(entry.get("meta") or {})
     trial_dir = Path(entry["trial_dir"])

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -249,6 +249,21 @@ best current judgment to finish and commit. A complete, gradeable answer takes
 priority over further exploration.
 """
 
+ZCODE_POMPEII_SUBMISSION_PROMPT = POMPEII_SUBMISSION_PROMPT + """
+
+This benchmark has exactly one declared deliverable: `model_answer.json` in
+the repository root. Derive the answer independently from the task inputs and
+write only that final JSON file. Do not modify or commit `question.png`,
+`output_schema.json`, anything under `reference/`, generated images, caches,
+logs, or intermediate analysis artifacts. Keep temporary image-processing and
+analysis files outside `/app` (for example under `/tmp`) and remove any
+accidental repository artifacts before committing.
+
+Before finishing, verify that `git diff --name-only pompeii-base HEAD` prints
+exactly `model_answer.json`, and that the file conforms to
+`output_schema.json`. Do not reuse another model's answer.
+"""
+
 
 @dataclass
 class TrialArtifacts:
@@ -476,6 +491,20 @@ def _ensure_codex_submission_prompt(
         path = home / "codex-submission-prompt.j2"
         prompt = CODEX_SUBMISSION_PROMPT
     return _materialize_shared_file(path, prompt.encode())
+
+
+def _ensure_zcode_submission_prompt(
+    home: Path, benchmark_id: str | None = None,
+) -> Path:
+    if benchmark_id != POMPEII_BENCHMARK_ID:
+        return _ensure_codex_submission_prompt(home, benchmark_id)
+    # ZCode needs an explicit repository boundary for this schema-only visual
+    # benchmark. Keep it separate so other agents retain their existing prompt
+    # and concurrent workers never overwrite each other's template.
+    path = home / "zcode-submission-prompt-pompeii-v1.j2"
+    return _materialize_shared_file(
+        path, ZCODE_POMPEII_SUBMISSION_PROMPT.encode(),
+    )
 
 
 def _ensure_deepseek_config(home: Path) -> Path:
@@ -1240,7 +1269,7 @@ def build_pier_command(
                 "Pinned ZCode CLI is unavailable; run "
                 "`dradar provider status zcode` first"
             )
-        submission_prompt = _ensure_codex_submission_prompt(
+        submission_prompt = _ensure_zcode_submission_prompt(
             home, assignment.get("benchmark_id")
         )
         cmd += [

--- a/tests/test_patch_guard.py
+++ b/tests/test_patch_guard.py
@@ -1,0 +1,62 @@
+from dradar.patch_guard import (
+    POMPEII_PATCH_MAX_BYTES,
+    check_pompeii_patch,
+    format_patch_guard_report,
+    inspect_patch,
+)
+
+
+def _text_patch(path: str = "model_answer.json", value: bytes = b'{"edges":[]}') -> bytes:
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        "index 9e26dfe..e9cfe4b 100644\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        "@@ -1 +1 @@\n"
+        "-{}\n"
+    ).encode() + b"+" + value + b"\n"
+
+
+def test_accepts_only_small_text_model_answer_patch():
+    result = check_pompeii_patch(_text_patch())
+
+    assert result.accepted is True
+    assert result.violations == ()
+    assert result.inspection.files[0].display_path == "model_answer.json"
+    assert result.inspection.files[0].binary is False
+
+
+def test_reports_unexpected_binary_file_and_its_patch_contribution():
+    patch = _text_patch() + (
+        b"diff --git a/generated/reconstruction.png "
+        b"b/generated/reconstruction.png\n"
+        b"new file mode 100644\n"
+        b"index 0000000..1111111\n"
+        b"GIT binary patch\n"
+        b"literal 4\nLc${NkU|;|M00aO5\n\n"
+    )
+
+    result = check_pompeii_patch(patch)
+    report = "\n".join(format_patch_guard_report(result))
+
+    assert result.accepted is False
+    assert "generated/reconstruction.png" in report
+    assert "binary" in report
+    assert "patch contribution" in report
+    assert "changes 2 files" in report
+
+
+def test_reports_oversized_model_answer_before_upload():
+    patch = _text_patch(value=b'"' + b"x" * POMPEII_PATCH_MAX_BYTES + b'"')
+
+    result = check_pompeii_patch(patch)
+
+    assert result.accepted is False
+    assert any("local Pompeii limit" in item for item in result.violations)
+
+
+def test_malformed_patch_fails_closed_without_content_dump():
+    inspection = inspect_patch(b"not a patch\n")
+
+    assert inspection.files == ()
+    assert inspection.parse_error is not None

--- a/tests/test_pending_upload.py
+++ b/tests/test_pending_upload.py
@@ -1207,6 +1207,74 @@ def test_definitively_rejected_upload_drops_ledger_entry(tmp_path: Path, monkeyp
     assert client.stopped == ["a1"]
 
 
+def test_zcode_pompeii_preflight_names_binary_file_before_submit(
+    tmp_path: Path, monkeypatch, capsys,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    raw_patch = (
+        b"diff --git a/model_answer.json b/model_answer.json\n"
+        b"index 9e26dfe..e9cfe4b 100644\n"
+        b"--- a/model_answer.json\n"
+        b"+++ b/model_answer.json\n"
+        b"@@ -1 +1 @@\n-{}\n+{\"edges\":[]}\n"
+        b"diff --git a/cache/stitch.png b/cache/stitch.png\n"
+        b"new file mode 100644\n"
+        b"index 0000000..1111111\n"
+        b"GIT binary patch\n"
+        b"literal 4\nLc${NkU|;|M00aO5\n\n"
+    )
+    (trial_dir / "artifacts" / "model.patch").write_bytes(raw_patch)
+    client = FakeClient(lambda _aid: pytest.fail("guarded patch must not submit"))
+    entry = _entry(
+        trial_dir,
+        task_id="pompeii-adjacency-rp-085",
+        meta={"model_runtime_profile": runloop.ZCODE_RUNTIME_PROFILE},
+    )
+
+    outcome = runloop._upload_trial(client, entry)
+
+    assert outcome == "rejected"
+    assert client.calls == []
+    assert client.stopped == ["a1"]
+    assert pending.load(tmp_path) == []
+    assert (trial_dir / "artifacts" / "model.patch").read_bytes() == raw_patch
+    out = capsys.readouterr().out
+    assert "patch preflight blocked upload" in out
+    assert "cache/stitch.png" in out
+    assert "binary" in out
+    assert "independent ZCode re-solve" in out
+
+
+def test_zcode_pompeii_preflight_allows_small_model_answer_patch(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    (trial_dir / "artifacts" / "model.patch").write_bytes(
+        b"diff --git a/model_answer.json b/model_answer.json\n"
+        b"index 9e26dfe..e9cfe4b 100644\n"
+        b"--- a/model_answer.json\n"
+        b"+++ b/model_answer.json\n"
+        b"@@ -1 +1 @@\n-{}\n+{\"edges\":[]}\n"
+    )
+    client = FakeClient(
+        lambda _aid: {"submission_id": "s1", "grade_status": "pending"},
+    )
+
+    outcome = runloop._upload_trial(
+        client,
+        _entry(
+            trial_dir,
+            task_id="pompeii-adjacency-rp-086",
+            meta={"zcode_protocol_version": 1},
+        ),
+    )
+
+    assert outcome == "submitted"
+    assert client.calls == ["a1"]
+
+
 def test_definitive_rejection_preserves_checkpoint_job(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(runloop, "HOME", tmp_path)
     aid = "4" * 32

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -95,6 +95,44 @@ def test_pompeii_prompt_sets_simple_time_budget(tmp_path, monkeypatch):
     assert "complete, gradeable answer" in text
 
 
+def test_zcode_pompeii_prompt_enforces_single_declared_deliverable(
+    tmp_path, monkeypatch,
+):
+    _stub_pier(monkeypatch)
+    task = tmp_path / "abs-module-cache-flags"
+    task.mkdir()
+    (task / "task.toml").write_text("[agent]\ntimeout_sec = 7200.0\n")
+    home = tmp_path / "home"
+    home.mkdir()
+    key = tmp_path / "zcode-key"
+    key.write_text("secret")
+    cli = tmp_path / "zcode.cjs"
+    cli.write_text("pinned")
+    assignment = _assignment(
+        runner_mod.ZCODE_AGENT,
+        model=runner_mod.ZCODE_MODEL,
+        effort="low",
+    ) | {
+        "benchmark_id": runner_mod.POMPEII_BENCHMARK_ID,
+        "provider": runner_mod.ZCODE_PROVIDER,
+        "agent_version": runner_mod.ZCODE_CLI_VERSION,
+    }
+
+    cmd = build_pier_command(
+        assignment, tmp_path, tmp_path / "jobs", "j", home,
+        provider_auth_path=key, provider_cli_path=cli,
+    )
+
+    prompt = home / "zcode-submission-prompt-pompeii-v1.j2"
+    assert f"prompt_template_path={prompt}" in cmd
+    text = prompt.read_text()
+    assert "exactly one declared deliverable" in text
+    assert "git diff --name-only pompeii-base HEAD" in text
+    assert "Do not modify or commit `question.png`" in text
+    assert "generated images, caches" in text
+    assert "Do not reuse another model's answer" in text
+
+
 def test_dev_agent_codex_uses_durable_openai_provider_default(tmp_path, monkeypatch):
     _stub_pier(monkeypatch)
     task = tmp_path / "abs-module-cache-flags"


### PR DESCRIPTION
## Summary
- give ZCode a Pompeii-specific prompt that limits committed output to `model_answer.json`
- inventory patch paths, per-file contribution, binary markers, and total bytes before upload
- reject malformed/oversized ZCode Pompeii patches locally, preserve raw evidence, and reopen the assignment for an independent re-solve
- leave Codex and all non-Pompeii upload behavior unchanged

## Verification
- `pytest -q`
- 1104 passed, 5 skipped