### PR TITLE
Fix ZCode runner cleanup and lease sequencing

### DIFF
--- a/src/dradar/pier_zcode.py
+++ b/src/dradar/pier_zcode.py
@@ -237,6 +237,25 @@ def write_runtime_diagnostic(status, turn_count, seen_running, terminal_observed
             pass
 
 
+def write_private_json(path_value, payload):
+    """Atomically publish a complete protocol artifact with private mode."""
+    path = Path(path_value)
+    temporary = path.with_name(path.name + f".tmp-{os.getpid()}")
+    try:
+        temporary.write_text(
+            json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n",
+            encoding="utf-8",
+        )
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            temporary.unlink()
+        except OSError:
+            pass
+        raise
+
+
 def collect_rollout_usage(
     session_id, *, max_files=8, max_file_bytes=16 * 1024 * 1024,
     max_total_bytes=32 * 1024 * 1024, max_lines=20_000, max_records=10_000,
@@ -873,13 +892,11 @@ safe_outcome = redact(outcome)
 encoded = json.dumps(safe_outcome, ensure_ascii=False, separators=(",", ":"))
 if key in encoded:
     raise ProtocolError("Coding Plan credential reached the ZCode outcome")
-Path(outcome_path).write_text(encoded + "\n", encoding="utf-8")
-os.chmod(outcome_path, 0o600)
-Path(events_path).write_text(
-    json.dumps(redact(notifications), ensure_ascii=False, separators=(",", ":")) + "\n",
-    encoding="utf-8",
-)
-os.chmod(events_path, 0o600)
+# Publish the outcome last. Its presence is the durable terminal boundary;
+# readers can never observe a partially-written JSON document or an outcome
+# whose companion event log has not been finalized yet.
+write_private_json(events_path, redact(notifications))
+write_private_json(outcome_path, safe_outcome)
 print(f"ZCode session {session_id} completed with {model_name} ({effort}).")
 '''
 

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -60,6 +60,7 @@ from .providers import (
 )
 from .runner import (
     CODEX_TRAJECTORY_BUNDLE_SCHEMA, DIAG_ADVICE, BuildFlakeError, RunnerError,
+    RunnerCleanupUnconfirmedError,
     POMPEII_BENCHMARK_ID,
     POMPEII_FINALIZATION_RESERVE_SEC, POMPEII_SOFT_BUDGET_SEC,
     POMPEII_TERMINAL_HEAVY_TIMEOUT_SEC,
@@ -2256,6 +2257,17 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
                     client, assignment, failure_kind="environment_build_failed",
                 )
             return "environment-build-failed"
+        except RunnerCleanupUnconfirmedError as exc:
+            _signal_pool_abort(
+                "local Pier cleanup could not be confirmed",
+                interrupt_siblings=False,
+            )
+            print(
+                f"trial stopped: {exc}\n"
+                "the lease remains running because local cleanup was not proven; "
+                "automatic retry/backfill is disabled to prevent a duplicate agent"
+            )
+            return "cleanup-unconfirmed"
         except RunnerError as exc:
             failure_kind = classify_exception_message(str(exc))
             terminal_outcome = _terminal_failure_outcome(failure_kind)

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -291,6 +291,10 @@ class RunnerError(RuntimeError):
         self.failure_diagnostic = failure_diagnostic
 
 
+class RunnerCleanupUnconfirmedError(RunnerError):
+    """The local runtime may still be alive, so its lease must stay running."""
+
+
 class LiveAccountTerminalError(RunnerError):
     """A running agent reported an account-wide terminal provider failure."""
 
@@ -2221,8 +2225,8 @@ DEEP_SWE_REPO = "https://github.com/datacurve-ai/deep-swe"
 # Temporary SecurityMind Pier build containing datacurve-ai/pier#23 plus
 # persistent workspace/Codex-session checkpoints. Keep the immutable commit
 # pin until both fixes are released upstream, then follow the official tag.
-PIER_VERSION = "0.3.0.post3"
-PIER_COMMIT = "acd1d94a53c9ada225187e4b73206970f14ba415"
+PIER_VERSION = "0.3.0.post4"
+PIER_COMMIT = "fd5d8f18149844cbe255d7b98d655c7f7bbff030"
 PIER_SPEC = (
     "datacurve-pier @ git+https://github.com/SecurityMind/pier.git@"
     f"{PIER_COMMIT}"
@@ -2871,6 +2875,8 @@ def _zcode_false_success_reason(
         and steps > 0
     )
     status = runtime_diagnostic.get("zcode_last_status")
+    if runtime_diagnostic.get("zcode_terminal_observed") is not True:
+        return "terminal_not_observed"
     if status in {"error", "failed", "stopped"}:
         return "terminal_status"
     if explicit_model_error and not provider_turn_completed:
@@ -3023,6 +3029,24 @@ def _terminate_pier_process_tree(proc: subprocess.Popen) -> bool:
     return True
 
 
+def _cleanup_exited_pier_process_group(proc: subprocess.Popen) -> bool:
+    """Reap helpers left in Pier's isolated POSIX group after its leader exits."""
+
+    pid = getattr(proc, "pid", None)
+    if os.name == "nt" or not isinstance(pid, int) or pid <= 0:
+        return False
+    try:
+        os.killpg(pid, 0)
+    except ProcessLookupError:
+        return False
+    except OSError as exc:
+        raise RunnerError(
+            "Pier exited but its process group could not be audited",
+        ) from exc
+    _terminate_pier_process_tree(proc)
+    return True
+
+
 def _path_is_below(path: str, root: Path) -> bool:
     try:
         return Path(path).resolve().is_relative_to(root.resolve())
@@ -3030,7 +3054,13 @@ def _path_is_below(path: str, root: Path) -> bool:
         return False
 
 
-def _cleanup_terminated_pier_containers(job_root: Path) -> None:
+@dataclass(frozen=True)
+class PierContainerCleanup:
+    matched: int = 0
+    running: int = 0
+
+
+def _cleanup_terminated_pier_containers(job_root: Path) -> PierContainerCleanup:
     """Remove only surviving containers bound to the exact terminated job."""
 
     try:
@@ -3056,7 +3086,7 @@ def _cleanup_terminated_pier_containers(job_root: Path) -> None:
         if re.fullmatch(r"[0-9a-f]{12,64}", value)
     ]
     if not container_ids:
-        return
+        return PierContainerCleanup()
     try:
         inspected = subprocess.run(
             ["docker", "inspect", *container_ids],
@@ -3078,6 +3108,7 @@ def _cleanup_terminated_pier_containers(job_root: Path) -> None:
         raise RunnerError("Docker returned invalid orphan inspection data") from exc
 
     owned: list[str] = []
+    running: list[str] = []
     for container in containers:
         if not isinstance(container, dict):
             continue
@@ -3106,8 +3137,11 @@ def _cleanup_terminated_pier_containers(job_root: Path) -> None:
         )
         if mounts_owned or config_owned:
             owned.append(container_id)
+            state = container.get("State")
+            if isinstance(state, dict) and state.get("Running") is True:
+                running.append(container_id)
     if not owned:
-        return
+        return PierContainerCleanup()
     try:
         removed = subprocess.run(
             ["docker", "rm", "-f", *owned],
@@ -3123,6 +3157,7 @@ def _cleanup_terminated_pier_containers(job_root: Path) -> None:
         raise RunnerError(
             "terminated Pier task container could not be removed",
         )
+    return PierContainerCleanup(matched=len(owned), running=len(running))
 
 
 def run_trial(
@@ -3427,7 +3462,7 @@ def run_trial(
                 except RunnerError as cleanup_error:
                     cleanup_errors.append(str(cleanup_error))
                 if cleanup_errors:
-                    raise RunnerError(
+                    raise RunnerCleanupUnconfirmedError(
                         f"{exc}\nPier cleanup safety check failed: "
                         + "; ".join(cleanup_errors),
                     ) from exc
@@ -3441,6 +3476,39 @@ def run_trial(
                     terminal_error = exc
                 else:
                     raise
+        if effective_agent == ZCODE_AGENT:
+            cleanup_errors: list[str] = []
+            process_residue = False
+            try:
+                process_residue = _cleanup_exited_pier_process_group(proc)
+            except RunnerError as exc:
+                cleanup_errors.append(str(exc))
+            try:
+                cleanup = _cleanup_terminated_pier_containers(jobs_dir / job_name)
+            except RunnerError as exc:
+                cleanup_errors.append(str(exc))
+                cleanup = PierContainerCleanup()
+            if cleanup_errors:
+                raise RunnerCleanupUnconfirmedError(
+                    "Pier exited, but exact-job runtime cleanup could not be "
+                    "confirmed; the server lease was intentionally left running "
+                    "to prevent a duplicate retry ("
+                    + "; ".join(cleanup_errors)
+                    + ")",
+                )
+            if process_residue or cleanup.running:
+                raise RunnerError(
+                    "Pier exited while the ZCode runtime was still active; exact-job "
+                    "processes and containers were stopped before the "
+                    "assignment was made retryable",
+                    failure_diagnostic=_zcode_failure_diagnostic(
+                        effective_assignment,
+                        tasks_root / assignment["task_id"],
+                        jobs_dir,
+                        job_name,
+                        "agent_no_artifact",
+                    ),
+                )
     finally:
         if provider_auth_path is not None:
             if (
@@ -3562,7 +3630,7 @@ def run_trial(
         )
         if false_success_reason is not None:
             raise RunnerError(
-                "ZCode returned process status 0 without a gradeable terminal "
+                "Pier exited with process status 0 without a gradeable ZCode terminal "
                 f"result ({false_success_reason}); local artifacts were kept "
                 "and the assignment remains retryable",
                 failure_diagnostic=_zcode_failure_diagnostic(

--- a/tests/test_go_menu.py
+++ b/tests/test_go_menu.py
@@ -601,6 +601,38 @@ def test_task_content_mismatch_stops_before_model_run(
     assert "no model quota was consumed" in capsys.readouterr().out
 
 
+def test_cleanup_unconfirmed_drains_pool_without_marking_lease_stopped(
+    monkeypatch, tmp_path: Path, capsys,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
+    abort_file = tmp_path / "POOL_ABORT"
+    monkeypatch.setenv("DRADAR_POOL_ABORT_FILE", str(abort_file))
+
+    def fail(*_args, **_kwargs):
+        raise runloop.RunnerCleanupUnconfirmedError("exact runtime is unknown")
+
+    monkeypatch.setattr(runloop, "run_trial", fail)
+    stopped = []
+    monkeypatch.setattr(
+        runloop,
+        "_mark_stopped_quietly",
+        lambda *_args, **_kwargs: stopped.append(True),
+    )
+    client = SubmitClient({})
+
+    outcome = runloop._run_and_submit(
+        client, ASSIGNMENT, tmp_path, _args(), "abc123",
+    )
+
+    assert outcome == "cleanup-unconfirmed"
+    assert stopped == []
+    assert client.submissions == []
+    assert abort_file.read_text() == (
+        "drain:local Pier cleanup could not be confirmed"
+    )
+    assert "lease remains running" in capsys.readouterr().out
+
+
 def test_explicit_task_drift_override_keeps_existing_audited_behavior(
     monkeypatch, tmp_path: Path,
 ):

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -441,7 +441,7 @@ def test_ensure_pier_noop_when_required_version_present(monkeypatch):
 
 def test_ensure_pier_accepts_newer_compatible_post_release(monkeypatch):
     monkeypatch.setattr(runner_mod.shutil, "which", lambda n: "/usr/bin/pier")
-    monkeypatch.setattr(runner_mod, "_pier_version", lambda _: "0.3.0.post3")
+    monkeypatch.setattr(runner_mod, "_pier_version", lambda _: "0.3.0.post5")
     called = []
     monkeypatch.setattr(runner_mod.subprocess, "run", lambda *a, **k: called.append(a))
     ensure_pier()
@@ -693,6 +693,16 @@ def _fake_pier(monkeypatch, work_dir, *, patch=True, trajectory=True,
 
     monkeypatch.setattr(runner_mod, "build_pier_command", fake_build)
     monkeypatch.setattr(runner_mod.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(
+        runner_mod,
+        "_cleanup_exited_pier_process_group",
+        lambda _proc: False,
+    )
+    monkeypatch.setattr(
+        runner_mod,
+        "_cleanup_terminated_pier_containers",
+        lambda _job_root: runner_mod.PierContainerCleanup(),
+    )
     return captured
 
 
@@ -812,6 +822,30 @@ def test_terminate_pier_kills_children_after_leader_exits(monkeypatch):
     ]
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process groups only")
+def test_cleanup_exited_pier_process_group_detects_surviving_helper(monkeypatch):
+    signals = []
+
+    class LeaderExited:
+        pid = 65432
+
+        def wait(self, timeout=None):
+            return 0
+
+    monkeypatch.setattr(
+        runner_mod.os, "killpg",
+        lambda pid, sig: signals.append((pid, sig)),
+    )
+
+    assert runner_mod._cleanup_exited_pier_process_group(LeaderExited()) is True
+    assert signals == [
+        (65432, 0),
+        (65432, runner_mod.signal.SIGTERM),
+        (65432, 0),
+        (65432, runner_mod.signal.SIGKILL),
+    ]
+
+
 def test_forced_cleanup_removes_only_container_bound_to_exact_job(
     tmp_path, monkeypatch,
 ):
@@ -832,6 +866,7 @@ def test_forced_cleanup_removes_only_container_bound_to_exact_job(
             containers = [
                 {
                     "Id": owned_id,
+                    "State": {"Running": True},
                     "Config": {"Labels": {
                         "com.docker.compose.project": "pier__abcdef",
                     }},
@@ -860,9 +895,66 @@ def test_forced_cleanup_removes_only_container_bound_to_exact_job(
 
     monkeypatch.setattr(runner_mod.subprocess, "run", fake_run)
 
-    runner_mod._cleanup_terminated_pier_containers(job_root)
+    cleanup = runner_mod._cleanup_terminated_pier_containers(job_root)
 
     assert calls[-1] == ["docker", "rm", "-f", owned_id]
+    assert cleanup == runner_mod.PierContainerCleanup(matched=1, running=1)
+
+
+def test_zcode_rc0_with_live_exact_job_container_is_reaped_before_retry(
+    tmp_path, monkeypatch,
+):
+    _prepare_fake_zcode(monkeypatch, tmp_path)
+    _fake_pier(
+        monkeypatch,
+        tmp_path,
+        runtime_diagnostic={
+            "schema": "dradar-zcode-runtime-v1",
+            "status": "running",
+            "turn_count": 1,
+            "seen_running": True,
+            "terminal_observed": False,
+        },
+        rc=0,
+    )
+    process_groups = []
+    monkeypatch.setattr(
+        runner_mod,
+        "_cleanup_terminated_pier_containers",
+        lambda _job_root: runner_mod.PierContainerCleanup(matched=1, running=1),
+    )
+    monkeypatch.setattr(
+        runner_mod,
+        "_cleanup_exited_pier_process_group",
+        lambda proc: process_groups.append(proc) or False,
+    )
+
+    with pytest.raises(
+        RunnerError, match="ZCode runtime was still active",
+    ):
+        run_trial(_zcode_assignment_for_trial(), tmp_path, tmp_path)
+
+    assert len(process_groups) == 1
+
+
+def test_zcode_rc0_keeps_lease_running_when_cleanup_cannot_be_proven(
+    tmp_path, monkeypatch,
+):
+    _prepare_fake_zcode(monkeypatch, tmp_path)
+    _fake_pier(monkeypatch, tmp_path, rc=0)
+
+    def cleanup_failed(_job_root):
+        raise RunnerError("docker daemon unavailable")
+
+    monkeypatch.setattr(
+        runner_mod, "_cleanup_terminated_pier_containers", cleanup_failed,
+    )
+
+    with pytest.raises(
+        runner_mod.RunnerCleanupUnconfirmedError,
+        match="lease was intentionally left running",
+    ):
+        run_trial(_zcode_assignment_for_trial(), tmp_path, tmp_path)
 
 
 def test_run_trial_stops_live_codex_quota_error_loop(tmp_path, monkeypatch):
@@ -1357,6 +1449,27 @@ def test_run_trial_rejects_zcode_rc0_without_meaningful_agent_result(
     )
 
     with pytest.raises(RunnerError, match="empty_agent_result"):
+        run_trial(_zcode_assignment_for_trial(), tmp_path, tmp_path)
+
+
+def test_run_trial_rejects_zcode_rc0_before_terminal_is_observed(
+        tmp_path, monkeypatch):
+    _prepare_fake_zcode(monkeypatch, tmp_path)
+    _fake_pier(
+        monkeypatch,
+        tmp_path,
+        result={"agent_result": {"n_agent_steps": 1}},
+        runtime_diagnostic={
+            "schema": "dradar-zcode-runtime-v1",
+            "status": "running",
+            "turn_count": 1,
+            "seen_running": True,
+            "terminal_observed": False,
+        },
+        rc=0,
+    )
+
+    with pytest.raises(RunnerError, match="terminal_not_observed"):
         run_trial(_zcode_assignment_for_trial(), tmp_path, tmp_path)
 
 

--- a/tests/test_zcode_coding_plan.py
+++ b/tests/test_zcode_coding_plan.py
@@ -461,6 +461,27 @@ def test_zcode_session_id_is_durable_before_the_paid_turn() -> None:
     assert write_at < replace_at < unlink_at < send_at
 
 
+def test_zcode_terminal_outcome_is_atomic_and_published_last() -> None:
+    source = Path(providers.__file__).with_name("pier_zcode.py").read_text()
+    module = ast.parse(source)
+    runner_assignment = next(
+        node for node in module.body
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "_PROTOCOL_RUNNER"
+                for target in node.targets)
+    )
+    runner_source = ast.literal_eval(runner_assignment.value)
+    ast.parse(runner_source)
+    events_at = runner_source.index(
+        "write_private_json(events_path, redact(notifications))"
+    )
+    outcome_at = runner_source.index(
+        "write_private_json(outcome_path, safe_outcome)"
+    )
+    assert "os.replace(temporary, path)" in runner_source
+    assert events_at < outcome_at
+
+
 def test_zcode_session_deadline_tracks_long_assignment_budget(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- audit and reap ZCode's exact Pier process group and Docker containers after the Pier leader exits
- never move a lease back to retryable when local cleanup cannot be proven; gracefully drain the worker pool instead
- require an observed ZCode terminal lifecycle state before accepting Pier rc=0
- atomically publish protocol events and publish `zcode-outcome.json` last
- pin Pier 0.3.0.post4 with cancellation-safe compose subprocess cleanup

## Regression safety

- container cleanup remains scoped to the exact job's bind mount/config path plus Pier's Compose project label
- running sibling assignments are not interrupted when cleanup is unconfirmed
- cleanup-unconfirmed assignments are neither uploaded nor marked stopped

## Verification

- `uv run pytest -q` (1110 passed, 5 skipped)
- `uvx ruff check --select E9,F63,F7,F82 ...`
- `python -m compileall -q src tests`

Pier dependency: SecurityMind/pier#2, merged as `fd5d8f18149844cbe255d7b98d655c7f7bbff030`.
