### PR TITLE
fix: isolate scoped refill accounting by harness

### DIFF
--- a/src/dradar/refill.py
+++ b/src/dradar/refill.py
@@ -307,8 +307,8 @@ def configure(
     refill_effort: str | None = None,
     replace_existing: bool = False,
 ) -> dict:
-    if refill_to < 1 or max_tasks < 1 or max_tasks < len(active):
-        raise RefillError("max tasks must be at least the currently held task count")
+    if refill_to < 1 or max_tasks < 1:
+        raise RefillError("refill target and max tasks must be positive")
     if quota_tier not in TIERS:
         raise RefillError(f"unknown quota tier: {quota_tier}")
     if refill_harness is None and (refill_model is not None or refill_effort is not None):
@@ -330,6 +330,16 @@ def configure(
         "refill_model": refill_model,
         "refill_effort": refill_effort,
     }
+    # A scoped plan owns only its Harness/model/effort lane.  The account may
+    # legitimately hold work for other independent Harness campaigns; treating
+    # those assignments as seeds would block this plan until the entire account
+    # drained and would also consume its max-tasks budget.  Keep unscoped plans
+    # unchanged, but isolate scoped accounting from the first persisted write.
+    if refill_harness is not None:
+        active = [assignment for assignment in active
+                  if _matches_scope(desired, assignment)]
+    if max_tasks < len(active):
+        raise RefillError("max tasks must be at least the currently held task count")
     with _locked(home):
         current = _load_unlocked(home)
         replaced_plan_id = None
@@ -633,6 +643,9 @@ def refill_once(home: Path, client) -> dict:
         if active is None:
             one = data.get("assignment")
             active = [one] if one else []
+        if plan.get("refill_harness"):
+            active = [assignment for assignment in active
+                      if _matches_scope(plan, assignment)]
         try:
             for assignment in active:
                 _reserve(plan, assignment)

--- a/tests/test_refill_scope.py
+++ b/tests/test_refill_scope.py
@@ -286,6 +286,52 @@ def test_scoped_seed_barrier_still_blocks_every_auto_claim(tmp_path: Path):
     assert client.claimed == []
 
 
+def test_scoped_plan_ignores_other_harness_assignments_at_configuration(
+    tmp_path: Path,
+):
+    wanted = _assignment("wanted")
+    unrelated = [
+        _assignment("zcode", agent=ZCODE_AGENT,
+                    model="glm-5.3-flash", effort="high"),
+        _assignment("codex", agent="codex",
+                    model="gpt-5.6-luna", effort="high"),
+    ]
+
+    plan = _configure(
+        tmp_path, refill_to=2, max_tasks=2,
+        active=[wanted, *unrelated],
+    )
+
+    assert plan["seed_assignment_ids"] == ["wanted"]
+    assert set(plan["assignments"]) == {"wanted"}
+
+
+def test_scoped_reconcile_counts_only_its_harness_active_assignments(
+    tmp_path: Path,
+):
+    wanted = _assignment("wanted")
+    unrelated = [
+        _assignment("zcode", agent=ZCODE_AGENT,
+                    model="glm-5.3-flash", effort="high"),
+        _assignment("codex", agent="codex",
+                    model="gpt-5.6-luna", effort="high"),
+    ]
+    client = ScopedClient(_table(
+        ("next", KIMI_AGENT, "k3", "low", "open"),
+    ), active=[wanted, *unrelated])
+    _configure(tmp_path, refill_to=2, max_tasks=3, active=[wanted])
+    refill.mark_submitted(tmp_path, "wanted")
+
+    result = refill.refill_once(tmp_path, client)
+
+    assert result["claimed"] == 1
+    assert result["held"] == 2
+    assert client.claimed == [("next", "k3", "low")]
+    assert set(refill.load(tmp_path)["assignments"]) == {
+        "wanted", "a-next",
+    }
+
+
 def test_scoped_plan_persists_scope_and_conflicts_safely(tmp_path: Path):
     first = _configure(tmp_path)
     stored = refill.load(tmp_path)


### PR DESCRIPTION
## Summary
- scope refill seed barriers and task accounting to the selected Harness/model/effort
- ignore unrelated in-flight assignments owned by independent Harness campaigns
- preserve existing unscoped refill behavior

## Verification
- `pytest -q tests/test_refill_scope.py tests/test_refill.py` (64 passed)
- `pytest -q` (1200 passed, 5 skipped)

## Incident
A ZCode refill session on a mixed Codex/ZCode/Grok/Antigravity account treated every other Harness assignment as a seed barrier, so it could not refill until the whole account drained. This keeps each scoped campaign independent.