### PR TITLE
fix: preflight Claude website run plans

### DIFF
--- a/src/dradar/doctor.py
+++ b/src/dradar/doctor.py
@@ -175,7 +175,7 @@ def _plan_agent_recovery(
             },
         ))
     if harness in {
-        "codex", "dsh-minimal", GROK_AGENT, KIMI_AGENT, ZCODE_AGENT,
+        "codex", "dsh-minimal", GROK_AGENT, KIMI_AGENT, CLAUDE_AGENT, ZCODE_AGENT,
         ANTIGRAVITY_AGENT, CODEBUDDY_AGENT,
     }:
         commands.append({
@@ -321,6 +321,16 @@ def plan_environment_issue(plan: dict) -> dict | None:
                 harness, "current_tool_not_ready",
                 "这次运行需要 Kimi；请完成 Kimi 的安装和登录后重试。",
                 "setup_current_tool", setup_provider="kimi",
+            )
+        return None
+    if harness == CLAUDE_AGENT:
+        executable = shutil.which("claude")
+        ready = bool(executable) and claude_oauth_error() is None
+        if not ready:
+            return _plan_issue(
+                harness, "current_tool_not_ready",
+                "这次运行需要 Claude Code；请完成 Claude Code 的安装和登录后重试。",
+                "setup_current_tool", setup_provider="claude",
             )
         return None
     if harness == ZCODE_AGENT:

--- a/tests/test_run_plans.py
+++ b/tests/test_run_plans.py
@@ -2068,12 +2068,57 @@ def test_missing_current_tool_on_second_machine_has_actionable_issue(
     ]
 
 
+def test_claude_plan_accepts_ready_subscription_runtime(monkeypatch):
+    monkeypatch.setattr(
+        doctor.shutil, "which",
+        lambda name: f"/usr/bin/{name}" if name in {"docker", "claude"} else None,
+    )
+    monkeypatch.setattr(doctor, "_probe", lambda _command: True)
+    monkeypatch.setattr(doctor.runner, "ensure_pier", lambda: None)
+    monkeypatch.setattr(doctor, "claude_oauth_error", lambda: None)
+
+    assert doctor.plan_environment_issue(
+        _plan(harness="claude-code", task_count=1),
+    ) is None
+
+
+@pytest.mark.parametrize("missing", ["cli", "oauth"])
+def test_claude_plan_fails_closed_with_actionable_setup(missing, monkeypatch):
+    monkeypatch.setattr(
+        doctor.shutil, "which",
+        lambda name: (
+            "/usr/bin/docker" if name == "docker" else
+            (None if missing == "cli" else "/usr/bin/claude")
+        ),
+    )
+    monkeypatch.setattr(doctor, "_probe", lambda _command: True)
+    monkeypatch.setattr(doctor.runner, "ensure_pier", lambda: None)
+    monkeypatch.setattr(
+        doctor, "claude_oauth_error",
+        lambda: "missing OAuth" if missing == "oauth" else None,
+    )
+
+    issue = doctor.plan_environment_issue(
+        _plan(harness="claude-code", task_count=1),
+    )
+
+    assert issue["error_code"] == "current_tool_not_ready"
+    assert issue["agent_action"] == "setup_current_tool"
+    assert issue["agent"]["requires_user_action"] is True
+    assert [item["argv"] for item in issue["agent"]["next_commands"]] == [
+        ["dradar", "provider", "setup", "claude"],
+        ["dradar", "provider", "status", "claude", "--live"],
+        ["dradar", "doctor", "--agent", "claude-code"],
+    ]
+
+
 @pytest.mark.parametrize(
     "harness,provider",
     [
         ("dsh-minimal", "deepseek"),
         ("grok-build", "grok"),
         ("kimi-code", "kimi"),
+        ("claude-code", "claude"),
         ("zcode", "zcode"),
         ("antigravity", "antigravity"),
         ("codebuddy", "codebuddy"),


### PR DESCRIPTION
## Summary
- recognize `claude-code` in website run-plan environment preflight
- require the local Claude CLI and subscription OAuth before server start
- return structured, non-secret recovery commands when setup is missing
- cover ready, missing-CLI, and missing-OAuth paths

## Tests
- `pytest -q tests/test_run_plans.py -k "claude_plan or every_optional_tool"` (10 passed)
- `pytest -q tests/test_run_plans.py` (95 passed)
- isolated `DRADAR_HOME`: `pytest -q` (1281 passed, 2 skipped)