### PR TITLE
fix: boot overlayfs/fuse for isolated builders, never fall back to native

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Pier + Docker 作为现阶段的任务执行方案；未来可以继续接入其
 - Python 3.11 或更高版本，以及 [`uv`](https://docs.astral.sh/uv/)
 - Docker，推荐 macOS 使用 [OrbStack](https://orbstack.dev/)
 - 本机已登录 `codex` 或 `claude` CLI，二者准备好一个即可
-- 至少约 20 GB 可用磁盘；多 worker 需要更多 CPU、内存和磁盘
+- 至少约 20 GB 可用磁盘；Docker 若只能用 vfs 存储驱动（常见于套娃 Docker），单题构建峰值可达 80 GB 以上，请只开 1 个 worker 并保留约 80 GB 空闲
 
 原生 Windows 为候选支持，需要 Docker Desktop 运行 Linux containers，并确保 Codex CLI
 能直接在 PowerShell 的 `PATH` 中调用。WSL2 也可使用，不限定 Ubuntu。
@@ -794,7 +794,18 @@ dradar cleanup --docker --shared-build-cache -y
 本地诊断文件和题目镜像，但仍会停止容器并删除临时构建空间。
 
 默认每道题使用独立、一次性的 Docker 构建空间，单 worker 题目结束时直接删除该构建空间，
-因此不会清理或占用用户其他项目的 BuildKit 缓存。多 worker 并发时，如果没有显式配置，CLI
+因此不会清理或占用用户其他项目的 BuildKit 缓存。该构建空间会先启动 overlayfs，不行再试
+fuse-overlayfs，避免 BuildKit auto 落到 native、在每条 Dockerfile `RUN` 上复制完整
+rootfs。两种叠加方式都不可用时，或当前进程已在容器内（套娃 Docker 无法写入 overlay
+whiteout）时，本题改用本机默认构建空间，而不会静默使用 native，也不会把
+`operation not permitted` 或磁盘耗尽当成镜像源/网络抽风自动重试同一套隔离构建器。
+
+隔离构建器改的是 BuildKit 快照层。若本机 Docker 守护进程本身是 vfs，compose 构建和
+每个容器仍会整份拷贝 rootfs。套娃 Docker 上的 unix-socket 旁路转发器因此使用小型
+python 镜像，而不是再复制一份考试镜像。vfs 主机请只跑 1 个 worker；能把守护进程改成
+overlay2 才是根治。
+
+多 worker 并发时，如果没有显式配置，CLI
 会自动启用同一操作系统用户范围内的共享 BuildKit 缓存，以便公共基础镜像和依赖层只下载/构建
 一次；也可以显式指定策略：
 
@@ -824,7 +835,7 @@ dradar config show
 恢复状态校验；旧版本写入默认 builder 的历史缓存无法证明只属于 DRadar，因此不会在
 升级时擅自删除。`--dry-run` 会先展示镜像列表和预计可回收空间。
 
-可用空间低于 25 GiB 时停止领取新题，但不打断已在运行的任务。在 WSL 中会同时检查
+可用空间低于 25 GiB（vfs 主机为 80 GiB）时停止领取新题，但不打断已在运行的任务。在 WSL 中会同时检查
 Ubuntu 内部空间，以及实际存放该发行版虚拟盘的 Windows 磁盘；任一空间不足或宿主盘
 无法确认，都会停止自动补题，避免 Linux 内部仍显示可用而 Windows 宿主盘已经耗尽。
 

--- a/src/dradar/capacity.py
+++ b/src/dradar/capacity.py
@@ -21,7 +21,17 @@ MEM_GIB_PER_WORKER = 6
 DOCKER_MEM_RESERVE_GIB = 2
 FIRST_WORKER_DISK_GIB = 20
 EXTRA_WORKER_DISK_GIB = 12
+# vfs copies a full rootfs per image layer and per container. Isolated
+# BuildKit overlay/fuse snapshotters do not change the daemon graph driver.
+VFS_FIRST_WORKER_DISK_GIB = 80
+VFS_EXTRA_WORKER_DISK_GIB = 60
 AUTO_WORKER_CAP = 4
+_VFS_WARNING = (
+    "Docker storage driver is vfs; each image layer and container copies a "
+    "full rootfs, so one Pier compose build can use 80+ GiB. Run one worker "
+    "and keep about 80 GiB free. overlay2 is the durable fix when the daemon "
+    "can use it"
+)
 
 
 @dataclass(frozen=True)
@@ -37,26 +47,57 @@ class CapacityReport:
     memory_limit: int
     disk_limit: int
     warnings: tuple[str, ...] = ()
+    docker_driver: str | None = None
+    first_worker_disk_gib: int = FIRST_WORKER_DISK_GIB
+    extra_worker_disk_gib: int = EXTRA_WORKER_DISK_GIB
 
 
-def _docker_resources() -> tuple[int | None, float | None, tuple[str, ...]]:
+def _docker_info() -> tuple[dict | None, tuple[str, ...]]:
     docker = shutil.which("docker")
     if not docker:
-        return None, None, ("docker CLI not found; falling back to 1 worker",)
+        return None, ("docker CLI not found; falling back to 1 worker",)
     try:
         proc = subprocess.run(
             [docker, "info", "--format", "{{json .}}"],
             capture_output=True, text=True, timeout=10,
         )
     except (OSError, subprocess.TimeoutExpired):
-        return None, None, ("cannot inspect Docker resources; falling back to 1 worker",)
+        return None, ("cannot inspect Docker resources; falling back to 1 worker",)
     if proc.returncode != 0:
-        return None, None, ("Docker daemon is unavailable; falling back to 1 worker",)
+        return None, ("Docker daemon is unavailable; falling back to 1 worker",)
     try:
         info = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None, ("Docker returned unreadable capacity data; falling back to 1 worker",)
+    if not isinstance(info, dict):
+        return None, ("Docker returned unreadable capacity data; falling back to 1 worker",)
+    return info, ()
+
+
+def _driver_from_info(info: dict | None) -> str | None:
+    if not info:
+        return None
+    driver = info.get("Driver")
+    if not isinstance(driver, str):
+        return None
+    value = driver.strip().lower()
+    return value or None
+
+
+def _disk_budget(driver: str | None) -> tuple[int, int]:
+    if driver == "vfs":
+        return VFS_FIRST_WORKER_DISK_GIB, VFS_EXTRA_WORKER_DISK_GIB
+    return FIRST_WORKER_DISK_GIB, EXTRA_WORKER_DISK_GIB
+
+
+def _docker_resources() -> tuple[int | None, float | None, tuple[str, ...]]:
+    info, warnings = _docker_info()
+    if info is None:
+        return None, None, warnings
+    try:
         cpus = int(info.get("NCPU") or 0)
         memory = int(info.get("MemTotal") or 0) / (1024 ** 3)
-    except (TypeError, ValueError, json.JSONDecodeError):
+    except (TypeError, ValueError):
         return None, None, ("Docker returned unreadable capacity data; falling back to 1 worker",)
     if cpus < 1 or memory <= 0:
         return None, None, ("Docker omitted CPU/memory capacity; falling back to 1 worker",)
@@ -67,6 +108,13 @@ def docker_resources() -> tuple[int | None, float | None, tuple[str, ...]]:
     """Read the capacity exposed by Docker, not the host headline specs."""
 
     return _docker_resources()
+
+
+def docker_storage_driver() -> str | None:
+    """Return the daemon graph driver (overlay2, vfs, ...) or None."""
+
+    info, _warnings = _docker_info()
+    return _driver_from_info(info)
 
 
 def worker_resource_warnings(
@@ -118,8 +166,26 @@ def inspect_capacity(client, requested_tasks: int | None = None) -> CapacityRepo
         me.get("concurrent_limit") or me.get("claim_limit") or 1))
     task_limit = max(1, int(requested_tasks or held or account_limit))
 
-    cpus, memory_gib, warnings = docker_resources()
+    info, warnings = _docker_info()
+    cpus = memory_gib = None
+    driver = _driver_from_info(info)
+    if info is not None:
+        try:
+            parsed_cpus = int(info.get("NCPU") or 0)
+            parsed_memory = int(info.get("MemTotal") or 0) / (1024 ** 3)
+        except (TypeError, ValueError):
+            warnings = ("Docker returned unreadable capacity data; falling back to 1 worker",)
+        else:
+            if parsed_cpus < 1 or parsed_memory <= 0:
+                warnings = ("Docker omitted CPU/memory capacity; falling back to 1 worker",)
+            else:
+                cpus, memory_gib = parsed_cpus, parsed_memory
+    elif not warnings:
+        warnings = ("cannot inspect Docker resources; falling back to 1 worker",)
+    if driver == "vfs":
+        warnings = warnings + (_VFS_WARNING,)
     disk_gib = shutil.disk_usage(Path.home()).free / (1024 ** 3)
+    first_disk, extra_disk = _disk_budget(driver)
     if cpus is None or memory_gib is None:
         cpu_limit = memory_limit = 1
     else:
@@ -128,8 +194,7 @@ def inspect_capacity(client, requested_tasks: int | None = None) -> CapacityRepo
             1, int((memory_gib - DOCKER_MEM_RESERVE_GIB) // MEM_GIB_PER_WORKER))
     disk_limit = max(
         1,
-        1 + int(max(0.0, disk_gib - FIRST_WORKER_DISK_GIB)
-                // EXTRA_WORKER_DISK_GIB),
+        1 + int(max(0.0, disk_gib - first_disk) // extra_disk),
     )
     recommended = max(1, min(
         cpu_limit, memory_limit, disk_limit, account_limit, task_limit,
@@ -147,6 +212,9 @@ def inspect_capacity(client, requested_tasks: int | None = None) -> CapacityRepo
         memory_limit=memory_limit,
         disk_limit=disk_limit,
         warnings=warnings,
+        docker_driver=driver,
+        first_worker_disk_gib=first_disk,
+        extra_worker_disk_gib=extra_disk,
     )
 
 
@@ -157,6 +225,7 @@ def print_report(report: CapacityReport) -> None:
                   f"{report.docker_memory_gib:.1f} GiB memory")
     print("local worker capacity:")
     print(f"  Docker: {docker}")
+    print(f"  Docker storage driver: {report.docker_driver or 'unknown'}")
     print(f"  disk free: {report.disk_free_gib:.0f} GiB")
     print(f"  account concurrency limit: {report.account_limit}")
     print(f"  currently held tasks: {report.held_tasks}")
@@ -167,8 +236,8 @@ def print_report(report: CapacityReport) -> None:
           f"({MEM_GIB_PER_WORKER} GiB per worker + "
           f"{DOCKER_MEM_RESERVE_GIB} GiB Docker reserve)")
     print(f"    disk: {report.disk_limit} worker(s) "
-          f"({FIRST_WORKER_DISK_GIB} GiB first-worker reserve, "
-          f"{EXTRA_WORKER_DISK_GIB} GiB each extra)")
+          f"({report.first_worker_disk_gib} GiB first-worker reserve, "
+          f"{report.extra_worker_disk_gib} GiB each extra)")
     print(f"    account: {report.account_limit} worker(s)")
     print(f"    requested task capacity: {report.task_limit} worker(s)")
     print(f"    automatic safety cap: {AUTO_WORKER_CAP} worker(s)")
@@ -211,6 +280,7 @@ def cmd_capacity(args) -> int:
 
 
 __all__ = [
-    "CapacityReport", "cmd_capacity", "docker_resources", "inspect_capacity",
-    "print_report", "worker_resource_warnings",
+    "CapacityReport", "cmd_capacity", "docker_resources",
+    "docker_storage_driver", "inspect_capacity", "print_report",
+    "worker_resource_warnings",
 ]

--- a/src/dradar/doctor.py
+++ b/src/dradar/doctor.py
@@ -10,7 +10,7 @@ import tempfile
 from pathlib import Path
 
 from . import __version__, egress, runner
-from .capacity import docker_resources, worker_resource_warnings
+from .capacity import docker_resources, docker_storage_driver, worker_resource_warnings
 from .codebuddy_provider import (
     CODEBUDDY_AGENT,
     CODEBUDDY_CLI_VERSION,
@@ -635,6 +635,15 @@ def cmd_doctor(args) -> int:
                 egress_ready,
                 egress_hint,
             )
+            driver = docker_storage_driver()
+            if driver == "vfs":
+                _warn(
+                    "docker storage driver (vfs)",
+                    "vfs copies a full rootfs for every image layer and "
+                    "container; a single Pier compose build can use 80+ GiB. "
+                    "Run one worker and keep about 80 GiB free. overlay2 is "
+                    "the durable fix when the daemon can use it",
+                )
             cpus, memory_gib, probe_warnings = docker_resources()
             if cpus is not None and memory_gib is not None:
                 resource_label = (

--- a/src/dradar/egress.py
+++ b/src/dradar/egress.py
@@ -44,6 +44,9 @@ EGRESS_PROXY_ASSETS = {
 EGRESS_PROXY_MODE_ENV = "DRADAR_EGRESS_PROXY_MODE"
 EGRESS_PROXY_IMAGE_OVERRIDE_ENV = "DRADAR_EGRESS_PROXY_IMAGE_OVERRIDE"
 EGRESS_PROXY_LEGACY_MODE = "legacy-build"
+NESTED_SIDECAR_IMAGE_ENV = "DRADAR_NESTED_SIDECAR_IMAGE"
+NESTED_SIDECAR_IMAGE = "python:3.12-alpine"
+NESTED_SIDECAR_LOCAL_TAG = "dradar-nested-sidecar:py3"
 DRADAR_HTTP_PROXY_ENV = "DRADAR_HTTP_PROXY"
 DRADAR_NO_PROXY_ENV = "DRADAR_NO_PROXY"
 DRADAR_CONTAINER_HTTP_PROXY_ENV = "DRADAR_CONTAINER_HTTP_PROXY"
@@ -650,6 +653,95 @@ def _validate_build_proxy_compatibility(
     )
 
 
+def _running_in_container() -> bool:
+    if os.environ.get("container"):
+        return True
+    if Path("/.dockerenv").is_file():
+        return True
+    try:
+        text = Path("/proc/1/cgroup").read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    lowered = text.lower()
+    return any(
+        token in lowered
+        for token in ("docker", "containerd", "kubepods", "lxc", "podman")
+    )
+
+
+def _docker_image_exists(docker: str, image: str) -> bool:
+    try:
+        proc = subprocess.run(
+            [docker, "image", "inspect", "--format", "{{.Id}}", image],
+            capture_output=True,
+            text=True,
+            timeout=_IMAGE_INSPECT_TIMEOUT_SEC,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0 and bool(proc.stdout.strip())
+
+
+def _pull_docker_image(docker: str, image: str) -> bool:
+    try:
+        proc = subprocess.run(
+            [docker, "pull", image],
+            capture_output=True,
+            text=True,
+            timeout=_IMAGE_PULL_TIMEOUT_SEC,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0
+
+
+def _build_python_sidecar_from_proxy(docker: str, proxy_image: str, tag: str) -> bool:
+    dockerfile = (
+        f"FROM {proxy_image}\n"
+        "USER root\n"
+        "RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y "
+        "--no-install-recommends python3 && rm -rf /var/lib/apt/lists/*\n"
+    )
+    try:
+        proc = subprocess.run(
+            [docker, "build", "--network=default", "-t", tag, "-"],
+            input=dockerfile,
+            capture_output=True,
+            text=True,
+            timeout=_IMAGE_PULL_TIMEOUT_SEC,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0
+
+
+def ensure_nested_sidecar_image(docker: str, proxy_image: str) -> str:
+    """Small python image for DinD unix-socket forwarders.
+
+    vfs copies a full rootfs per container, so the exam image cannot be reused
+    for these processes. Prefer a local alpine image, then a Hub pull, then a
+    python3 derivative of the already-loaded Pier egress image.
+    """
+    if _docker_image_exists(docker, NESTED_SIDECAR_IMAGE):
+        return NESTED_SIDECAR_IMAGE
+    if _pull_docker_image(docker, NESTED_SIDECAR_IMAGE) and _docker_image_exists(
+        docker, NESTED_SIDECAR_IMAGE,
+    ):
+        return NESTED_SIDECAR_IMAGE
+    if _docker_image_exists(docker, NESTED_SIDECAR_LOCAL_TAG):
+        return NESTED_SIDECAR_LOCAL_TAG
+    if _build_python_sidecar_from_proxy(docker, proxy_image, NESTED_SIDECAR_LOCAL_TAG):
+        return NESTED_SIDECAR_LOCAL_TAG
+    raise EgressProxyError(
+        "nested Docker needs a small python image for the unix-socket sidecar; "
+        f"could not pull {NESTED_SIDECAR_IMAGE} and could not install python3 "
+        "on a copy of the Pier egress image"
+    )
+
+
 def prepare_egress_proxy_runtime(
     docker: str | None = None, *, announce: bool = False,
 ) -> dict[str, str]:
@@ -658,6 +750,10 @@ def prepare_egress_proxy_runtime(
     runtime = pier_egress_environment(image)
     if resolved_docker:
         _validate_build_proxy_compatibility(resolved_docker, runtime)
+        if image and _running_in_container():
+            runtime[NESTED_SIDECAR_IMAGE_ENV] = ensure_nested_sidecar_image(
+                resolved_docker, image,
+            )
     return runtime
 
 
@@ -848,6 +944,9 @@ __all__ = [
     "EgressProxyError", "egress_proxy_image",
     "egress_proxy_mode", "egress_proxy_preflight",
     "ensure_egress_proxy_image", "ensure_egress_runtime_ready",
+    "ensure_nested_sidecar_image",
+    "NESTED_SIDECAR_IMAGE", "NESTED_SIDECAR_IMAGE_ENV",
+    "NESTED_SIDECAR_LOCAL_TAG",
     "pier_egress_environment",
     "prepare_egress_proxy_runtime",
 ]

--- a/src/dradar/image_cache.py
+++ b/src/dradar/image_cache.py
@@ -45,6 +45,10 @@ SHARED_BUILDER_READY_MAX_AGE_SEC = 6 * 60 * 60
 SHARED_BUILDER_STATE_DIR_ENV = "DRADAR_SHARED_BUILDER_STATE_DIR"
 BUILD_CACHE_MODES = frozenset({"isolated", "shared"})
 DEFAULT_BUILD_CACHE_MODE = "isolated"
+# docker-container BuildKit auto can select native, which copies a full
+# rootfs for every Dockerfile RUN. Never accept that fallback.
+ISOLATED_SNAPSHOTTERS = ("overlayfs", "fuse-overlayfs")
+_BUILDER_BOOTSTRAP_TIMEOUT = 300
 GIB = 1024 ** 3
 DEFAULT_MIN_FREE_GIB = 25.0
 _PROJECT_RE = re.compile(r"[a-z0-9][a-z0-9-]*__[a-z0-9]{6,8}$")
@@ -112,6 +116,10 @@ class TrialBuilderLease:
     # survives one trial so BuildKit can reuse immutable layers for the next
     # task, even when Fleet gives each harness a separate DRADAR_HOME.
     reusable: bool = False
+    # False when isolation was skipped on purpose (nested Docker, or neither
+    # copy-on-write snapshotter could boot). Cleanup must not treat that as a
+    # failed builder and block the next task.
+    expected: bool = True
 
 
 @dataclass
@@ -203,6 +211,28 @@ def disk_allows_new_tasks(home: Path, *, min_free_bytes: int) -> tuple[bool, str
         if host < min_free_bytes:
             return False, "承载 Ubuntu 的 Windows 磁盘空间低于安全线"
     return True, None
+
+
+def running_in_container() -> bool:
+    """Whether this process is already inside a container/pod.
+
+    Nested Docker cannot create overlay whiteouts (character device 0/0), so
+    fuse-overlayfs fails with ``operation not permitted`` even when BuildKit
+    itself is privileged. Those hosts must use the daemon's default builder.
+    """
+    if os.environ.get("container"):
+        return True
+    if Path("/.dockerenv").is_file():
+        return True
+    try:
+        text = Path("/proc/1/cgroup").read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    lowered = text.lower()
+    return any(
+        token in lowered
+        for token in ("docker", "containerd", "kubepods", "lxc", "podman")
+    )
 
 
 def _sanitize_project(name: str) -> str:
@@ -369,8 +399,22 @@ def _shared_builder_lock() -> Iterator[None]:
             fh.close()
 
 
+def _trial_builder_create_command(name: str, snapshotter: str) -> list[str]:
+    return [
+        "buildx", "create", "--name", name,
+        "--driver", "docker-container",
+        "--buildkitd-flags",
+        f"--oci-worker-snapshotter={snapshotter}",
+    ]
+
+
+def _cow_snapshotter_failure(detail: str | None) -> str:
+    suffix = f"：{detail[:160]}" if detail else ""
+    return "隔离构建无法使用叠加文件系统" + suffix
+
+
 def _ensure_named_builder(name: str, *, reusable: bool) -> str | None:
-    """Create/refresh one builder and return a bounded failure reason."""
+    """Create/refresh one overlay/fuse builder; never fall back to native."""
 
     existing = _run_docker(
         ["buildx", "inspect", name], timeout=30, allow_fail=True,
@@ -386,14 +430,29 @@ def _ensure_named_builder(name: str, *, reusable: bool) -> str | None:
             return None
 
     if existing.returncode != 0:
-        created = _run_docker([
-            "buildx", "create", "--name", name,
-            "--driver", "docker-container",
-        ], timeout=120, allow_fail=True)
-        if created.returncode != 0:
-            # This is normally a harmless create race.  The shared lock makes
-            # it rare, but the bounded inspect proves whether Docker already
-            # has the named builder before reporting a real failure.
+        last_detail = None
+        created_ok = False
+        for snapshotter in ISOLATED_SNAPSHOTTERS:
+            _run_docker(["buildx", "rm", name], timeout=180, allow_fail=True)
+            created = _run_docker(
+                _trial_builder_create_command(name, snapshotter),
+                timeout=120, allow_fail=True,
+            )
+            if created.returncode != 0:
+                last_detail = (created.stderr or created.stdout or "").strip()
+                continue
+            bootstrapped = _run_docker(
+                ["buildx", "inspect", name, "--bootstrap"],
+                timeout=_BUILDER_BOOTSTRAP_TIMEOUT, allow_fail=True,
+            )
+            if bootstrapped.returncode == 0:
+                created_ok = True
+                existing = bootstrapped
+                break
+            last_detail = (bootstrapped.stderr or bootstrapped.stdout or "").strip()
+            _run_docker(["buildx", "rm", name], timeout=180, allow_fail=True)
+        if not created_ok:
+            # A shared create race is still possible; inspect before giving up.
             if reusable:
                 raced = None
                 for _ in range(8):
@@ -404,20 +463,13 @@ def _ensure_named_builder(name: str, *, reusable: bool) -> str | None:
                     )
                     if raced.returncode == 0:
                         existing = raced
+                        created_ok = True
                         break
                     time.sleep(0.5)
-                if raced is None or raced.returncode != 0:
-                    detail = (created.stderr or created.stdout or "").strip()
-                    return (
-                        "无法创建共享构建缓存空间"
-                        + (f"：{detail[:160]}" if detail else "")
-                    )
+                if not created_ok:
+                    return _cow_snapshotter_failure(last_detail)
             else:
-                detail = (created.stderr or created.stdout or "").strip()
-                return (
-                    "无法创建隔离的临时构建空间"
-                    + (f"：{detail[:160]}" if detail else "")
-                )
+                return _cow_snapshotter_failure(last_detail)
 
     if reusable:
         # Bootstrap only when the stamp is absent/stale or the builder was
@@ -478,6 +530,7 @@ def _builder_proxy_is_safe(runtime: dict[str, str]) -> tuple[bool, str | None]:
 def prepare_trial_builder(
     home: Path, *, assignment_id: str, runtime: dict[str, str] | None = None,
     mode: str = DEFAULT_BUILD_CACHE_MODE,
+    force_default: bool = False,
 ) -> TrialBuilderLease:
     """Create a BuildKit builder for one assignment or a scoped shared cache.
 
@@ -486,12 +539,26 @@ def prepare_trial_builder(
     assignment-scoped lifecycle; ``shared`` keeps one host-user-scoped
     BuildKit state volume so immutable base/install layers can be reused by
     concurrent tasks.  No credential or task worktree is placed in that cache.
+    The docker-container node must boot overlayfs or fuse-overlayfs; native
+    full-rootfs copies are not used as a silent fallback. Nested Docker and
+    hosts that cannot boot a copy-on-write snapshotter use the default builder
+    instead of failing isolation cleanup.
     """
     mode = normalize_build_cache_mode(mode)
     runtime = runtime or {}
+    if force_default:
+        return TrialBuilderLease(
+            None, False, "本题改用本机默认构建空间", expected=False,
+        )
     safe, note = _builder_proxy_is_safe(runtime)
     if not safe:
         return TrialBuilderLease(None, False, note)
+    if running_in_container():
+        return TrialBuilderLease(
+            None, False,
+            "当前运行在容器内，隔离构建无法写入 overlay whiteout，本题改用本机默认构建空间",
+            expected=False,
+        )
     reusable = mode == "shared"
     name = shared_builder_name(home) if reusable else trial_builder_name(
         home, assignment_id,
@@ -511,6 +578,8 @@ def prepare_trial_builder(
         else:
             failure = _ensure_named_builder(name, reusable=False)
         if failure is not None:
+            if failure.startswith("隔离构建无法使用叠加文件系统"):
+                return TrialBuilderLease(None, False, failure, expected=False)
             return TrialBuilderLease(None, False, failure)
     except DockerUnavailable as exc:
         label = "共享构建缓存空间" if reusable else "临时构建空间"
@@ -953,9 +1022,18 @@ def effective_policy(home: Path, cfg: dict) -> CachePolicy:
         mode=mode,
         limit_bytes=limit,
         target_bytes=target,
-        min_free_bytes=int(DEFAULT_MIN_FREE_GIB * GIB),
+        min_free_bytes=_policy_min_free_bytes(),
         automatic=mode != "metered",
     )
+
+
+def _policy_min_free_bytes() -> int:
+    """vfs needs a much higher floor than overlay2; 25 GiB is not enough."""
+    from .capacity import VFS_FIRST_WORKER_DISK_GIB, docker_storage_driver
+
+    if docker_storage_driver() == "vfs":
+        return int(VFS_FIRST_WORKER_DISK_GIB * GIB)
+    return int(DEFAULT_MIN_FREE_GIB * GIB)
 
 
 def _protected_projects(home: Path, protected_assignment_ids: set[str],
@@ -1316,6 +1394,7 @@ def cleanup_trial_resources(
     home: Path, *, assignment_id: str, job_dir: Path, trial_name: str,
     builder_isolated: bool, builder_reusable: bool = False,
     builder_name: str | None = None, keep_images: bool = False,
+    builder_expected: bool = True,
 ) -> TaskCleanupResult:
     """Delete one settled task's exact Docker resources before any refill.
 
@@ -1366,8 +1445,9 @@ def cleanup_trial_resources(
         builder_removed, builder_note = remove_trial_builder(home, assignment_id)
     result.builder_removed = builder_removed
     if not builder_isolated:
-        result.success = False
-        notes.append("本题未使用隔离的临时构建空间")
+        if builder_expected:
+            result.success = False
+            notes.append("本题未使用隔离的临时构建空间")
     elif not builder_removed:
         result.success = False
         notes.append(f"临时构建空间清理失败：{builder_note or 'unknown error'}")
@@ -1557,7 +1637,9 @@ __all__ = [
     "automatic_maintenance", "cleanup_trial_resources", "discover_pier_images",
     "claim_periodic_maintenance", "disk_allows_new_tasks", "disk_free_bytes",
     "effective_policy", "is_wsl", "load", "plan_cleanup",
+    "ISOLATED_SNAPSHOTTERS",
     "prepare_trial_builder", "proxy_detected", "record_trial_images",
+    "running_in_container",
     "remove_assignment_images", "remove_images", "remove_trial_builder",
     "prune_shared_build_cache",
     "trial_builder_name", "shared_builder_name", "normalize_build_cache_mode",

--- a/src/dradar/pier_sitecustomize.py
+++ b/src/dradar/pier_sitecustomize.py
@@ -16,6 +16,8 @@ import uuid
 from pathlib import Path
 
 _IMAGE_ENV = "DRADAR_EGRESS_PROXY_IMAGE"
+_NESTED_SIDECAR_IMAGE_ENV = "DRADAR_NESTED_SIDECAR_IMAGE"
+_DEFAULT_NESTED_SIDECAR_IMAGE = "python:3.12-alpine"
 _CODEBUDDY_SOURCE_IMAGE_ENV = "DRADAR_CODEBUDDY_SOURCE_IMAGE"
 _PATCH_MARKER = "_dradar_prebuilt_egress_codebuddy_v2"
 _LOCAL_IMAGE_ID_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
@@ -46,6 +48,246 @@ def _image_is_immutable(image: str) -> bool:
             and _LOCAL_IMAGE_ID_RE.fullmatch(image.split("@", 1)[1])
         )
     )
+
+
+def _running_in_container() -> bool:
+    """Nested Docker often cannot implement Compose ``internal: true`` ICC."""
+    if os.environ.get("container"):
+        return True
+    if Path("/.dockerenv").is_file():
+        return True
+    try:
+        text = Path("/proc/1/cgroup").read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    lowered = text.lower()
+    return any(
+        token in lowered
+        for token in ("docker", "containerd", "kubepods", "lxc", "podman")
+    )
+
+
+def _localhost_proxy_environment(runtime_environment: dict[str, str]) -> dict[str, str]:
+    """Point HTTP(S)_PROXY at loopback when the exam uses a local forwarder."""
+    rewritten = dict(runtime_environment)
+    for key in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
+        value = rewritten.get(key)
+        if value:
+            rewritten[key] = value.replace("@pier-egress-proxy:", "@127.0.0.1:")
+    return rewritten
+
+
+def _egress_network_spec() -> dict[str, object]:
+    return {"internal": True}
+
+
+_SQUID_LOOPBACK_BOOTSTRAP = r"""#!/usr/bin/env bash
+set -euo pipefail
+: "${PROXY_TOKEN:?PROXY_TOKEN is required}"
+: "${ALLOWLIST_DOMAINS:?ALLOWLIST_DOMAINS is required}"
+umask 077
+allowed_domains=/tmp/allowed_domains.txt
+password_file=/tmp/squid.passwd
+printf '%s' "$ALLOWLIST_DOMAINS" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;/^$/d' > "$allowed_domains"
+if [[ ! -s "$allowed_domains" ]]; then
+  echo "ALLOWLIST_DOMAINS did not contain any domains" >&2
+  exit 2
+fi
+printf '%s\n' "$PROXY_TOKEN" | htpasswd -ci "$password_file" agent >/dev/null
+unset PROXY_TOKEN
+upstream_config=
+if [[ -n "${UPSTREAM_PROXY_HOST:-}" ]]; then
+  upstream_config="cache_peer ${UPSTREAM_PROXY_HOST} parent ${UPSTREAM_PROXY_PORT} 0 no-query default"
+  if [[ -n "${UPSTREAM_PROXY_USERNAME:-}" || -n "${UPSTREAM_PROXY_PASSWORD:-}" ]]; then
+    upstream_config+=" login=${UPSTREAM_PROXY_USERNAME:-}:${UPSTREAM_PROXY_PASSWORD:-}"
+  fi
+  upstream_config+=$'\nnever_direct allow all'
+fi
+cat > /tmp/squid.conf <<'EOF'
+http_port 127.0.0.1:8080
+pid_filename /tmp/squid.pid
+coredump_dir /tmp
+auth_param basic program /usr/lib/squid/basic_ncsa_auth /tmp/squid.passwd
+auth_param basic realm PierPolicyProxy
+acl authenticated proxy_auth REQUIRED
+acl SSL_ports port 443
+acl Safe_ports port 80 443
+acl CONNECT method CONNECT
+acl allowed_domains dstdomain "/tmp/allowed_domains.txt"
+http_access deny !Safe_ports
+http_access deny CONNECT !SSL_ports
+http_access allow authenticated allowed_domains
+http_access deny all
+cache deny all
+access_log stdio:/tmp/squid_access.log
+cache_log /tmp/squid_cache.log
+log_mime_hdrs off
+shutdown_lifetime 1 seconds
+EOF
+if [[ -n "$upstream_config" ]]; then
+  printf '\n%s\n' "$upstream_config" >> /tmp/squid.conf
+fi
+exec squid -N -f /tmp/squid.conf -d 1
+"""
+
+
+_PROXY_UNIX_TO_TCP_PY = r"""
+import os
+import socket
+import threading
+import time
+
+SOCK = "/egress/http.sock"
+TARGET = ("127.0.0.1", 8080)
+
+
+def _pump(src: socket.socket, dst: socket.socket) -> None:
+    try:
+        while True:
+            data = src.recv(65536)
+            if not data:
+                break
+            dst.sendall(data)
+    except OSError:
+        pass
+    finally:
+        try:
+            dst.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+
+def _handle(client: socket.socket) -> None:
+    remote = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        remote.connect(TARGET)
+    except OSError:
+        client.close()
+        return
+    threading.Thread(target=_pump, args=(client, remote), daemon=True).start()
+    _pump(remote, client)
+    client.close()
+    remote.close()
+
+
+def main() -> None:
+    deadline = time.time() + 60
+    while True:
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            probe.settimeout(1)
+            probe.connect(TARGET)
+            probe.close()
+            break
+        except OSError:
+            probe.close()
+            if time.time() >= deadline:
+                raise SystemExit("squid 127.0.0.1:8080 did not appear")
+            time.sleep(0.1)
+    os.makedirs("/egress", exist_ok=True)
+    try:
+        os.chmod("/egress", 0o1777)
+    except OSError:
+        try:
+            os.chmod("/egress", 0o777)
+        except OSError:
+            pass
+    try:
+        os.unlink(SOCK)
+    except OSError:
+        pass
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(SOCK)
+    try:
+        os.chmod(SOCK, 0o666)
+    except OSError:
+        pass
+    server.listen(128)
+    while True:
+        client, _ignored = server.accept()
+        threading.Thread(target=_handle, args=(client,), daemon=True).start()
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+
+_PROXY_FORWARD_PY = r"""
+import os
+import socket
+import threading
+import time
+
+SOCK = "/egress/http.sock"
+LISTEN = ("127.0.0.1", 8080)
+
+
+def _pump(src: socket.socket, dst: socket.socket) -> None:
+    try:
+        while True:
+            data = src.recv(65536)
+            if not data:
+                break
+            dst.sendall(data)
+    except OSError:
+        pass
+    finally:
+        try:
+            dst.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+
+def _handle(client: socket.socket) -> None:
+    unix = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        unix.connect(SOCK)
+    except OSError:
+        client.close()
+        return
+    threading.Thread(target=_pump, args=(client, unix), daemon=True).start()
+    _pump(unix, client)
+    client.close()
+    unix.close()
+
+
+def main() -> None:
+    deadline = time.time() + 60
+    while not os.path.exists(SOCK):
+        if time.time() >= deadline:
+            raise SystemExit("egress unix socket did not appear")
+        time.sleep(0.1)
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(LISTEN)
+    server.listen(128)
+    while True:
+        client, _ignored = server.accept()
+        threading.Thread(target=_handle, args=(client,), daemon=True).start()
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+
+def _write_nested_egress_helpers(script_dir: Path) -> tuple[Path, Path, Path]:
+    squid = script_dir / "dradar-egress-loopback-squid.sh"
+    export = script_dir / "dradar-proxy-export.py"
+    forward = script_dir / "dradar-proxy-forward.py"
+    squid.write_text(_SQUID_LOOPBACK_BOOTSTRAP.lstrip("\n"), encoding="utf-8")
+    export.write_text(_PROXY_UNIX_TO_TCP_PY.lstrip("\n"), encoding="utf-8")
+    forward.write_text(_PROXY_FORWARD_PY.lstrip("\n"), encoding="utf-8")
+    try:
+        # Squid runs as USER proxy. Owner-only 0700 is Permission denied
+        # when the host writer is not that uid.
+        squid.chmod(0o755)
+        export.chmod(0o644)
+        forward.chmod(0o644)
+    except OSError:
+        pass
+    return squid.resolve(), export.resolve(), forward.resolve()
 
 
 def _proxy_policy_env(allowlist, token: str) -> dict[str, str]:
@@ -84,18 +326,80 @@ def _write_docker_proxy_compose(
     }
     if os.environ.get("DRADAR_EGRESS_UPSTREAM_HOST") == "host.docker.internal":
         proxy_service["extra_hosts"] = ["host.docker.internal:host-gateway"]
-    compose = {
-        "services": {
-            "main": {
-                "networks": ["pier-egress-internal"],
-                "depends_on": {
-                    "pier-egress-proxy": {"condition": "service_healthy"},
+    if _running_in_container():
+        # Keep the exam container off the default/internet bridge. DinD custom
+        # bridges drop ICC, so do not rely on TCP to pier-egress-proxy:8080.
+        # Squid still has default+internal; a unix socket volume plus a
+        # loopback forwarder in the exam netns is the only path out.
+        squid_script, export_script, forward_script = _write_nested_egress_helpers(
+            path.parent,
+        )
+        proxy_service["volumes"] = [
+            f"{squid_script}:/usr/local/bin/start-squid.sh:ro",
+        ]
+        sidecar_image = (
+            os.environ.get(_NESTED_SIDECAR_IMAGE_ENV)
+            or _DEFAULT_NESTED_SIDECAR_IMAGE
+        )
+        compose = {
+            "services": {
+                "main": {
+                    # Compose build does not tag hb__* unless image is set.
+                    "image": "${MAIN_IMAGE_NAME}",
+                    "networks": ["pier-egress-internal"],
+                    "depends_on": {
+                        "pier-egress-proxy": {"condition": "service_healthy"},
+                    },
+                },
+                "pier-egress-proxy": proxy_service,
+                "pier-egress-sock-export": {
+                    # vfs copies a full rootfs per container. Do not reuse the
+                    # multi-gigabyte exam image for these tiny forwarders.
+                    "image": sidecar_image,
+                    "pull_policy": "never",
+                    "user": "0:0",
+                    "network_mode": "service:pier-egress-proxy",
+                    "volumes": [
+                        f"{export_script}:/dradar-proxy-export.py:ro",
+                        "pier-egress-sock:/egress",
+                    ],
+                    "command": ["python3", "/dradar-proxy-export.py"],
+                    "depends_on": {
+                        "pier-egress-proxy": {"condition": "service_healthy"},
+                    },
+                },
+                "pier-egress-forward": {
+                    "image": sidecar_image,
+                    "pull_policy": "never",
+                    "user": "0:0",
+                    "network_mode": "service:main",
+                    "volumes": [
+                        f"{forward_script}:/dradar-proxy-forward.py:ro",
+                        "pier-egress-sock:/egress",
+                    ],
+                    "command": ["python3", "/dradar-proxy-forward.py"],
+                    "depends_on": {
+                        "main": {"condition": "service_started"},
+                        "pier-egress-sock-export": {"condition": "service_started"},
+                    },
                 },
             },
-            "pier-egress-proxy": proxy_service,
-        },
-        "networks": {"pier-egress-internal": {"internal": True}},
-    }
+            "networks": {"pier-egress-internal": _egress_network_spec()},
+            "volumes": {"pier-egress-sock": {}},
+        }
+    else:
+        compose = {
+            "services": {
+                "main": {
+                    "networks": ["pier-egress-internal"],
+                    "depends_on": {
+                        "pier-egress-proxy": {"condition": "service_healthy"},
+                    },
+                },
+                "pier-egress-proxy": proxy_service,
+            },
+            "networks": {"pier-egress-internal": _egress_network_spec()},
+        }
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(compose, indent=2), encoding="utf-8")
     try:
@@ -133,6 +437,8 @@ def _finalize_docker_proxy_compose(
     compose = json.loads(path.read_text(encoding="utf-8"))
     main = compose["services"]["main"]
     environment = dict(main.get("environment") or {})
+    if "pier-egress-forward" in compose.get("services", {}):
+        runtime_environment = _localhost_proxy_environment(runtime_environment)
     environment.update(runtime_environment)
     main["environment"] = environment
     if build_override is not None:

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -86,7 +86,8 @@ from .providers import (
 )
 from .runner import (
     CODEX_TRAJECTORY_BUNDLE_SCHEMA, DIAG_ADVICE,
-    BuildFlakeError, RunnerError,
+    BuildDiskFullError, BuildFlakeError, BuildSnapshotterPermissionError,
+    RunnerError,
     RunnerCleanupUnconfirmedError, RunnerTaskRetryableError,
     POMPEII_BENCHMARK_ID,
     POMPEII_FINALIZATION_RESERVE_SEC, POMPEII_SOFT_BUDGET_SEC,
@@ -2537,6 +2538,7 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
             )
             telemetry.flush()
 
+    allow_isolated_builder = True
     for attempt in (1, 2):
         try:
             try:
@@ -2553,6 +2555,7 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
                         or getattr(args, "build_cache_mode", None)
                         or image_cache.DEFAULT_BUILD_CACHE_MODE
                     ),
+                    allow_isolated_builder=allow_isolated_builder,
                 )
             finally:
                 # Assignment-scoped builders own only this trial's BuildKit
@@ -2580,6 +2583,36 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
                         + (builder_note or "Docker 未返回具体原因")
                     )
             break
+        except BuildDiskFullError as exc:
+            print(
+                f"trial failed: {exc}\n"
+                "the build ran out of disk space — free space and re-run "
+                "`dradar resume` (still free: the agent never started), or "
+                "use `dradar release` if you do not want to keep the cell"
+            )
+            _mark_stopped_quietly(
+                client, assignment, failure_kind="environment_build_failed",
+            )
+            return "environment-build-failed"
+        except BuildSnapshotterPermissionError as exc:
+            if attempt == 1 and allow_isolated_builder:
+                print(
+                    f"environment build failed ({exc})\n"
+                    "isolated overlay is not permitted here — retrying with "
+                    "the host default builder (no quota was consumed)..."
+                )
+                allow_isolated_builder = False
+                continue
+            print(
+                f"trial failed: {exc}\n"
+                "the image build cannot write overlay whiteouts on this host; "
+                "run on a machine with a full Linux kernel, or `dradar release` "
+                "if you do not want to keep the cell"
+            )
+            _mark_stopped_quietly(
+                client, assignment, failure_kind="environment_build_failed",
+            )
+            return "environment-build-failed"
         except BuildFlakeError as exc:
             # The image build died before the agent ran — a free failure
             # (zero quota), and mirror flakes usually pass on the second
@@ -2723,6 +2756,7 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
         builder_isolated=art.builder_isolated,
         builder_reusable=art.builder_reusable,
         builder_name=art.builder_name,
+        builder_expected=art.builder_expected,
         keep_images=bool(args.keep),
     )
     removed_objects = (

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -348,6 +348,7 @@ class TrialArtifacts:
     builder_note: str | None = None
     builder_reusable: bool = False
     builder_name: str | None = None
+    builder_expected: bool = True
 
 
 class RunnerError(RuntimeError):
@@ -447,6 +448,24 @@ class BuildFlakeError(RunnerError):
     blaming the agent for a mirror hiccup)."""
 
 
+class BuildDiskFullError(RunnerError):
+    """The trial died while BUILDING because the host disk was full.
+
+    Distinct from BuildFlakeError: retrying cannot create space, and BuildKit
+    ENOSPC lines almost always also contain ``failed to solve``, which would
+    otherwise be misread as a mirror/network flake.
+    """
+
+
+class BuildSnapshotterPermissionError(RunnerError):
+    """Isolated overlay/fuse-overlayfs cannot write whiteouts here.
+
+    Nested Docker often boots BuildKit, then fails on ``operation not
+    permitted`` while converting whiteouts. Distinct from BuildFlakeError
+    because retrying the same isolated builder cannot create that permission.
+    """
+
+
 # Signatures (in the pier log tail) of an image build / infra failure that
 # happened before any agent ran. Deliberately specific: a false positive here
 # would auto-retry a run that DID burn quota.
@@ -455,9 +474,32 @@ _BUILD_FLAKE_MARKERS = (
     "apt-get update", "Temporary failure resolving", "proxyconnect",
     "TLS handshake timeout", "error getting credentials",
 )
+_DISK_FULL_MARKERS = (
+    "no space left",
+    "enospc",
+    "disk quota exceeded",
+)
+_SNAPSHOTTER_PERM_MARKERS = (
+    "whiteout",
+    "fuse-overlayfs",
+)
+
+
+def _looks_like_disk_full(log_tail: str) -> bool:
+    lowered = log_tail.lower()
+    return any(marker in lowered for marker in _DISK_FULL_MARKERS)
+
+
+def _looks_like_snapshotter_permission(log_tail: str) -> bool:
+    lowered = log_tail.lower()
+    if "operation not permitted" not in lowered and "eperm" not in lowered:
+        return False
+    return any(marker in lowered for marker in _SNAPSHOTTER_PERM_MARKERS)
 
 
 def _looks_like_build_flake(log_tail: str) -> bool:
+    if _looks_like_disk_full(log_tail) or _looks_like_snapshotter_permission(log_tail):
+        return False
     return any(m in log_tail for m in _BUILD_FLAKE_MARKERS)
 
 
@@ -3687,6 +3729,7 @@ def run_trial(
     on_started: Callable[[], None] | None = None,
     environment_build_timeout_multiplier: float | None = None,
     build_cache_mode: str = image_cache.DEFAULT_BUILD_CACHE_MODE,
+    allow_isolated_builder: bool = True,
 ) -> TrialArtifacts:
     effective_assignment = assignment
     codex_cli_version = None
@@ -3840,12 +3883,15 @@ def run_trial(
         assignment_id=str(assignment["assignment_id"]),
         runtime=egress_environment,
         mode=build_cache_mode,
+        force_default=not allow_isolated_builder,
     )
     if builder_lease.isolated:
         if builder_lease.reusable:
             print("已为本题准备共享的 DRadar BuildKit 缓存")
         else:
             print("已为本题准备独立的临时运行环境")
+    elif not builder_lease.expected:
+        print(f"本题改用本机默认构建空间（{builder_lease.note}）")
     else:
         print(
             "提示：本题可以继续运行，但临时环境暂时无法安全隔离；"
@@ -4196,6 +4242,17 @@ def run_trial(
                     _zcode_runtime_diagnostic(jobs_dir, job_name)
                 )
             raise terminal_error
+        if _looks_like_disk_full(tail):
+            raise BuildDiskFullError(
+                "the task environment failed to BUILD because the disk is full "
+                "— the agent never started and no quota was used.\n"
+                f"last lines of the log:\n{tail}")
+        if _looks_like_snapshotter_permission(tail):
+            raise BuildSnapshotterPermissionError(
+                "the task environment failed to BUILD because overlay whiteouts "
+                "are not permitted here — the agent never started and no quota "
+                "was used.\n"
+                f"last lines of the log:\n{tail}")
         if _looks_like_build_flake(tail):
             raise BuildFlakeError(
                 f"the task environment failed to BUILD (mirror/network flake) — "
@@ -4241,6 +4298,17 @@ def run_trial(
         # agent for a mirror hiccup.
         result_exception = _result_exception_text(result)
         diagnostic = "\n".join(x for x in (tail, result_exception) if x)
+        if _looks_like_disk_full(diagnostic):
+            raise BuildDiskFullError(
+                "the task environment failed to BUILD because the disk is full "
+                "— the agent never started and no quota was used.\n"
+                f"build diagnostic:\n{_diagnostic_tail(diagnostic)}")
+        if _looks_like_snapshotter_permission(diagnostic):
+            raise BuildSnapshotterPermissionError(
+                "the task environment failed to BUILD because overlay whiteouts "
+                "are not permitted here — the agent never started and no quota "
+                "was used.\n"
+                f"build diagnostic:\n{_diagnostic_tail(diagnostic)}")
         if _looks_like_build_flake(diagnostic):
             raise BuildFlakeError(
                 f"the task environment failed to BUILD (mirror/network flake) — "
@@ -4317,6 +4385,7 @@ def run_trial(
         builder_note=builder_lease.note,
         builder_reusable=builder_lease.reusable,
         builder_name=builder_lease.name,
+        builder_expected=builder_lease.expected,
     )
 
 

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -79,6 +79,26 @@ def test_worker_resource_warnings_accept_exact_published_budget():
     assert capacity.worker_resource_warnings(2, 4, 14) == ()
 
 
+def test_vfs_driver_reserves_one_worker_and_warns(monkeypatch):
+    payload = json.dumps({
+        "NCPU": 8, "MemTotal": 32 * 1024 ** 3, "Driver": "vfs",
+    })
+    monkeypatch.setattr(capacity.shutil, "which", lambda _name: "/usr/bin/docker")
+    monkeypatch.setattr(
+        capacity.subprocess, "run",
+        lambda *_a, **_k: type("Proc", (), {"returncode": 0, "stdout": payload})(),
+    )
+    monkeypatch.setattr(capacity.shutil, "disk_usage", lambda _path: Disk(100))
+
+    report = capacity.inspect_capacity(Client())
+
+    assert report.docker_driver == "vfs"
+    assert report.first_worker_disk_gib == capacity.VFS_FIRST_WORKER_DISK_GIB
+    assert report.disk_limit == 1
+    assert report.recommended_workers == 1
+    assert any("vfs" in warning for warning in report.warnings)
+
+
 def test_low_disk_space_never_recommends_zero(monkeypatch):
     _docker(monkeypatch, cpus=64, memory_gib=128)
     monkeypatch.setattr(capacity.shutil, "disk_usage", lambda _path: Disk(5))
@@ -102,6 +122,7 @@ def test_capacity_command_prints_machine_and_account_summary(monkeypatch, capsys
     assert capacity.cmd_capacity(object()) == 0
     out = capsys.readouterr().out
     assert "8 CPU / 16.0 GiB" in out
+    assert "Docker storage driver: unknown" in out
     assert "CPU: 4 worker(s)" in out
     assert "memory: 2 worker(s)" in out
     assert "limiting constraint(s): memory" in out

--- a/tests/test_egress.py
+++ b/tests/test_egress.py
@@ -1,6 +1,7 @@
 """Immutable Pier egress image and host-proxy bridge contracts."""
 
 import json
+import os
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -8,6 +9,11 @@ from types import SimpleNamespace
 import pytest
 
 from dradar import egress, pier_sitecustomize
+
+
+@pytest.fixture(autouse=True)
+def _host_prepare_is_not_nested(monkeypatch):
+    monkeypatch.setattr(egress, "_running_in_container", lambda: False)
 
 
 _REAL_ENSURE_IMAGE = egress.ensure_egress_proxy_image
@@ -310,6 +316,7 @@ def test_compose_uses_pinned_image_and_never_dynamic_build(
     monkeypatch.setenv("DRADAR_EGRESS_PROXY_IMAGE", _TEST_IMAGE)
     monkeypatch.setenv("DRADAR_EGRESS_UPSTREAM_HOST", "host.docker.internal")
     monkeypatch.setenv("DRADAR_EGRESS_UPSTREAM_PORT", "39127")
+    monkeypatch.setattr(pier_sitecustomize, "_running_in_container", lambda: False)
     path = tmp_path / "docker-compose-egress-proxy.json"
     allowlist = SimpleNamespace(domains=["api.openai.com"])
 
@@ -327,8 +334,195 @@ def test_compose_uses_pinned_image_and_never_dynamic_build(
     assert "build" not in service
     assert service["environment"]["PROXY_TOKEN"] == "runtime-secret"
     assert service["extra_hosts"] == ["host.docker.internal:host-gateway"]
+    assert compose["networks"]["pier-egress-internal"] == {"internal": True}
     assert not (tmp_path / "must-not-exist").exists()
     assert path.stat().st_mode & 0o077 == 0
+
+
+def test_compose_keeps_exam_off_internet_and_uses_unix_socket_inside_a_container(
+    monkeypatch, tmp_path: Path,
+):
+    monkeypatch.setenv("DRADAR_EGRESS_PROXY_IMAGE", _TEST_IMAGE)
+    monkeypatch.setattr(pier_sitecustomize, "_running_in_container", lambda: True)
+    path = tmp_path / "docker-compose-egress-proxy.json"
+
+    pier_sitecustomize._write_docker_proxy_compose(
+        path=path,
+        proxy_dir=tmp_path / "must-not-exist",
+        allowlist=SimpleNamespace(domains=["cli-chat-proxy.grok.com"]),
+        token="runtime-secret",
+    )
+
+    compose = json.loads(path.read_text())
+    main = compose["services"]["main"]
+    proxy = compose["services"]["pier-egress-proxy"]
+    export = compose["services"]["pier-egress-sock-export"]
+    forward = compose["services"]["pier-egress-forward"]
+    squid_script = (tmp_path / "dradar-egress-loopback-squid.sh").read_text(
+        encoding="utf-8",
+    )
+    export_script = (tmp_path / "dradar-proxy-export.py").read_text(encoding="utf-8")
+    assert main["image"] == "${MAIN_IMAGE_NAME}"
+    assert main["networks"] == ["pier-egress-internal"]
+    assert "network_mode" not in main
+    assert export["image"] == "python:3.12-alpine"
+    assert forward["image"] == "python:3.12-alpine"
+    assert export.get("pull_policy") == "never"
+    assert forward.get("pull_policy") == "never"
+    assert export.get("user") == "0:0"
+    assert forward.get("user") == "0:0"
+    assert compose["networks"]["pier-egress-internal"] == {"internal": True}
+    assert proxy["networks"] == ["pier-egress-internal", "default"]
+    assert "http_port 127.0.0.1:8080" in squid_script
+    assert "http.sock" not in squid_script
+    assert "chmod 1777" not in squid_script
+    assert export["network_mode"] == "service:pier-egress-proxy"
+    assert forward["network_mode"] == "service:main"
+    assert "pier-egress-sock:/egress" in export["volumes"]
+    assert "pier-egress-sock:/egress" in forward["volumes"]
+    assert "/egress/http.sock" in export_script
+    assert compose["volumes"] == {"pier-egress-sock": {}}
+    assert (tmp_path / "dradar-proxy-forward.py").is_file()
+    squid_path = tmp_path / "dradar-egress-loopback-squid.sh"
+    export_path = tmp_path / "dradar-proxy-export.py"
+    forward_path = tmp_path / "dradar-proxy-forward.py"
+    if os.name != "nt":
+        assert squid_path.stat().st_mode & 0o777 == 0o755
+        assert export_path.stat().st_mode & 0o777 == 0o644
+        assert forward_path.stat().st_mode & 0o777 == 0o644
+
+
+def test_compose_nested_sidecar_uses_resolved_small_image(
+    monkeypatch, tmp_path: Path,
+):
+    monkeypatch.setenv("DRADAR_EGRESS_PROXY_IMAGE", _TEST_IMAGE)
+    monkeypatch.setenv(
+        pier_sitecustomize._NESTED_SIDECAR_IMAGE_ENV,
+        "dradar-nested-sidecar:py3",
+    )
+    monkeypatch.setattr(pier_sitecustomize, "_running_in_container", lambda: True)
+    path = tmp_path / "docker-compose-egress-proxy.json"
+
+    pier_sitecustomize._write_docker_proxy_compose(
+        path=path,
+        proxy_dir=tmp_path / "must-not-exist",
+        allowlist=SimpleNamespace(domains=["cli-chat-proxy.grok.com"]),
+        token="runtime-secret",
+    )
+
+    compose = json.loads(path.read_text())
+    assert compose["services"]["main"]["image"] == "${MAIN_IMAGE_NAME}"
+    assert compose["services"]["pier-egress-sock-export"]["image"] == (
+        "dradar-nested-sidecar:py3"
+    )
+    assert compose["services"]["pier-egress-forward"]["image"] == (
+        "dradar-nested-sidecar:py3"
+    )
+
+
+def test_nested_sidecar_uses_local_alpine(monkeypatch):
+    monkeypatch.setattr(
+        egress, "_docker_image_exists",
+        lambda _docker, image: image == egress.NESTED_SIDECAR_IMAGE,
+    )
+    monkeypatch.setattr(
+        egress, "_pull_docker_image",
+        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("must not pull")),
+    )
+
+    assert egress.ensure_nested_sidecar_image("docker", _TEST_IMAGE) == (
+        egress.NESTED_SIDECAR_IMAGE
+    )
+
+
+def test_nested_sidecar_pulls_alpine_when_missing(monkeypatch):
+    present: set[str] = set()
+
+    def exists(_docker, image):
+        return image in present
+
+    def pull(_docker, image):
+        present.add(image)
+        return True
+
+    monkeypatch.setattr(egress, "_docker_image_exists", exists)
+    monkeypatch.setattr(egress, "_pull_docker_image", pull)
+    monkeypatch.setattr(
+        egress, "_build_python_sidecar_from_proxy", lambda *_a, **_k: False,
+    )
+
+    assert egress.ensure_nested_sidecar_image("docker", _TEST_IMAGE) == (
+        egress.NESTED_SIDECAR_IMAGE
+    )
+
+
+def test_nested_sidecar_derives_python_from_proxy_when_hub_is_blocked(monkeypatch):
+    present: set[str] = set()
+
+    def exists(_docker, image):
+        return image in present
+
+    def build(_docker, _proxy, tag):
+        present.add(tag)
+        return True
+
+    monkeypatch.setattr(egress, "_docker_image_exists", exists)
+    monkeypatch.setattr(egress, "_pull_docker_image", lambda *_a, **_k: False)
+    monkeypatch.setattr(egress, "_build_python_sidecar_from_proxy", build)
+
+    assert egress.ensure_nested_sidecar_image("docker", _TEST_IMAGE) == (
+        egress.NESTED_SIDECAR_LOCAL_TAG
+    )
+
+
+def test_nested_sidecar_fails_closed_when_no_python_image(monkeypatch):
+    monkeypatch.setattr(egress, "_docker_image_exists", lambda *_a, **_k: False)
+    monkeypatch.setattr(egress, "_pull_docker_image", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        egress, "_build_python_sidecar_from_proxy", lambda *_a, **_k: False,
+    )
+
+    with pytest.raises(egress.EgressProxyError, match="small python image"):
+        egress.ensure_nested_sidecar_image("docker", _TEST_IMAGE)
+
+
+def test_prepare_injects_nested_sidecar_image_inside_a_container(monkeypatch):
+    monkeypatch.setattr(egress, "_running_in_container", lambda: True)
+    monkeypatch.setattr(
+        egress, "ensure_egress_proxy_image",
+        lambda *_args, **_kwargs: _TEST_IMAGE,
+    )
+    monkeypatch.setattr(
+        egress, "_validate_build_proxy_compatibility", lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        egress, "ensure_nested_sidecar_image",
+        lambda *_a, **_k: "python:3.12-alpine",
+    )
+
+    runtime = _REAL_PREPARE_RUNTIME("docker")
+
+    assert runtime[egress.NESTED_SIDECAR_IMAGE_ENV] == "python:3.12-alpine"
+
+
+def test_unix_forwarder_points_http_proxy_at_loopback(tmp_path: Path):
+    path = tmp_path / "docker-compose-egress-proxy.json"
+    path.write_text(json.dumps({
+        "services": {
+            "main": {},
+            "pier-egress-forward": {"network_mode": "service:main"},
+        },
+    }))
+    runtime = {
+        "HTTP_PROXY": "http://agent:short-lived@pier-egress-proxy:8080",
+        "HTTPS_PROXY": "http://agent:short-lived@pier-egress-proxy:8080",
+    }
+
+    pier_sitecustomize._finalize_docker_proxy_compose(path, runtime, None)
+
+    environment = json.loads(path.read_text())["services"]["main"]["environment"]
+    assert environment["HTTP_PROXY"] == "http://agent:short-lived@127.0.0.1:8080"
+    assert environment["HTTPS_PROXY"] == "http://agent:short-lived@127.0.0.1:8080"
 
 
 def test_pier_bootstrap_accepts_only_local_image_id_or_official_digest():

--- a/tests/test_feedback_round2.py
+++ b/tests/test_feedback_round2.py
@@ -115,7 +115,10 @@ def test_quota_share_tiny_pct_never_shows_zero():
 
 import pytest
 
-from dradar.runner import BuildFlakeError, RunnerError, run_trial
+from dradar.runner import (
+    BuildDiskFullError, BuildFlakeError, BuildSnapshotterPermissionError,
+    RunnerError, run_trial,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -222,3 +225,83 @@ def test_run_and_submit_gives_up_after_second_flake(monkeypatch, capsys, tmp_pat
         {"defer_seconds": 300, "failure_kind": "environment_build_failed"},
     )]
     assert "failed twice" in capsys.readouterr().out
+
+
+def test_disk_full_build_is_not_a_mirror_flake(tmp_path, monkeypatch):
+    _flaky_pier(
+        monkeypatch, tmp_path, fail_times=99,
+        log_line="ERROR: failed to solve: no space left on device",
+    )
+    with pytest.raises(BuildDiskFullError) as exc:
+        run_trial({"assignment_id": "a1", "task_id": "t", "agent": "codex",
+                   "model": "m", "effort": "low", "est_minutes": 2}, tmp_path, tmp_path)
+    assert "disk is full" in str(exc.value)
+
+
+def test_copy_file_range_without_enospc_stays_a_build_flake(tmp_path, monkeypatch):
+    _flaky_pier(
+        monkeypatch, tmp_path, fail_times=99,
+        log_line="ERROR: failed to solve: copy_file_range: input/output error",
+    )
+    with pytest.raises(BuildFlakeError):
+        run_trial({"assignment_id": "a1", "task_id": "t", "agent": "codex",
+                   "model": "m", "effort": "low", "est_minutes": 2}, tmp_path, tmp_path)
+
+
+def test_overlay_whiteout_permission_is_not_a_mirror_flake(tmp_path, monkeypatch):
+    _flaky_pier(
+        monkeypatch, tmp_path, fail_times=99,
+        log_line=(
+            "ERROR: failed to solve: fuse-overlayfs: converting whiteout: "
+            "operation not permitted"
+        ),
+    )
+    with pytest.raises(BuildSnapshotterPermissionError) as exc:
+        run_trial({"assignment_id": "a1", "task_id": "t", "agent": "codex",
+                   "model": "m", "effort": "low", "est_minutes": 2}, tmp_path, tmp_path)
+    assert "overlay whiteouts" in str(exc.value)
+
+
+def test_run_and_submit_retries_overlay_permission_on_default_builder(
+    monkeypatch, capsys, tmp_path,
+):
+    from test_go_menu import ASSIGNMENT, SubmitClient, _fake_art
+    monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
+    calls = {"n": 0}
+
+    def flaky_run(*_a, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            assert kw.get("allow_isolated_builder") is True
+            raise BuildSnapshotterPermissionError("whiteout eperm")
+        assert kw.get("allow_isolated_builder") is False
+        return _fake_art(tmp_path, rc=0)
+
+    monkeypatch.setattr(runloop, "run_trial", flaky_run)
+    client = SubmitClient({})
+    tag = runloop._run_and_submit(client, ASSIGNMENT, tmp_path, _args(), "abc")
+    assert tag == "submitted" and calls["n"] == 2
+    assert "host default builder" in capsys.readouterr().out
+
+
+def test_run_and_submit_does_not_retry_disk_full(monkeypatch, capsys, tmp_path):
+    from test_go_menu import ASSIGNMENT, SubmitClient
+    monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
+    calls = {"n": 0}
+
+    def always_full(*_a, **_kw):
+        calls["n"] += 1
+        raise BuildDiskFullError("no space left")
+
+    monkeypatch.setattr(runloop, "run_trial", always_full)
+    client = SubmitClient({})
+    stopped = []
+    client.mark_stopped = lambda aid, **kw: stopped.append((aid, kw))
+    tag = runloop._run_and_submit(client, ASSIGNMENT, tmp_path, _args(), "abc")
+    assert tag == "environment-build-failed"
+    assert calls["n"] == 1
+    assert stopped == [(
+        ASSIGNMENT["assignment_id"],
+        {"defer_seconds": 300, "failure_kind": "environment_build_failed"},
+    )]
+    assert "disk space" in capsys.readouterr().out

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -86,6 +86,16 @@ def test_periodic_maintenance_claim_is_shared_and_throttled(tmp_path: Path):
     )
 
 
+def _snapshotter_from(command):
+    for index, part in enumerate(command):
+        if part == "--buildkitd-flags" and index + 1 < len(command):
+            value = command[index + 1]
+            prefix = "--oci-worker-snapshotter="
+            if value.startswith(prefix):
+                return value[len(prefix):]
+    return None
+
+
 def test_trial_builder_is_assignment_scoped_and_never_selected_globally(
     tmp_path: Path, monkeypatch,
 ):
@@ -93,21 +103,26 @@ def test_trial_builder_is_assignment_scoped_and_never_selected_globally(
 
     def run(command, **_kwargs):
         calls.append(command)
-        if command[:2] == ["buildx", "inspect"]:
+        if command[:2] == ["buildx", "inspect"] and "--bootstrap" not in command:
             return subprocess.CompletedProcess(command, 1, "", "not found")
         return subprocess.CompletedProcess(command, 0, "ok", "")
 
+    monkeypatch.setattr(image_cache, "running_in_container", lambda: False)
     monkeypatch.setattr(image_cache, "_run_docker", run)
     lease = image_cache.prepare_trial_builder(
         tmp_path, assignment_id="a1", runtime={},
     )
 
-    assert lease.isolated and lease.name == image_cache.trial_builder_name(tmp_path, "a1")
-    assert calls[-1] == [
-        "buildx", "create", "--name", lease.name,
+    name = image_cache.trial_builder_name(tmp_path, "a1")
+    creates = [command for command in calls if command[:2] == ["buildx", "create"]]
+    assert lease.isolated and lease.name == name
+    assert creates == [[
+        "buildx", "create", "--name", name,
         "--driver", "docker-container",
-    ]
-    assert "--use" not in calls[-1]
+        "--buildkitd-flags", "--oci-worker-snapshotter=overlayfs",
+    ]]
+    assert "--use" not in creates[0]
+    assert image_cache.ISOLATED_SNAPSHOTTERS == ("overlayfs", "fuse-overlayfs")
 
 
 def test_shared_trial_builder_is_bootstrapped_and_reusable(
@@ -128,6 +143,7 @@ def test_shared_trial_builder_is_bootstrapped_and_reusable(
             builder_exists = True
         return subprocess.CompletedProcess(command, 0, "ok", "")
 
+    monkeypatch.setattr(image_cache, "running_in_container", lambda: False)
     monkeypatch.setattr(image_cache, "_run_docker", run)
     lease = image_cache.prepare_trial_builder(
         tmp_path, assignment_id="a1", runtime={}, mode="shared",
@@ -150,6 +166,100 @@ def test_shared_trial_builder_is_bootstrapped_and_reusable(
     ) == (True, None)
     # Shared cleanup must not remove the persistent BuildKit cache.
     assert calls[-1] == ["buildx", "inspect", lease.name]
+
+
+def test_trial_builder_falls_back_to_fuse_overlayfs_when_overlayfs_cannot_boot(
+    tmp_path: Path, monkeypatch,
+):
+    calls = []
+
+    def run(command, **_kwargs):
+        calls.append(command)
+        if command[:2] == ["buildx", "inspect"] and "--bootstrap" not in command:
+            return subprocess.CompletedProcess(command, 1, "", "not found")
+        if _snapshotter_from(command) == "overlayfs":
+            return subprocess.CompletedProcess(command, 1, "", "overlayfs not supported")
+        return subprocess.CompletedProcess(command, 0, "ok", "")
+
+    monkeypatch.setattr(image_cache, "running_in_container", lambda: False)
+    monkeypatch.setattr(image_cache, "_run_docker", run)
+    lease = image_cache.prepare_trial_builder(
+        tmp_path, assignment_id="a1", runtime={},
+    )
+
+    creates = [command for command in calls if command[:2] == ["buildx", "create"]]
+    assert lease.isolated and lease.name == image_cache.trial_builder_name(tmp_path, "a1")
+    assert [_snapshotter_from(command) for command in creates] == [
+        "overlayfs", "fuse-overlayfs",
+    ]
+
+
+def test_trial_builder_uses_host_default_instead_of_native_copies(
+    tmp_path: Path, monkeypatch,
+):
+    def run(command, **_kwargs):
+        if command[:2] == ["buildx", "create"]:
+            return subprocess.CompletedProcess(command, 1, "", "no copy-on-write snapshotter")
+        if command[:2] == ["buildx", "inspect"]:
+            return subprocess.CompletedProcess(command, 1, "", "not found")
+        return subprocess.CompletedProcess(command, 0, "ok", "")
+
+    monkeypatch.setattr(image_cache, "running_in_container", lambda: False)
+    monkeypatch.setattr(image_cache, "_run_docker", run)
+    lease = image_cache.prepare_trial_builder(
+        tmp_path, assignment_id="a1", runtime={},
+    )
+
+    assert not lease.isolated and lease.name is None
+    assert not lease.expected
+    assert "叠加文件系统" in lease.note
+    assert "默认构建空间" in lease.note or "叠加文件系统" in lease.note
+
+
+def test_trial_builder_skips_isolated_volume_inside_a_container(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(image_cache, "running_in_container", lambda: True)
+    monkeypatch.setattr(
+        image_cache, "_run_docker",
+        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("must not create builder")),
+    )
+    lease = image_cache.prepare_trial_builder(
+        tmp_path, assignment_id="a1", runtime={},
+    )
+
+    assert not lease.isolated and lease.name is None
+    assert not lease.expected
+    assert "容器内" in lease.note
+
+
+def test_task_cleanup_allows_intentional_default_builder(
+    tmp_path: Path, monkeypatch,
+):
+    assignment_id = "a1"
+    job_dir = tmp_path / "work" / "jobs" / "aa1"
+    (job_dir / PROJECT).mkdir(parents=True)
+    monkeypatch.setattr(
+        image_cache, "_remove_project_runtime", lambda *_a: (0, 0, 0),
+    )
+    monkeypatch.setattr(
+        image_cache, "remove_assignment_images",
+        lambda *_a, **_k: (0, 0, None),
+    )
+    monkeypatch.setattr(
+        image_cache, "remove_trial_builder", lambda *_a, **_k: (True, None),
+    )
+
+    result = image_cache.cleanup_trial_resources(
+        tmp_path,
+        assignment_id=assignment_id,
+        job_dir=job_dir,
+        trial_name=PROJECT,
+        builder_isolated=False,
+        builder_expected=False,
+    )
+
+    assert result.success
 
 
 def test_shared_build_cache_prune_targets_only_dradar_builder(
@@ -582,6 +692,10 @@ def test_server_state_failure_never_deletes_but_keeps_disk_claim_guard(
 
 def test_default_policy_is_adaptive_and_bounded(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(
+        image_cache, "_policy_min_free_bytes",
+        lambda: int(image_cache.DEFAULT_MIN_FREE_GIB * image_cache.GIB),
+    )
+    monkeypatch.setattr(
         image_cache.shutil, "disk_usage",
         lambda _p: SimpleNamespace(total=2_000 * image_cache.GIB,
                                    used=0, free=2_000 * image_cache.GIB),
@@ -598,6 +712,20 @@ def test_default_policy_is_adaptive_and_bounded(tmp_path: Path, monkeypatch):
     )
     small = image_cache.effective_policy(tmp_path, {})
     assert small.limit_bytes == 20 * image_cache.GIB
+    assert small.min_free_bytes == 25 * image_cache.GIB
+
+
+def test_vfs_policy_raises_the_free_disk_floor(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("dradar.capacity.docker_storage_driver", lambda: "vfs")
+    monkeypatch.setattr(
+        image_cache.shutil, "disk_usage",
+        lambda _p: SimpleNamespace(total=128 * image_cache.GIB,
+                                   used=0, free=112 * image_cache.GIB),
+    )
+
+    policy = image_cache.effective_policy(tmp_path, {})
+
+    assert policy.min_free_bytes == 80 * image_cache.GIB
 
 
 def test_config_set_preserves_identity_token(tmp_path: Path, monkeypatch):

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -2042,6 +2042,19 @@ def test_run_trial_classifies_build_failure_from_nested_result(tmp_path, monkeyp
     assert "failed to solve" in str(exc.value)
 
 
+def test_run_trial_disk_full_nested_result_is_not_a_mirror_flake(tmp_path, monkeypatch):
+    _fake_pier(
+        monkeypatch, tmp_path, patch=False,
+        result={"exception_info": {
+            "exception_type": "RuntimeError",
+            "exception_message": "failed to solve: no space left on device",
+        }},
+    )
+    with pytest.raises(runner_mod.BuildDiskFullError) as exc:
+        run_trial(_assignment("codex"), tmp_path, tmp_path)
+    assert "disk is full" in str(exc.value)
+
+
 def test_run_trial_missing_patch_message_includes_log_tail(tmp_path, monkeypatch):
     captured = {}
     def fake_build(assignment, tasks_root, jobs_dir, job_name, home, dev_agent=None):


### PR DESCRIPTION
Per-task docker-container builders used BuildKit auto snapshotter. On some Linux hosts that selects native, which copies a full rootfs for every Dockerfile RUN and can fill the disk during compose build.

Try overlayfs, then fuse-overlayfs, and bootstrap so the snapshotter is proven before Pier starts. If neither copy-on-write option starts, use the host default builder instead of native. ENOSPC is not retried as a mirror/network flake.