### PR TITLE
fix: preserve complete Claude usage on upload

### DIFF
--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -1636,12 +1636,21 @@ def _upload_trial(
 
     upload_meta = dict(entry.get("meta") or {})
     trial_dir = Path(entry["trial_dir"])
+    # Claude Code emits an ATIF trajectory that is intentionally useful for
+    # audit, but it is not a Codex session tree. Prefer the adapter's strictly
+    # reconciled provider sidecar so the generic Codex bundle parser cannot
+    # shadow complete Claude request usage with an incomplete session bundle.
+    claude_usage = (
+        _subscription_trial_usage(trial_dir, upload_meta)
+        if upload_meta.get("claude_cli_version")
+        else None
+    )
     trajectory_bundle = None
     if not upload_meta.get("codebuddy_cli_version"):
         trajectory_bundle = build_codex_trajectory_bundle(trial_dir)
         if trajectory_bundle is None:
             trajectory_bundle = build_kimi_trajectory_bundle(trial_dir)
-    usage = (
+    usage = claude_usage or (
         codex_trajectory_bundle_usage(trajectory_bundle)
         if (
             trajectory_bundle is not None

--- a/tests/test_pending_upload.py
+++ b/tests/test_pending_upload.py
@@ -924,6 +924,81 @@ def test_upload_uses_reconciled_kimi_provider_usage_with_audit_bundle(
     assert outcome == "submitted"
 
 
+def test_upload_prefers_complete_claude_sidecar_over_incomplete_codex_bundle(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    agent_dir = trial_dir / "agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "provider-usage.json").write_text(json.dumps({
+        "schema": "dradar-subscription-provider-usage-v1",
+        "provider": "claude-code",
+        "model": "claude-sonnet-5",
+        "complete": True,
+        "request_count": 2,
+        "n_input_tokens": 300,
+        "n_cache_tokens": 200,
+        "n_output_tokens": 21,
+        "cache_creation_tokens": 75,
+        "request_usage_complete": True,
+        "request_usage_observed": True,
+        "timed_usage_complete": True,
+        "usage_evidence_tier": "complete_reconciled",
+        "provider_actual_cost_observed": False,
+        "cost_semantics": "api_equivalent_only",
+        "token_usage_events": [{
+            "occurred_at": "2026-08-31T00:00:00Z",
+            "n_input_tokens": 100,
+            "n_cache_tokens": 80,
+            "n_output_tokens": 10,
+        }, {
+            "occurred_at": "2026-08-31T00:01:00Z",
+            "n_input_tokens": 200,
+            "n_cache_tokens": 120,
+            "n_output_tokens": 11,
+        }],
+    }), encoding="utf-8")
+    incomplete_bundle = {
+        "schema_version": runloop.CODEX_TRAJECTORY_BUNDLE_SCHEMA,
+        "complete": False,
+        "session_file_count": 2,
+        "agent_session_count": 2,
+        "root_session_count": 0,
+        "subagent_session_count": 0,
+        "aggregate_usage": {},
+        "timed_usage_complete": False,
+        "usage_sessions": [],
+        "sessions": [],
+    }
+    monkeypatch.setattr(
+        runloop, "build_codex_trajectory_bundle",
+        lambda _path: incomplete_bundle,
+    )
+
+    class CaptureClient(FakeClient):
+        def submit(self, assignment_id, nonce, patch, trajectory, result, meta,
+                   outcome="completed", resume_generation=None,
+                   trajectory_bundle=None):
+            assert meta["usage_aggregation"] == (
+                "dradar-subscription-provider-usage-v1"
+            )
+            assert meta["usage_aggregation_complete"] is True
+            assert meta["request_count"] == 2
+            assert meta["n_input_tokens"] == 300
+            assert meta["n_cache_tokens"] == 200
+            assert meta["n_output_tokens"] == 21
+            assert trajectory_bundle is not None
+            assert json.loads(trajectory_bundle.read_text())["complete"] is False
+            return {"submission_id": "s1", "grade_status": "pending"}
+
+    assert runloop._upload_trial(
+        CaptureClient(lambda _aid: None),
+        _entry(trial_dir, meta={"claude_cli_version": "2.1.251"}),
+    ) == "submitted"
+
+
 def test_incomplete_kimi_usage_keeps_tokens_and_cost_unavailable(
     tmp_path: Path, monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- prefer the reconciled Claude Code provider usage sidecar over a generic incomplete Codex bundle
- retain the generic trajectory bundle as an audit artifact
- add a regression test for the exact production shadowing failure

## Validation
- `PYTHONPATH=src pytest -q tests/test_pending_upload.py tests/test_claude_subscription.py` (95 passed)
- isolated full suite with temporary `DRADAR_HOME` (1282 passed, 2 skipped)