### PR TITLE
fix(antigravity): bridge discovered host proxy into containers

### DIFF
--- a/src/dradar/egress.py
+++ b/src/dradar/egress.py
@@ -538,11 +538,12 @@ def _validate_proxy_credential(value: str, label: str) -> str:
 def _upstream_proxy_environment(
     source_env: dict[str, str] | None = None,
 ) -> dict[str, str]:
-    # Container egress uses only explicit, portable configuration. In
-    # particular, do not infer a volunteer's Docker topology from the
-    # developer's macOS/OrbStack setup. provider_subprocess_env still handles
-    # OS proxy discovery for host-side OAuth, independently.
-    env = source_env if source_env is not None else dict(os.environ)
+    # Use the same host-side proxy discovery as provider setup/live checks, then
+    # translate only the container copy below. This keeps the host process on
+    # its real loopback address while Docker receives host.docker.internal and
+    # the exact discovered port. DRADAR_CONTAINER_HTTP_PROXY remains the
+    # authoritative escape hatch when Docker needs a different address.
+    env = source_env if source_env is not None else provider_subprocess_env()
     raw = _container_proxy_value(env)
     if not raw:
         return {}

--- a/src/dradar/provider_config.py
+++ b/src/dradar/provider_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import getpass
 import hashlib
+import ipaddress
 import os
 import platform
 import shutil
@@ -14,7 +15,7 @@ import tarfile
 import tempfile
 import urllib.request
 from pathlib import Path
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
 
 import certifi
 import httpx
@@ -83,6 +84,10 @@ _GROK_INSTALLER_SHA256 = (
 )
 _ANTIGRAVITY_SETUP_IMAGE = "debian:bookworm-slim"
 _ANTIGRAVITY_CA_BUNDLE_TARGET = "/tmp/dradar-ca-certificates.crt"
+_PROXY_ENV_NAMES = (
+    "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
+    "http_proxy", "https_proxy", "all_proxy", "no_proxy",
+)
 
 
 def _private_directory(path: Path) -> None:
@@ -127,6 +132,46 @@ def _provider_httpx_get(url: str, **kwargs):
         follow_redirects=follow_redirects,
     ) as client:
         return client.get(url, **kwargs)
+
+
+def _is_loopback_host(host: str) -> bool:
+    if host.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _containerize_proxy_environment(
+    source: dict[str, str],
+) -> tuple[dict[str, str], bool]:
+    """Translate host loopback proxy URLs for a Docker child process."""
+
+    env = dict(source)
+    translated = False
+    for name in _PROXY_ENV_NAMES:
+        if name.lower() == "no_proxy":
+            continue
+        value = env.get(name)
+        if not value:
+            continue
+        parsed = urlsplit(value)
+        host = parsed.hostname
+        if not host or not _is_loopback_host(host):
+            continue
+        try:
+            port = parsed.port
+        except ValueError as exc:
+            raise ValueError(f"{name} contains an invalid proxy port") from exc
+        userinfo, separator, _host_port = parsed.netloc.rpartition("@")
+        authority = f"{userinfo}@" if separator else ""
+        authority += "host.docker.internal"
+        if port is not None:
+            authority += f":{port}"
+        env[name] = urlunsplit(parsed._replace(netloc=authority))
+        translated = True
+    return env, translated
 
 
 def _grok_cli_version(executable: str | Path) -> str | None:
@@ -464,11 +509,12 @@ def _antigravity_container_command(
             f"target={_ANTIGRAVITY_CA_BUNDLE_TARGET},readonly"
         ),
     ]
-    env = provider_subprocess_env()
-    for name in (
-        "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
-        "http_proxy", "https_proxy", "all_proxy", "no_proxy",
-    ):
+    env, loopback_proxy = _containerize_proxy_environment(
+        provider_subprocess_env(),
+    )
+    if loopback_proxy:
+        command += ["--add-host", "host.docker.internal:host-gateway"]
+    for name in _PROXY_ENV_NAMES:
         if env.get(name):
             command += ["--env", name]
     for name in (

--- a/tests/test_egress.py
+++ b/tests/test_egress.py
@@ -35,10 +35,6 @@ def test_legacy_mode_is_an_explicit_one_release_escape_hatch(monkeypatch):
 
 
 def test_loopback_http_proxy_is_bridged_into_docker(monkeypatch):
-    monkeypatch.setattr(
-        egress,
-        "provider_subprocess_env", lambda: pytest.fail("not used for container config"),
-    )
     monkeypatch.setenv(
         egress.DRADAR_HTTP_PROXY_ENV,
         "http://user:p%40ss@127.0.0.1:39127",
@@ -56,12 +52,53 @@ def test_loopback_http_proxy_is_bridged_into_docker(monkeypatch):
     )
 
 
+@pytest.mark.parametrize("port", [7890, 7897, 8080, 10809, 65535])
+def test_os_loopback_proxy_is_discovered_for_docker_without_mutating_host_env(
+    monkeypatch, port,
+):
+    host_env = {
+        "HTTP_PROXY": f"http://127.0.0.1:{port}",
+        "HTTPS_PROXY": f"http://127.0.0.1:{port}",
+        "NO_PROXY": "localhost,127.0.0.1",
+    }
+    monkeypatch.setattr(
+        egress, "provider_subprocess_env", lambda: dict(host_env),
+    )
+
+    runtime = egress.pier_egress_environment(_TEST_IMAGE)
+
+    assert runtime["DRADAR_EGRESS_UPSTREAM_HOST"] == "host.docker.internal"
+    assert runtime["DRADAR_EGRESS_UPSTREAM_PORT"] == str(port)
+    assert runtime["DRADAR_EGRESS_BUILD_PROXY"] == (
+        f"http://host.docker.internal:{port}"
+    )
+    assert runtime["DRADAR_EGRESS_BUILD_NO_PROXY"] == "localhost,127.0.0.1"
+    assert host_env["HTTP_PROXY"] == f"http://127.0.0.1:{port}"
+
+
+def test_os_remote_proxy_is_discovered_without_rewriting_its_address(monkeypatch):
+    monkeypatch.setattr(
+        egress,
+        "provider_subprocess_env",
+        lambda: {"HTTPS_PROXY": "http://proxy.corp.example:43128"},
+    )
+
+    runtime = egress.pier_egress_environment(_TEST_IMAGE)
+
+    assert runtime["DRADAR_EGRESS_UPSTREAM_HOST"] == "proxy.corp.example"
+    assert runtime["DRADAR_EGRESS_UPSTREAM_PORT"] == "43128"
+    assert runtime["DRADAR_EGRESS_BUILD_PROXY"] == (
+        "http://proxy.corp.example:43128"
+    )
+
+
 def test_no_proxy_configuration_does_not_invent_one(monkeypatch):
     for name in (
         egress.DRADAR_HTTP_PROXY_ENV, "HTTPS_PROXY", "https_proxy",
         "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy",
     ):
         monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(egress, "provider_subprocess_env", lambda: {})
 
     runtime = egress.pier_egress_environment(_TEST_IMAGE)
 

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -353,35 +353,66 @@ def test_antigravity_setup_mounts_a_verified_ca_bundle_readonly(
     ]
 
 
+@pytest.mark.parametrize("port", [7890, 7897, 8080, 10809, 65535])
 def test_antigravity_setup_bridges_host_loopback_proxy_into_docker(
-    tmp_path, monkeypatch,
+    port, tmp_path, monkeypatch,
 ):
     executable = tmp_path / "antigravity"
     executable.write_bytes(b"official-binary")
+    source = {
+        "HTTP_PROXY": f"http://localhost:{port}",
+        "HTTPS_PROXY": f"http://user:p%40ss@127.0.0.1:{port}",
+        "ALL_PROXY": f"socks5://[::1]:{port}",
+        "NO_PROXY": "localhost,127.0.0.1",
+    }
     monkeypatch.setattr(
         provider_config,
         "provider_subprocess_env",
-        lambda: {
-            "HTTP_PROXY": "http://localhost:7897",
-            "HTTPS_PROXY": "http://user:p%40ss@127.0.0.1:7897",
-            "ALL_PROXY": "socks5://[::1]:7897",
-            "NO_PROXY": "localhost,127.0.0.1",
-        },
+        lambda: source,
     )
 
     command, env = provider_config._antigravity_container_command(
         "/usr/bin/docker", executable, ["models"], interactive=False,
     )
 
-    assert env["HTTP_PROXY"] == "http://host.docker.internal:7897"
+    assert env["HTTP_PROXY"] == f"http://host.docker.internal:{port}"
     assert env["HTTPS_PROXY"] == (
-        "http://user:p%40ss@host.docker.internal:7897"
+        f"http://user:p%40ss@host.docker.internal:{port}"
     )
-    assert env["ALL_PROXY"] == "socks5://host.docker.internal:7897"
+    assert env["ALL_PROXY"] == f"socks5://host.docker.internal:{port}"
     assert env["NO_PROXY"] == "localhost,127.0.0.1"
     add_host = command.index("--add-host")
     assert command[add_host + 1] == "host.docker.internal:host-gateway"
-    assert "http://user:p%40ss@host.docker.internal:7897" not in command
+    assert f"http://user:p%40ss@host.docker.internal:{port}" not in command
+    assert source == {
+        "HTTP_PROXY": f"http://localhost:{port}",
+        "HTTPS_PROXY": f"http://user:p%40ss@127.0.0.1:{port}",
+        "ALL_PROXY": f"socks5://[::1]:{port}",
+        "NO_PROXY": "localhost,127.0.0.1",
+    }
+
+
+def test_antigravity_setup_leaves_remote_proxy_outside_docker_mapping(
+    tmp_path, monkeypatch,
+):
+    executable = tmp_path / "antigravity"
+    executable.write_bytes(b"official-binary")
+    source = {
+        "HTTP_PROXY": "http://proxy.corp.example:43128",
+        "HTTPS_PROXY": "http://proxy.corp.example:43128",
+        "NO_PROXY": "localhost,127.0.0.1",
+    }
+    monkeypatch.setattr(
+        provider_config, "provider_subprocess_env", lambda: source,
+    )
+
+    command, env = provider_config._antigravity_container_command(
+        "/usr/bin/docker", executable, ["models"], interactive=False,
+    )
+
+    assert env == source
+    assert "--add-host" not in command
+    assert "host.docker.internal:host-gateway" not in command
 
 
 @pytest.mark.parametrize("kind", ["missing", "directory", "empty", "invalid"])

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -353,6 +353,37 @@ def test_antigravity_setup_mounts_a_verified_ca_bundle_readonly(
     ]
 
 
+def test_antigravity_setup_bridges_host_loopback_proxy_into_docker(
+    tmp_path, monkeypatch,
+):
+    executable = tmp_path / "antigravity"
+    executable.write_bytes(b"official-binary")
+    monkeypatch.setattr(
+        provider_config,
+        "provider_subprocess_env",
+        lambda: {
+            "HTTP_PROXY": "http://localhost:7897",
+            "HTTPS_PROXY": "http://user:p%40ss@127.0.0.1:7897",
+            "ALL_PROXY": "socks5://[::1]:7897",
+            "NO_PROXY": "localhost,127.0.0.1",
+        },
+    )
+
+    command, env = provider_config._antigravity_container_command(
+        "/usr/bin/docker", executable, ["models"], interactive=False,
+    )
+
+    assert env["HTTP_PROXY"] == "http://host.docker.internal:7897"
+    assert env["HTTPS_PROXY"] == (
+        "http://user:p%40ss@host.docker.internal:7897"
+    )
+    assert env["ALL_PROXY"] == "socks5://host.docker.internal:7897"
+    assert env["NO_PROXY"] == "localhost,127.0.0.1"
+    add_host = command.index("--add-host")
+    assert command[add_host + 1] == "host.docker.internal:host-gateway"
+    assert "http://user:p%40ss@host.docker.internal:7897" not in command
+
+
 @pytest.mark.parametrize("kind", ["missing", "directory", "empty", "invalid"])
 def test_antigravity_setup_rejects_an_unusable_ca_bundle(
     kind, tmp_path, monkeypatch,


### PR DESCRIPTION
## Summary

- use the same explicit, shell, or OS-level proxy discovery for Antigravity OAuth setup and Pier task egress
- translate localhost, IPv4 loopback, and IPv6 loopback proxy URLs to host.docker.internal only for Docker
- preserve every configured proxy port, scheme, encoded credentials, and NO_PROXY value
- keep remote proxy addresses and the original host environment unchanged
- keep DRADAR_CONTAINER_HTTP_PROXY authoritative when Docker needs a different address
- add the Docker host-gateway mapping only when a loopback proxy is translated
- keep proxy values out of command arguments

## Root cause

OAuth setup succeeded through the macOS proxy, but Pier task egress did not use the same OS proxy discovery. Task containers therefore reached Google directly and received a location-not-supported response; a concurrent token initialization could then surface as an authentication timeout.

## Verification

- 94 focused egress, provider setup, Antigravity, and shared OAuth tests passed
- dynamic loopback ports covered: 7890, 7897, 8080, 10809, and 65535
- remote proxy preservation and host-environment immutability covered
- real Antigravity doctor passed every Docker, egress, OAuth, and model check using the installed local build
- generated runtime maps the detected host proxy from 127.0.0.1:7897 to host.docker.internal:7897
- full suite: 1154 passed, 5 skipped, with one unrelated pre-existing dangling-symlink checkpoint test failure