### PR TITLE
fix: pin isolated BuildKit to fuse-overlayfs and stop retrying ENOSPC as a mirror flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,10 +790,13 @@ dradar cleanup --docker --all-task-images  # 一次性处理升级前遗留镜�
 本地诊断文件和题目镜像，但仍会停止容器并删除临时构建空间。
 
 每道题使用独立、一次性的 Docker 构建空间，题目结束时直接删除该构建空间，因此不会
-清理或占用用户其他项目的 BuildKit 缓存。容器、网络、卷和镜像仍须同时通过精确任务
-目录、Compose 标签、镜像引用和镜像 ID 校验；不会运行全局 `docker system prune`、
-`docker image prune` 或默认 builder 的全局缓存清理。任何一步无法确认时，本题结果仍会
-保存，但该 worker 会停止继续领取或运行下一题，并显示可操作的原因。
+清理或占用用户其他项目的 BuildKit 缓存。该构建空间固定使用 fuse-overlayfs，避免
+BuildKit 在 native snapshotter 下落到每条 Dockerfile `RUN` 都复制完整 rootfs，从而在
+构建过程中把磁盘打满。构建因磁盘耗尽失败时不会当成镜像源/网络抽风自动重试。容器、
+网络、卷和镜像仍须同时通过精确任务目录、Compose 标签、镜像引用和镜像 ID 校验；不会
+运行全局 `docker system prune`、`docker image prune` 或默认 builder 的全局缓存清理。
+任何一步无法确认时，本题结果仍会保存，但该 worker 会停止继续领取或运行下一题，并显示
+可操作的原因。
 
 升级前已经积累的 Pier 镜像必须显式使用 `--all-task-images`，仍会经过标签、容器和本地
 恢复状态校验；旧版本写入默认 builder 的历史缓存无法证明只属于 DRadar，因此不会在

--- a/src/dradar/image_cache.py
+++ b/src/dradar/image_cache.py
@@ -33,6 +33,13 @@ LEDGER_NAME = "image-cache.json"
 LOCK_NAME = "image-cache.lock"
 MAINTENANCE_STAMP_NAME = "image-cache-maintenance.stamp"
 BUILDER_PREFIX = "dradar-task-"
+# docker-container BuildKit auto can select the native snapshotter, which
+# copies a full rootfs for every Dockerfile RUN. That peak has filled a
+# volunteer Linux disk during a single DeepSWE compose build, then vanished
+# when the per-task volume was deleted after Pier exited. Pin fuse-overlayfs
+# so the isolated builder stays copy-on-write even when kernel overlay is
+# unavailable inside the privileged BuildKit container.
+ISOLATED_SNAPSHOTTER = "fuse-overlayfs"
 GIB = 1024 ** 3
 DEFAULT_MIN_FREE_GIB = 25.0
 _PROJECT_RE = re.compile(r"[a-z0-9][a-z0-9-]*__[a-z0-9]{6,8}$")
@@ -201,6 +208,15 @@ def trial_builder_name(home: Path, assignment_id: str) -> str:
     return BUILDER_PREFIX + hashlib.sha256(identity).hexdigest()[:20]
 
 
+def _trial_builder_create_command(name: str) -> list[str]:
+    return [
+        "buildx", "create", "--name", name,
+        "--driver", "docker-container",
+        "--buildkitd-flags",
+        f"--oci-worker-snapshotter={ISOLATED_SNAPSHOTTER}",
+    ]
+
+
 def _builder_proxy_is_safe(runtime: dict[str, str]) -> tuple[bool, str | None]:
     """Whether a dedicated bridge builder can use the configured build proxy.
 
@@ -233,6 +249,8 @@ def prepare_trial_builder(
     The builder is never selected globally. ``BUILDX_BUILDER`` is applied only
     to Pier's child environment, and deleting the builder removes its dedicated
     BuildKit state volume without touching the user's default builder cache.
+    The docker-container node is pinned to fuse-overlayfs so BuildKit cannot
+    fall back to the native snapshotter's full-rootfs copies.
     """
     runtime = runtime or {}
     safe, note = _builder_proxy_is_safe(runtime)
@@ -253,10 +271,9 @@ def prepare_trial_builder(
             # assignment concurrently. A matching builder is stale residue
             # from a crashed prior attempt and is safe to replace exactly.
             _run_docker(["buildx", "rm", name], timeout=180)
-        created = _run_docker([
-            "buildx", "create", "--name", name,
-            "--driver", "docker-container",
-        ], timeout=120, allow_fail=True)
+        created = _run_docker(
+            _trial_builder_create_command(name), timeout=120, allow_fail=True,
+        )
         if created.returncode != 0:
             detail = (created.stderr or created.stdout or "").strip()
             return TrialBuilderLease(
@@ -1212,6 +1229,7 @@ __all__ = [
     "automatic_maintenance", "cleanup_trial_resources", "discover_pier_images",
     "claim_periodic_maintenance", "disk_allows_new_tasks", "disk_free_bytes",
     "effective_policy", "is_wsl", "load", "plan_cleanup",
+    "ISOLATED_SNAPSHOTTER",
     "prepare_trial_builder", "proxy_detected", "record_trial_images",
     "remove_assignment_images", "remove_images", "remove_trial_builder",
     "trial_builder_name",

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -86,7 +86,7 @@ from .providers import (
 )
 from .runner import (
     CODEX_TRAJECTORY_BUNDLE_SCHEMA, DIAG_ADVICE,
-    BuildFlakeError, RunnerError,
+    BuildDiskFullError, BuildFlakeError, RunnerError,
     RunnerCleanupUnconfirmedError, RunnerTaskRetryableError,
     POMPEII_BENCHMARK_ID,
     POMPEII_FINALIZATION_RESERVE_SEC, POMPEII_SOFT_BUDGET_SEC,
@@ -2514,6 +2514,21 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
                         + (builder_note or "Docker 未返回具体原因")
                     )
             break
+        except BuildDiskFullError as exc:
+            # ENOSPC during compose build is not a transient mirror flake.
+            # Retrying immediately re-creates the same per-task builder and
+            # fills the disk again. Stop this worker so the volunteer can
+            # free space; the agent never started.
+            print(
+                f"trial failed: {exc}\n"
+                "the build ran out of disk space — free space and re-run "
+                "`dradar resume` (still free: the agent never started), or "
+                "use `dradar release` if you do not want to keep the cell"
+            )
+            _mark_stopped_quietly(
+                client, assignment, failure_kind="environment_build_failed",
+            )
+            return "environment-build-failed"
         except BuildFlakeError as exc:
             # The image build died before the agent ran — a free failure
             # (zero quota), and mirror flakes usually pass on the second

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -433,6 +433,15 @@ class BuildFlakeError(RunnerError):
     blaming the agent for a mirror hiccup)."""
 
 
+class BuildDiskFullError(RunnerError):
+    """The trial died while BUILDING because the host disk was full.
+
+    Distinct from BuildFlakeError: retrying cannot create space, and BuildKit
+    ENOSPC lines almost always also contain ``failed to solve``, which would
+    otherwise be misread as a mirror/network flake.
+    """
+
+
 # Signatures (in the pier log tail) of an image build / infra failure that
 # happened before any agent ran. Deliberately specific: a false positive here
 # would auto-retry a run that DID burn quota.
@@ -441,9 +450,22 @@ _BUILD_FLAKE_MARKERS = (
     "apt-get update", "Temporary failure resolving", "proxyconnect",
     "TLS handshake timeout", "error getting credentials",
 )
+_DISK_FULL_MARKERS = (
+    "no space left",
+    "enospc",
+    "copy_file_range",
+    "disk quota exceeded",
+)
+
+
+def _looks_like_disk_full(log_tail: str) -> bool:
+    lowered = log_tail.lower()
+    return any(marker in lowered for marker in _DISK_FULL_MARKERS)
 
 
 def _looks_like_build_flake(log_tail: str) -> bool:
+    if _looks_like_disk_full(log_tail):
+        return False
     return any(m in log_tail for m in _BUILD_FLAKE_MARKERS)
 
 
@@ -3961,6 +3983,11 @@ def run_trial(
                     _zcode_runtime_diagnostic(jobs_dir, job_name)
                 )
             raise terminal_error
+        if _looks_like_disk_full(tail):
+            raise BuildDiskFullError(
+                "the task environment failed to BUILD because the disk is full "
+                "— the agent never started and no quota was used.\n"
+                f"last lines of the log:\n{tail}")
         if _looks_like_build_flake(tail):
             raise BuildFlakeError(
                 f"the task environment failed to BUILD (mirror/network flake) — "
@@ -4006,6 +4033,11 @@ def run_trial(
         # agent for a mirror hiccup.
         result_exception = _result_exception_text(result)
         diagnostic = "\n".join(x for x in (tail, result_exception) if x)
+        if _looks_like_disk_full(diagnostic):
+            raise BuildDiskFullError(
+                "the task environment failed to BUILD because the disk is full "
+                "— the agent never started and no quota was used.\n"
+                f"build diagnostic:\n{_diagnostic_tail(diagnostic)}")
         if _looks_like_build_flake(diagnostic):
             raise BuildFlakeError(
                 f"the task environment failed to BUILD (mirror/network flake) — "

--- a/tests/test_feedback_round2.py
+++ b/tests/test_feedback_round2.py
@@ -115,7 +115,9 @@ def test_quota_share_tiny_pct_never_shows_zero():
 
 import pytest
 
-from dradar.runner import BuildFlakeError, RunnerError, run_trial
+from dradar.runner import (
+    BuildDiskFullError, BuildFlakeError, RunnerError, run_trial,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -202,6 +204,46 @@ def test_run_and_submit_retries_build_flake_once(monkeypatch, capsys, tmp_path):
     tag = runloop._run_and_submit(client, ASSIGNMENT, tmp_path, _args(), "abc")
     assert tag == "submitted" and calls["n"] == 2
     assert "retrying once automatically" in capsys.readouterr().out
+
+
+def test_disk_full_build_is_not_a_mirror_flake(tmp_path, monkeypatch):
+    _flaky_pier(
+        monkeypatch, tmp_path, fail_times=99,
+        log_line=(
+            "ERROR: failed to solve: failed to copy files: "
+            "copy_file_range: no space left on device"
+        ),
+    )
+    with pytest.raises(BuildDiskFullError) as exc:
+        run_trial({"assignment_id": "a1", "task_id": "t", "agent": "codex",
+                   "model": "m", "effort": "low", "est_minutes": 2}, tmp_path, tmp_path)
+    assert "disk is full" in str(exc.value)
+    assert "no quota was used" in str(exc.value)
+    assert "copy_file_range" in str(exc.value)
+
+
+def test_run_and_submit_does_not_retry_disk_full(monkeypatch, capsys, tmp_path):
+    from test_go_menu import ASSIGNMENT, SubmitClient
+    monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
+    calls = {"n": 0}
+
+    def disk_full(*a, **kw):
+        calls["n"] += 1
+        raise BuildDiskFullError("disk is full")
+
+    monkeypatch.setattr(runloop, "run_trial", disk_full)
+    client = SubmitClient({})
+    stopped = []
+    client.mark_stopped = lambda aid, **kw: stopped.append((aid, kw))
+    tag = runloop._run_and_submit(client, ASSIGNMENT, tmp_path, _args(), "abc")
+    assert tag == "environment-build-failed" and calls["n"] == 1
+    assert stopped == [(
+        ASSIGNMENT["assignment_id"],
+        {"defer_seconds": 300, "failure_kind": "environment_build_failed"},
+    )]
+    out = capsys.readouterr().out
+    assert "ran out of disk space" in out
+    assert "retrying once automatically" not in out
 
 
 def test_run_and_submit_gives_up_after_second_flake(monkeypatch, capsys, tmp_path):

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -106,8 +106,11 @@ def test_trial_builder_is_assignment_scoped_and_never_selected_globally(
     assert calls[-1] == [
         "buildx", "create", "--name", lease.name,
         "--driver", "docker-container",
+        "--buildkitd-flags",
+        f"--oci-worker-snapshotter={image_cache.ISOLATED_SNAPSHOTTER}",
     ]
     assert "--use" not in calls[-1]
+    assert image_cache.ISOLATED_SNAPSHOTTER == "fuse-overlayfs"
 
 
 def test_trial_builder_falls_back_without_exposing_loopback_proxy(

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -1975,6 +1975,25 @@ def test_run_trial_classifies_build_failure_from_nested_result(tmp_path, monkeyp
     assert "failed to solve" in str(exc.value)
 
 
+def test_run_trial_disk_full_nested_result_is_not_a_mirror_flake(
+    tmp_path, monkeypatch,
+):
+    _fake_pier(
+        monkeypatch, tmp_path, patch=False,
+        result={"exception_info": {
+            "exception_type": "RuntimeError",
+            "exception_message": (
+                "ERROR: failed to solve: copy_file_range: no space left on device"
+            ),
+        }},
+    )
+    with pytest.raises(runner_mod.BuildDiskFullError) as exc:
+        run_trial(_assignment("codex"), tmp_path, tmp_path)
+    assert "disk is full" in str(exc.value)
+    assert "no quota was used" in str(exc.value)
+    assert not isinstance(exc.value, runner_mod.BuildFlakeError)
+
+
 def test_run_trial_missing_patch_message_includes_log_tail(tmp_path, monkeypatch):
     captured = {}
     def fake_build(assignment, tasks_root, jobs_dir, job_name, home, dev_agent=None):


### PR DESCRIPTION
Per-task docker-container builders were created with BuildKit auto snapshotter. On volunteer Linux hosts that falls back to native, which copies a full rootfs for every Dockerfile RUN. A single DeepSWE compose build then filled the disk under buildx_buildkit_dradar-task-*_state before cleanup ran after Pier exited.

Pin the isolated builder to fuse-overlayfs so those copies stay copy-on-write. Also treat no space left / copy_file_range as a disk failure instead of matching failed to solve as a free network retry.