### PR TITLE
Fix Antigravity shared OAuth ownership handoff

### DIFF
--- a/src/dradar/pier_antigravity.py
+++ b/src/dradar/pier_antigravity.py
@@ -62,6 +62,51 @@ def _model_line_pattern(model: str) -> str:
     return "^" + re.escape(model) + r"([[:space:]]|$)"
 
 
+def _shared_oauth_guarded_command(command: str, *, remote_gemini: str) -> str:
+    """Return a rootful-container command with a bounded OAuth handoff guard.
+
+    The official CLI atomically replaces files below its ``.gemini`` home and
+    creates ``antigravity-cli/cli.log`` as a convenience symlink.  In a
+    rootful task container those new inodes otherwise become root-owned on the
+    host bind mount, so a concurrent worker (or the host-side post-run policy
+    restore) cannot inspect them.  Derive the numeric host owner from the
+    mounted directory, never follow links while repairing ownership, remove
+    only the known disposable log link, and make one synchronous final repair
+    before control returns to the host.
+    """
+
+    oauth_root = shlex.quote(remote_gemini)
+    cli_log = shlex.quote(remote_gemini + "/antigravity-cli/cli.log")
+    guarded = (
+        f"oauth_root={oauth_root}; oauth_cli_log={cli_log}; "
+        "oauth_owner=$(stat -c '%u:%g' \"$oauth_root\") || exit 1; "
+        "oauth_uid=${oauth_owner%%:*}; oauth_gid=${oauth_owner#*:}; "
+        "oauth_guard_pid=''; "
+        "oauth_repair() { "
+        "if [ -L \"$oauth_cli_log\" ]; then rm -f -- \"$oauth_cli_log\"; fi; "
+        "find \"$oauth_root\" -xdev ! -type l "
+        "\\( ! -uid \"$oauth_uid\" -o ! -gid \"$oauth_gid\" \\) "
+        "-exec chown -h -- \"$oauth_owner\" {} +; "
+        "}; "
+        "oauth_cleanup() { "
+        "oauth_status=$?; "
+        "if [ -n \"$oauth_guard_pid\" ]; then "
+        "kill \"$oauth_guard_pid\" 2>/dev/null || true; "
+        "wait \"$oauth_guard_pid\" 2>/dev/null || true; fi; "
+        "oauth_repair || true; "
+        "exit \"$oauth_status\"; "
+        "}; "
+        "if [ \"$(id -u)\" = 0 ]; then "
+        "oauth_repair || exit 1; "
+        "(while :; do oauth_repair || true; sleep 0.02; done) & "
+        "oauth_guard_pid=$!; "
+        "trap oauth_cleanup EXIT; "
+        "trap 'exit 130' INT; trap 'exit 143' TERM; fi; "
+        + command
+    )
+    return "bash -o pipefail -c " + shlex.quote(guarded)
+
+
 def _nonnegative_int(value: object) -> int | None:
     if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
         return value
@@ -388,12 +433,18 @@ class Antigravity(BaseInstalledAgent):
             )
             for slug in ANTIGRAVITY_RUNTIME_MODELS.values()
         )
+        models_command = (
+            f"umask 077; {shlex.quote(remote_cli)} models > {shlex.quote(models_file)} "
+            f"&& {model_checks}"
+        )
+        if self._shared_oauth:
+            models_command = _shared_oauth_guarded_command(
+                models_command,
+                remote_gemini=remote_gemini,
+            )
         await self.exec_as_agent(
             environment,
-            command=(
-                f"umask 077; {shlex.quote(remote_cli)} models > {shlex.quote(models_file)} "
-                f"&& {model_checks}"
-            ),
+            command=models_command,
             env=env,
         )
         stream = f"/logs/agent/{self._STREAM_FILE}"
@@ -415,12 +466,17 @@ class Antigravity(BaseInstalledAgent):
             "--print-timeout", "120m",
         ]
         command = " ".join(shlex.quote(part) for part in invocation)
+        invocation_command = "bash -o pipefail -c " + shlex.quote(
+            f"umask 077; cd /app && {command} 2>{shlex.quote(stderr)} "
+            f"| tee {shlex.quote(stream)}"
+        )
+        if self._shared_oauth:
+            invocation_command = _shared_oauth_guarded_command(
+                invocation_command, remote_gemini=remote_gemini,
+            )
         await self.exec_as_agent(
             environment,
-            command="bash -o pipefail -c " + shlex.quote(
-                f"umask 077; cd /app && {command} 2>{shlex.quote(stderr)} "
-                f"| tee {shlex.quote(stream)}"
-            ),
+            command=invocation_command,
             env=env,
         )
 

--- a/tests/test_antigravity_subscription.py
+++ b/tests/test_antigravity_subscription.py
@@ -671,6 +671,68 @@ def test_shared_oauth_guard_hands_rootful_runtime_state_back_to_host() -> None:
     subprocess.run(["bash", "-n", "-c", command], check=True)
 
 
+@pytest.mark.parametrize("uid", [0, 1000])
+@pytest.mark.parametrize("exit_status", [0, 23])
+def test_shared_oauth_guard_repairs_during_command_and_preserves_exit_status(
+    tmp_path: Path, uid: int, exit_status: int,
+) -> None:
+    helper = _shared_oauth_guard_helper()
+    root = tmp_path / "shared home" / ".gemini"
+    log_dir = root / "antigravity-cli"
+    log_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.log"
+    outside.write_text("untouched", encoding="utf-8")
+    log_link = log_dir / "cli.log"
+    log_link.symlink_to(outside)
+    trace = tmp_path / "trace"
+    repaired = tmp_path / "repaired"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    # Exercise the generated shell without requiring root or GNU utilities.
+    # The fake find records a repair; it never changes real file ownership.
+    for name, body in {
+        "id": f"printf '%s\\n' {uid}",
+        "stat": "printf '%s\\n' '1000:1000'",
+        "find": 'printf "repair\\n" >> "$GUARD_TRACE"; : > "$GUARD_REPAIRED"',
+    }.items():
+        executable = fake_bin / name
+        executable.write_text("#!/bin/sh\n" + body + "\n", encoding="utf-8")
+        executable.chmod(0o700)
+    payload = 'printf "command\\n" >> "$GUARD_TRACE"; '
+    if uid == 0:
+        # Require a new repair while the foreground command is still active.
+        payload += (
+            'rm -f "$GUARD_REPAIRED"; tries=0; '
+            'while [ ! -f "$GUARD_REPAIRED" ] && [ "$tries" -lt 100 ]; do '
+            'sleep 0.01; tries=$((tries + 1)); done; '
+            '[ -f "$GUARD_REPAIRED" ] || exit 99; '
+        )
+    payload += f"exit {exit_status}"
+    result = subprocess.run(
+        ["bash", "-c", helper(payload, remote_gemini=str(root))],
+        env={
+            **os.environ,
+            "PATH": str(fake_bin) + os.pathsep + os.environ.get("PATH", ""),
+            "GUARD_TRACE": str(trace),
+            "GUARD_REPAIRED": str(repaired),
+        },
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+    assert result.returncode == exit_status, result.stderr
+    events = trace.read_text(encoding="utf-8").splitlines()
+    if uid == 0:
+        assert events[0] == events[-1] == "repair"
+        assert "repair" in events[events.index("command") + 1:-1]
+        assert not log_link.is_symlink()
+    else:
+        assert events == ["command"]
+        assert log_link.is_symlink()
+    assert outside.read_text(encoding="utf-8") == "untouched"
+
+
 def test_runtime_model_preflight_accepts_the_official_tabular_output() -> None:
     helper = _model_line_pattern_helper()
     slug = ANTIGRAVITY_RUNTIME_MODELS["low"]

--- a/tests/test_antigravity_subscription.py
+++ b/tests/test_antigravity_subscription.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import shutil
+import shlex
 import stat
 import subprocess
 from pathlib import Path
@@ -216,6 +217,22 @@ def _model_line_pattern_helper():
         namespace,
     )
     return namespace["_model_line_pattern"]
+
+
+def _shared_oauth_guard_helper():
+    source = Path(providers.__file__).with_name("pier_antigravity.py").read_text()
+    module = ast.parse(source)
+    helper = next(
+        node for node in module.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_shared_oauth_guarded_command"
+    )
+    namespace = {"shlex": shlex}
+    exec(
+        compile(ast.Module(body=[helper], type_ignores=[]), "pier_antigravity.py", "exec"),
+        namespace,
+    )
+    return namespace["_shared_oauth_guarded_command"]
 
 
 def _usage(input_tokens: int, output_tokens: int, cache: int, thinking: int) -> dict:
@@ -494,6 +511,26 @@ def test_subscription_session_does_not_create_a_missing_oauth_tree(
     assert not antigravity_auth_path().exists()
 
 
+def test_subscription_session_discards_concurrent_cli_log_link(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    auth = _ready_home(tmp_path, monkeypatch)
+    log_dir = auth / "antigravity-cli" / "log"
+    log_dir.mkdir(parents=True)
+    log_file = log_dir / "cli-current.log"
+    log_file.write_text("official log", encoding="utf-8")
+    if os.name != "nt":
+        log_dir.chmod(0o700)
+        log_file.chmod(0o600)
+    cli_log = log_dir.parent / "cli.log"
+    cli_log.symlink_to(Path("log") / log_file.name)
+
+    with antigravity_subscription_session(tmp_path / "work"):
+        assert not cli_log.exists()
+
+    assert antigravity_auth_error() is None
+
+
 @pytest.mark.parametrize("raises", [False, True])
 def test_subscription_session_restores_policy_after_every_trial(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, raises: bool,
@@ -615,6 +652,23 @@ def test_adapter_uses_full_permissions_inside_pier_container() -> None:
     assert '"lh3.googleusercontent.com"' in source
     assert "*.googleapis.com" not in source
     assert "*.googleusercontent.com" not in source
+
+
+def test_shared_oauth_guard_hands_rootful_runtime_state_back_to_host() -> None:
+    helper = _shared_oauth_guard_helper()
+    command = helper(
+        "antigravity models", remote_gemini="/tmp/dradar-antigravity-user/.gemini",
+    )
+    assert "stat -c" in command
+    assert "find" in command
+    assert "-xdev" in command
+    assert "! -type l" in command
+    assert "chown -h" in command
+    assert "antigravity-cli/cli.log" in command
+    assert "sleep 0.02" in command
+    assert "trap oauth_cleanup EXIT" in command
+    assert "antigravity models" in command
+    subprocess.run(["bash", "-n", "-c", command], check=True)
 
 
 def test_runtime_model_preflight_accepts_the_official_tabular_output() -> None:


### PR DESCRIPTION
## Summary

The Antigravity CLI can atomically replace shared OAuth files with root-owned inodes while a rootful task container is still running. A concurrent host-side preflight or policy restore can then lose access before the command finishes. This change repairs ownership during each shared-OAuth command and performs a final repair on exit while preserving the command's status.

Rebased onto `main@82a1a003d340eb37ccd1b7a9663c34a6f700115a`. The remaining diff is limited to the Antigravity adapter and its regression tests. Upstream's `prepare_antigravity_auth`, private foreign-owned state handling, and post-command Docker ownership reconciliation are retained unchanged. The host-side convenience-link cleanup already landed upstream and is no longer duplicated here.

## Implementation

- Wrap only shared-OAuth Antigravity model discovery and task invocations; the non-shared path is unchanged.
- Derive the numeric UID/GID from the mounted root. Repair without following symlinks or crossing filesystems, remove only the known disposable `antigravity-cli/cli.log` link, and stop the guard before the final synchronous repair.
- Keep upstream's after-command reconciliation. The remaining guard covers the interval while the foreground command is running.
- Add isolated shell-execution regressions for root/non-root modes, in-flight repair, success/failure exit preservation, and preservation of the log symlink's external target. Fake ownership tools keep these tests independent of root privileges and real credentials.

## Verification

Head: `8e04f84e87b4ed3d6901653d18ca3ce3eb141a73`.

- Focused Antigravity and shared-OAuth Docker tests: **52 passed**.
- Full suite with Python 3.14 and the declared development dependencies plus the release-test dependency `botocore`: **1,908 passed, 2 skipped, 1 failed**.
- The sole remaining failure is `tests/test_go_menu.py::test_mixed_batch_one_failure_yields_rc_1`: its cleanup path requires a Docker CLI. It reproduces independently on a clean checkout of `main@82a1a003`; it is outside this diff. No Docker daemon, provider probe, or live authentication was invoked.
- `git diff --check`: passed.

The full suite is not claimed green. Maintainer review of the OAuth ownership change remains required.
