### PR TITLE
fix: wait for stable Claude trajectory usage

### DIFF
--- a/docs/HARNESS_INTEGRATION_BEST_PRACTICES.md
+++ b/docs/HARNESS_INTEGRATION_BEST_PRACTICES.md
@@ -154,6 +154,12 @@ trajectory；上传与 `retry-upload` 先读取严格校验的旁车，旁车缺
 或降级一份已完整对账的 Claude Code ATIF 用量。旁车和 trajectory 都不能通过校验时继续
 失败关闭，token、价格和榜单资格保持缺失。
 
+容器后处理写出的 trajectory 属于跨进程产物。“路径存在”不等于“内容已经稳定”：部分
+Docker 文件系统可能先暴露目录项，再补齐最终 JSON 字节。读取端应在短且有界的窗口内只对
+I/O/JSON 截断错误重试；一旦读到完整 JSON 但模型或总计不一致，立即失败关闭，不能继续等待
+并期待事实改变。生产 metadata 应记录最终采用的是 provider sidecar 还是 uploaded
+trajectory，便于金丝雀直接确认权威证据路径。
+
 ## 8. 测试分层与金丝雀门禁
 
 合并前至少完成：

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -1198,7 +1198,8 @@ def _subscription_trial_usage(trial_dir: Path, meta: dict) -> dict | None:
 
 
 def _claude_trial_usage_from_trajectory(
-    trial_dir: Path, expected_model: str,
+    trial_dir: Path, expected_model: str, *, attempts: int = 10,
+    retry_delay: float = 0.2,
 ) -> dict | None:
     """Rebuild Claude usage from the exact ATIF artifact being uploaded.
 
@@ -1213,11 +1214,22 @@ def _claude_trial_usage_from_trajectory(
     _patch, trajectory_path, _result = trial_artifact_paths(trial_dir)
     if trajectory_path is None:
         return None
-    try:
-        trajectory = json.loads(trajectory_path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return None
-    return claude_usage_facts(trajectory, expected_model)
+    for attempt in range(max(1, attempts)):
+        try:
+            trajectory = json.loads(trajectory_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            trajectory = None
+        if trajectory is not None:
+            usage = claude_usage_facts(trajectory, expected_model)
+            if usage is not None:
+                return usage
+            # A complete JSON document with the wrong model or irreconcilable
+            # totals will not become trustworthy by waiting. Keep that case
+            # fail-closed rather than masking it as a filesystem race.
+            return None
+        if attempt + 1 < attempts and retry_delay > 0:
+            time.sleep(retry_delay)
+    return None
 
 
 def _dsh_completed_outcome(
@@ -1669,15 +1681,22 @@ def _upload_trial(
         if upload_meta.get("claude_cli_version")
         else None
     )
-    if claude_usage is None and upload_meta.get("claude_cli_version"):
-        claude_usage = _claude_trial_usage_from_trajectory(
-            trial_dir, str(upload_meta.get("claude_model") or ""),
-        )
+    claude_usage_source = "provider-sidecar" if claude_usage is not None else None
     trajectory_bundle = None
     if not upload_meta.get("codebuddy_cli_version"):
         trajectory_bundle = build_codex_trajectory_bundle(trial_dir)
         if trajectory_bundle is None:
             trajectory_bundle = build_kimi_trajectory_bundle(trial_dir)
+    # Pier finalizes Claude's ATIF file in a post-run hook. On some Docker
+    # filesystems the directory entry becomes visible a fraction before the
+    # final JSON bytes do. Build the audit bundle first, then make a bounded
+    # stable read of the exact trajectory that will be uploaded.
+    if claude_usage is None and upload_meta.get("claude_cli_version"):
+        claude_usage = _claude_trial_usage_from_trajectory(
+            trial_dir, str(upload_meta.get("claude_model") or ""),
+        )
+        if claude_usage is not None:
+            claude_usage_source = "uploaded-trajectory"
     usage = claude_usage or (
         codex_trajectory_bundle_usage(trajectory_bundle)
         if (
@@ -1700,6 +1719,8 @@ def _upload_trial(
         upload_meta["cost_usd"] = None
         upload_meta["usage_aggregation"] = usage["schema"]
         upload_meta["usage_aggregation_complete"] = usage["complete"]
+        if claude_usage_source is not None:
+            upload_meta["claude_usage_source"] = claude_usage_source
         for key in (
             "agent_session_count", "root_session_count",
             "subagent_session_count", "agent_session_usage", "request_count",
@@ -1737,6 +1758,10 @@ def _upload_trial(
                 )
                 else None
             )
+    elif upload_meta.get("claude_cli_version"):
+        upload_meta["claude_usage_diagnostic"] = (
+            "provider-sidecar-and-trajectory-unavailable-or-invalid"
+        )
 
     with tempfile.TemporaryDirectory() as td:
         scrubbed = Path(td)

--- a/tests/test_pending_upload.py
+++ b/tests/test_pending_upload.py
@@ -1056,6 +1056,7 @@ def test_upload_rebuilds_claude_usage_from_trajectory_when_sidecar_is_missing(
             assert meta["n_cache_tokens"] == 200
             assert meta["n_output_tokens"] == 21
             assert meta["subscription_reported_cost_usd"] == 0.25
+            assert meta["claude_usage_source"] == "uploaded-trajectory"
             return {"submission_id": "s1", "grade_status": "pending"}
 
     assert runloop._upload_trial(
@@ -1065,6 +1066,59 @@ def test_upload_rebuilds_claude_usage_from_trajectory_when_sidecar_is_missing(
             "claude_model": "claude-sonnet-5",
         }),
     ) == "submitted"
+
+
+def test_claude_trajectory_read_retries_a_transient_partial_json(
+    tmp_path: Path,
+    monkeypatch,
+):
+    trial_dir = _make_trial_dir(tmp_path)
+    agent_dir = trial_dir / "agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    trajectory_path = agent_dir / "trajectory.json"
+    trajectory_path.write_text("{", encoding="utf-8")
+    complete = json.dumps({
+        "agent": {"model_name": "claude-sonnet-5"},
+        "steps": [{
+            "timestamp": "2026-09-01T00:00:00Z",
+            "metrics": {
+                "prompt_tokens": 10,
+                "cached_tokens": 6,
+                "completion_tokens": 2,
+                "extra": {"cache_creation_input_tokens": 3},
+            },
+        }],
+        "final_metrics": {
+            "total_prompt_tokens": 10,
+            "total_cached_tokens": 6,
+            "total_completion_tokens": 2,
+            "total_cost_usd": 0.01,
+            "extra": {"total_cache_creation_input_tokens": 3},
+        },
+    })
+    original_read_text = Path.read_text
+    reads = 0
+
+    def finish_after_first_read(path, *args, **kwargs):
+        nonlocal reads
+        value = original_read_text(path, *args, **kwargs)
+        if path == trajectory_path:
+            reads += 1
+            if reads == 1:
+                trajectory_path.write_text(complete, encoding="utf-8")
+        return value
+
+    delays = []
+    monkeypatch.setattr(Path, "read_text", finish_after_first_read)
+    monkeypatch.setattr(runloop.time, "sleep", delays.append)
+
+    usage = runloop._claude_trial_usage_from_trajectory(
+        trial_dir, "claude-sonnet-5", attempts=3, retry_delay=0.2,
+    )
+
+    assert usage is not None and usage["request_count"] == 1
+    assert reads == 2
+    assert delays == [0.2]
 
 
 def test_upload_does_not_rebuild_claude_usage_for_wrong_assignment_model(
@@ -1102,6 +1156,9 @@ def test_upload_does_not_rebuild_claude_usage_for_wrong_assignment_model(
                    trajectory_bundle=None):
             assert "usage_aggregation" not in meta
             assert "n_input_tokens" not in meta
+            assert meta["claude_usage_diagnostic"] == (
+                "provider-sidecar-and-trajectory-unavailable-or-invalid"
+            )
             return {"submission_id": "s1", "grade_status": "pending"}
 
     assert runloop._upload_trial(


### PR DESCRIPTION
## Summary
- make Claude trajectory usage reconstruction tolerate a transient partial JSON write with a short bounded retry
- delay the fallback until after the audit bundle build and record the selected evidence source
- retain fail-closed behavior for complete-but-mismatched trajectories and document the cross-process artifact rule

## Tests
- `pytest -q tests/test_pending_upload.py tests/test_go_menu.py tests/test_runner_tools.py tests/test_claude_subscription.py` (270 passed)
- `pytest -q` (1295 passed, 2 skipped)