### PR TITLE
Fix Antigravity Pompeii base ref validation

### DIFF
--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -3092,10 +3092,18 @@ def _antigravity_tasks_overlay(
     except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
         raise RunnerError(f"Antigravity task.toml is unreadable: {exc}") from exc
     base_commit = task_config.get("metadata", {}).get("base_commit_hash")
-    if (
-        not isinstance(base_commit, str)
-        or re.fullmatch(r"[0-9a-f]{40}", base_commit) is None
-    ):
+    valid_commit = (
+        isinstance(base_commit, str)
+        and re.fullmatch(r"[0-9a-f]{40}", base_commit) is not None
+    )
+    # Pompeii's reviewed task pack creates a fixed local tag rather than a
+    # portable 40-byte commit id.  Keep the shell substitution fail-closed:
+    # only that exact tag is accepted, and only for Pompeii task ids.
+    valid_pompeii_tag = (
+        base_commit == "pompeii-base"
+        and task_id.startswith(POMPEII_BENCHMARK_ID + "-")
+    )
+    if not (valid_commit or valid_pompeii_tag):
         raise RunnerError(
             "Antigravity task has an invalid metadata.base_commit_hash"
         )

--- a/tests/test_antigravity_subscription.py
+++ b/tests/test_antigravity_subscription.py
@@ -151,6 +151,28 @@ def test_antigravity_task_overlay_rejects_unverifiable_base(
             pass
 
 
+def test_antigravity_task_overlay_accepts_reviewed_pompeii_base_tag(
+    tmp_path: Path,
+) -> None:
+    task_id = "pompeii-adjacency-rp-002"
+    task = tmp_path / "tasks" / task_id
+    task.mkdir(parents=True)
+    (task / "task.toml").write_text(
+        '[metadata]\nbase_commit_hash = "pompeii-base"\n',
+        encoding="utf-8",
+    )
+
+    assignment = _assignment()
+    assignment["task_id"] = task_id
+    with runner._antigravity_tasks_overlay(
+        assignment, tmp_path / "tasks", tmp_path / "work", "job",
+    ) as overlay:
+        script = (overlay / task_id / "pre_artifacts.sh").read_text(
+            encoding="utf-8",
+        )
+        assert "base_ref='pompeii-base'" in script
+
+
 def _usage_helper():
     source = Path(providers.__file__).with_name("pier_antigravity.py").read_text()
     module = ast.parse(source)


### PR DESCRIPTION
## Summary
- accept the reviewed `pompeii-base` tag only for Pompeii task ids
- retain the existing 40-hex requirement for every other Antigravity task
- add regression coverage for the Pompeii overlay

## Tests
- `139 passed` across `test_runner_tools.py` and `test_antigravity_subscription.py`