### PR TITLE
Improve parallel build preparation resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,6 +774,8 @@ dradar cleanup --include-kept
 dradar cleanup --docker --dry-run
 dradar cleanup --docker
 dradar cleanup --docker --all-task-images  # 一次性处理升级前遗留镜像
+dradar cleanup --docker --shared-build-cache --dry-run
+dradar cleanup --docker --shared-build-cache -y
 ```
 
 清理前必须成功从服务端取得当前租约列表；网络失败时什么都不删除。以下内容默认保护：
@@ -793,7 +795,7 @@ dradar cleanup --docker --all-task-images  # 一次性处理升级前遗留镜�
 
 默认每道题使用独立、一次性的 Docker 构建空间，题目结束时直接删除该构建空间，因此
 不会清理或占用用户其他项目的 BuildKit 缓存。需要多 worker 并发、且希望复用相同基础层
-时，可以显式启用同一 DRadar 用户范围内的共享 BuildKit 缓存：
+时，可以显式启用同一操作系统用户范围内的共享 BuildKit 缓存：
 
 ```bash
 dradar config set build-cache-mode shared
@@ -801,13 +803,19 @@ dradar config set environment-build-timeout-multiplier 2
 dradar config show
 ```
 
-共享模式只复用 BuildKit 的不可变基础/依赖层；每道题的容器、网络、卷、任务镜像和
-工作目录仍按精确归属清理，凭据不会进入共享缓存。共享 builder 只在 Pier 子进程的
-`BUILDX_BUILDER` 环境中选择，不改变用户的全局 builder；恢复默认隔离模式可执行
-`dradar config set build-cache-mode isolated`。容器、网络、卷和镜像仍须同时通过精确
-任务目录、Compose 标签、镜像引用和镜像 ID 校验；不会运行全局 `docker system prune`、
-`docker image prune` 或默认 builder 的全局缓存清理。任何一步无法确认时，本题结果仍会
-保存，但该 worker 会停止继续领取或运行下一题，并显示可操作的原因。
+共享模式重点复用 BuildKit 的不可变基础/依赖层；每道题的容器、网络、卷、任务镜像和
+工作目录仍按精确归属清理，凭据不会进入共享缓存。共享 builder 以当前操作系统用户为
+边界，只在 Pier 子进程的 `BUILDX_BUILDER` 环境中选择，不改变用户的全局 builder；
+恢复默认隔离模式可执行 `dradar config set build-cache-mode isolated`。容器、网络、卷和
+镜像仍须同时通过精确任务目录、Compose 标签、镜像引用和镜像 ID 校验；不会运行全局
+`docker system prune`、`docker image prune` 或默认 builder 的全局缓存清理。任何一步无法
+确认时，本题结果仍会保存，但该 worker 会停止继续领取或运行下一题，并显示可操作的原因。
+
+共享 builder 不会在每道题结束时删除，否则无法复用公共层；使用
+`cleanup --docker --shared-build-cache` 可按当前 image-cache 上限显式回收它。`--dry-run`
+只展示目标 builder 和上限，`-y` 才执行 BuildKit GC；只要服务端仍有活动或可恢复租约，
+命令会保护并跳过共享缓存，避免打断在途构建。该选项只命中当前操作系统用户的
+`dradar-cache-*` builder，不会执行全局 prune。
 
 升级前已经积累的 Pier 镜像必须显式使用 `--all-task-images`，仍会经过标签、容器和本地
 恢复状态校验；旧版本写入默认 builder 的历史缓存无法证明只属于 DRadar，因此不会在

--- a/README.md
+++ b/README.md
@@ -574,6 +574,8 @@ dradar resume --assignment <ASSIGNMENT_ID>
 | `--allow-task-drift` | 显式允许本地 benchmark 版本或任务内容与服务端不一致；这类运行不可可靠比较，默认会在消耗模型额度前停止 |
 | `--workers N` | 由一个父进程管理 N 个并发 worker，范围 1–40，默认 1 |
 | `--workers auto` | 检测 Docker、磁盘和账号限制后选择保守并发数 |
+| `--environment-build-timeout-multiplier N` | 将 Pier 的环境构建超时乘以 N，范围 1–8，默认 2 |
+| `--build-cache-mode {isolated,shared}` | 本次运行覆盖构建缓存策略；默认读取 `dradar config`，未配置时为 `isolated` |
 | `--parallel` | 高级选项：允许手工启动另一个独立 DRadar 会话；隐含 `-y` |
 | `--refill` | 显式开启持续自动补题；必须同时给出额度或题数硬上限 |
 | `--refill-to N` | 持有/运行队列目标；传入时自动启用 `--refill`，但仍需硬上限 |
@@ -789,9 +791,21 @@ dradar cleanup --docker --all-task-images  # 一次性处理升级前遗留镜�
 上传失败只保留 Docker 外部的待补传结果，不需要保留整套题目环境。`--keep` 可以保留
 本地诊断文件和题目镜像，但仍会停止容器并删除临时构建空间。
 
-每道题使用独立、一次性的 Docker 构建空间，题目结束时直接删除该构建空间，因此不会
-清理或占用用户其他项目的 BuildKit 缓存。容器、网络、卷和镜像仍须同时通过精确任务
-目录、Compose 标签、镜像引用和镜像 ID 校验；不会运行全局 `docker system prune`、
+默认每道题使用独立、一次性的 Docker 构建空间，题目结束时直接删除该构建空间，因此
+不会清理或占用用户其他项目的 BuildKit 缓存。需要多 worker 并发、且希望复用相同基础层
+时，可以显式启用同一 DRadar 用户范围内的共享 BuildKit 缓存：
+
+```bash
+dradar config set build-cache-mode shared
+dradar config set environment-build-timeout-multiplier 2
+dradar config show
+```
+
+共享模式只复用 BuildKit 的不可变基础/依赖层；每道题的容器、网络、卷、任务镜像和
+工作目录仍按精确归属清理，凭据不会进入共享缓存。共享 builder 只在 Pier 子进程的
+`BUILDX_BUILDER` 环境中选择，不改变用户的全局 builder；恢复默认隔离模式可执行
+`dradar config set build-cache-mode isolated`。容器、网络、卷和镜像仍须同时通过精确
+任务目录、Compose 标签、镜像引用和镜像 ID 校验；不会运行全局 `docker system prune`、
 `docker image prune` 或默认 builder 的全局缓存清理。任何一步无法确认时，本题结果仍会
 保存，但该 worker 会停止继续领取或运行下一题，并显示可操作的原因。
 

--- a/src/dradar/cli.py
+++ b/src/dradar/cli.py
@@ -391,6 +391,13 @@ def main(argv: list[str] | None = None) -> int:
         "--all-task-images", action="store_true",
         help="with --docker, also include legacy label-validated Pier task images",
     )
+    p_cleanup.add_argument(
+        "--shared-build-cache", action="store_true",
+        help=(
+            "with --docker, inspect/prune only this OS user's DRadar shared "
+            "BuildKit cache (blocked while active assignments exist)"
+        ),
+    )
     p_cleanup.add_argument("-y", "--yes", action="store_true", help="skip confirmation")
     p_cleanup.set_defaults(func=cmd_cleanup)
 
@@ -508,7 +515,7 @@ def main(argv: list[str] | None = None) -> int:
             "--build-cache-mode",
             choices=("isolated", "shared"),
             default=None,
-            help="use an assignment-only BuildKit cache or a DRadar-home-scoped "
+            help="use an assignment-only BuildKit cache or an OS-user-scoped "
                  "shared immutable cache (default: saved setting, isolated)",
         )
         p.add_argument(

--- a/src/dradar/cli.py
+++ b/src/dradar/cli.py
@@ -80,6 +80,13 @@ def _nonnegative_float(value: str) -> float:
     return parsed
 
 
+def _environment_build_timeout_multiplier(value: str) -> float:
+    parsed = _nonnegative_float(value)
+    if not 1.0 <= parsed <= 8.0:
+        raise argparse.ArgumentTypeError("must be between 1 and 8")
+    return parsed
+
+
 def _pass_rate(value: str) -> float:
     parsed = _nonnegative_float(value)
     if parsed > 1:
@@ -393,7 +400,10 @@ def main(argv: list[str] | None = None) -> int:
     p_config_show.set_defaults(func=cmd_config_show)
     p_config_set = config_sub.add_parser("set", help="change a supported local setting")
     p_config_set.add_argument(
-        "key", choices=("image-cache-mode", "image-cache-limit-gb"),
+        "key", choices=(
+            "image-cache-mode", "image-cache-limit-gb", "build-cache-mode",
+            "environment-build-timeout-multiplier",
+        ),
     )
     p_config_set.add_argument("value")
     p_config_set.set_defaults(func=cmd_config_set)
@@ -485,6 +495,21 @@ def main(argv: list[str] | None = None) -> int:
             "--workers", type=_workers_value, default=1, metavar="N|auto",
             help="run up to N tasks concurrently, or use 'auto' for a "
                  "conservative Docker-based recommendation (default: 1; maximum: 40)",
+        )
+        p.add_argument(
+            "--environment-build-timeout-multiplier",
+            type=_environment_build_timeout_multiplier,
+            default=None,
+            metavar="N",
+            help="multiply each task's Docker environment build timeout "
+                 "(default: 2; allowed range 1..8)",
+        )
+        p.add_argument(
+            "--build-cache-mode",
+            choices=("isolated", "shared"),
+            default=None,
+            help="use an assignment-only BuildKit cache or a DRadar-home-scoped "
+                 "shared immutable cache (default: saved setting, isolated)",
         )
         p.add_argument(
             "--batch-id", type=_batch_id_value, metavar="UUID",

--- a/src/dradar/image_cache.py
+++ b/src/dradar/image_cache.py
@@ -98,9 +98,10 @@ class TrialBuilderLease:
     name: str | None
     isolated: bool
     note: str | None = None
-    # A shared builder is scoped to this DRadar home and is selected only in
-    # the child Pier environment, but it intentionally survives one trial so
-    # BuildKit can reuse immutable layers for the next task.
+    # A shared builder is scoped to the current OS user's Docker context and
+    # is selected only in the child Pier environment. It intentionally
+    # survives one trial so BuildKit can reuse immutable layers for the next
+    # task, even when Fleet gives each harness a separate DRADAR_HOME.
     reusable: bool = False
 
 
@@ -209,22 +210,23 @@ def trial_builder_name(home: Path, assignment_id: str) -> str:
 
 
 def shared_builder_name(home: Path) -> str:
-    """Return the persistent BuildKit builder scoped to one host cache root.
+    """Return the persistent BuildKit builder scoped to one OS user.
 
     The name is deterministic so concurrent workers converge on one builder,
-    while the hash prevents a user's shared cache from colliding with another
-    host cache root on the same Docker daemon.  It is never selected globally;
-    callers pass it through ``BUILDX_BUILDER`` only to the Pier child.
+    while the hash prevents a different OS user's builder from colliding on a
+    shared Docker daemon.  It is never selected globally; callers pass it
+    through ``BUILDX_BUILDER`` only to the Pier child. ``home`` remains in the
+    signature for compatibility with the assignment-scoped helper, but is not
+    the scope: Fleet deliberately uses separate DRADAR_HOME paths per harness.
     """
 
-    # A Fleet uses one DRADAR_HOME per harness.  Deliberately scope the shared
-    # builder to the host user's cache root (or an explicit operator-provided
-    # root) rather than that per-harness directory, otherwise eight cars would
-    # still download the same immutable layers eight times.  The Docker daemon
-    # already enforces the OS user's boundary; task credentials never enter
-    # this name or the BuildKit cache.
-    configured = os.environ.get("DRADAR_SHARED_BUILDER_SCOPE", "").strip()
-    scope = Path(configured).expanduser() if configured else Path.home()
+    # A Fleet uses one DRADAR_HOME per harness. Deliberately scope the shared
+    # builder to the host OS user rather than that per-harness directory,
+    # otherwise eight cars would still download the same immutable layers
+    # eight times. Do not accept an arbitrary environment override here: the
+    # OS user's home and Docker socket are the auditable isolation boundary;
+    # task credentials never enter this name or the BuildKit cache.
+    scope = Path.home()
     identity = f"{scope.resolve()}\0shared-build-cache".encode(
         "utf-8", "surrogatepass",
     )
@@ -365,7 +367,7 @@ def prepare_trial_builder(
         return TrialBuilderLease(None, False, f"{label}不可用：{exc}")
     if reusable:
         return TrialBuilderLease(
-            name, True, "共享 BuildKit 缓存已预热；仅限当前 DRadar 主目录", True,
+            name, True, "共享 BuildKit 缓存已预热；仅限当前 OS 用户的 Docker 环境", True,
         )
     return TrialBuilderLease(name, True)
 
@@ -393,6 +395,49 @@ def remove_trial_builder(
         detail = (removed.stderr or removed.stdout or "Docker 拒绝清理").strip()
         return False, detail[:300]
     return True, None
+
+
+def prune_shared_build_cache(
+    home: Path, *, max_used_bytes: int,
+) -> tuple[bool, str | None]:
+    """Prune only DRadar's persistent shared builder to a bounded cap.
+
+    The shared builder is intentionally retained between tasks, but it must
+    have an explicit lifecycle. This helper never touches the default builder
+    or another named builder: it first proves the deterministic, OS-user
+    scoped name exists, then invokes BuildKit's own GC with a byte cap. The
+    caller is responsible for refusing the operation while active assignments
+    are running and for asking the user before the destructive invocation.
+    """
+
+    if (
+        not isinstance(max_used_bytes, int)
+        or isinstance(max_used_bytes, bool)
+        or max_used_bytes <= 0
+    ):
+        return False, "共享构建缓存上限必须是正整数"
+    name = shared_builder_name(home)
+    try:
+        inspected = _run_docker(
+            ["buildx", "inspect", name], timeout=30, allow_fail=True,
+        )
+        if inspected.returncode != 0:
+            return True, "共享 builder 尚未创建，无需清理"
+        pruned = _run_docker(
+            [
+                "buildx", "prune", "--builder", name, "--force", "--all",
+                "--max-used-space", str(max_used_bytes),
+            ],
+            timeout=600,
+            allow_fail=True,
+        )
+    except DockerUnavailable as exc:
+        return False, str(exc)
+    if pruned.returncode != 0:
+        detail = (pruned.stderr or pruned.stdout or "BuildKit 拒绝清理").strip()
+        return False, detail[:300]
+    detail = (pruned.stdout or "").strip().replace("\n", " ")
+    return True, detail[:300] if detail else "共享构建缓存已按上限回收"
 
 
 def _parse_size(value: object) -> int:
@@ -1356,6 +1401,7 @@ __all__ = [
     "effective_policy", "is_wsl", "load", "plan_cleanup",
     "prepare_trial_builder", "proxy_detected", "record_trial_images",
     "remove_assignment_images", "remove_images", "remove_trial_builder",
+    "prune_shared_build_cache",
     "trial_builder_name", "shared_builder_name", "normalize_build_cache_mode",
     "configured_build_cache_mode", "BUILD_CACHE_MODES", "DEFAULT_BUILD_CACHE_MODE",
     "wsl_host_disk_free_bytes", "cmd_config_set", "cmd_config_show",

--- a/src/dradar/image_cache.py
+++ b/src/dradar/image_cache.py
@@ -33,6 +33,9 @@ LEDGER_NAME = "image-cache.json"
 LOCK_NAME = "image-cache.lock"
 MAINTENANCE_STAMP_NAME = "image-cache-maintenance.stamp"
 BUILDER_PREFIX = "dradar-task-"
+SHARED_BUILDER_PREFIX = "dradar-cache-"
+BUILD_CACHE_MODES = frozenset({"isolated", "shared"})
+DEFAULT_BUILD_CACHE_MODE = "isolated"
 GIB = 1024 ** 3
 DEFAULT_MIN_FREE_GIB = 25.0
 _PROJECT_RE = re.compile(r"[a-z0-9][a-z0-9-]*__[a-z0-9]{6,8}$")
@@ -95,6 +98,10 @@ class TrialBuilderLease:
     name: str | None
     isolated: bool
     note: str | None = None
+    # A shared builder is scoped to this DRadar home and is selected only in
+    # the child Pier environment, but it intentionally survives one trial so
+    # BuildKit can reuse immutable layers for the next task.
+    reusable: bool = False
 
 
 @dataclass
@@ -201,6 +208,44 @@ def trial_builder_name(home: Path, assignment_id: str) -> str:
     return BUILDER_PREFIX + hashlib.sha256(identity).hexdigest()[:20]
 
 
+def shared_builder_name(home: Path) -> str:
+    """Return the persistent BuildKit builder scoped to one host cache root.
+
+    The name is deterministic so concurrent workers converge on one builder,
+    while the hash prevents a user's shared cache from colliding with another
+    host cache root on the same Docker daemon.  It is never selected globally;
+    callers pass it through ``BUILDX_BUILDER`` only to the Pier child.
+    """
+
+    # A Fleet uses one DRADAR_HOME per harness.  Deliberately scope the shared
+    # builder to the host user's cache root (or an explicit operator-provided
+    # root) rather than that per-harness directory, otherwise eight cars would
+    # still download the same immutable layers eight times.  The Docker daemon
+    # already enforces the OS user's boundary; task credentials never enter
+    # this name or the BuildKit cache.
+    configured = os.environ.get("DRADAR_SHARED_BUILDER_SCOPE", "").strip()
+    scope = Path(configured).expanduser() if configured else Path.home()
+    identity = f"{scope.resolve()}\0shared-build-cache".encode(
+        "utf-8", "surrogatepass",
+    )
+    return SHARED_BUILDER_PREFIX + hashlib.sha256(identity).hexdigest()[:20]
+
+
+def normalize_build_cache_mode(value: object) -> str:
+    """Normalize the local build-cache policy without widening its scope."""
+
+    mode = str(value or DEFAULT_BUILD_CACHE_MODE).strip().lower()
+    return mode if mode in BUILD_CACHE_MODES else DEFAULT_BUILD_CACHE_MODE
+
+
+def configured_build_cache_mode(cfg: dict | None) -> str:
+    """Resolve the persisted policy; malformed config fails closed to isolated."""
+
+    return normalize_build_cache_mode(
+        (cfg or {}).get("build_cache_mode"),
+    )
+
+
 def _builder_proxy_is_safe(runtime: dict[str, str]) -> tuple[bool, str | None]:
     """Whether a dedicated bridge builder can use the configured build proxy.
 
@@ -227,18 +272,25 @@ def _builder_proxy_is_safe(runtime: dict[str, str]) -> tuple[bool, str | None]:
 
 def prepare_trial_builder(
     home: Path, *, assignment_id: str, runtime: dict[str, str] | None = None,
+    mode: str = DEFAULT_BUILD_CACHE_MODE,
 ) -> TrialBuilderLease:
-    """Create an isolated BuildKit builder for exactly one assignment.
+    """Create a BuildKit builder for one assignment or a scoped shared cache.
 
     The builder is never selected globally. ``BUILDX_BUILDER`` is applied only
-    to Pier's child environment, and deleting the builder removes its dedicated
-    BuildKit state volume without touching the user's default builder cache.
+    to Pier's child environment.  ``isolated`` keeps the historical
+    assignment-scoped lifecycle; ``shared`` keeps one host-user-scoped
+    BuildKit state volume so immutable base/install layers can be reused by
+    concurrent tasks.  No credential or task worktree is placed in that cache.
     """
+    mode = normalize_build_cache_mode(mode)
     runtime = runtime or {}
     safe, note = _builder_proxy_is_safe(runtime)
     if not safe:
         return TrialBuilderLease(None, False, note)
-    name = trial_builder_name(home, assignment_id)
+    reusable = mode == "shared"
+    name = shared_builder_name(home) if reusable else trial_builder_name(
+        home, assignment_id,
+    )
     try:
         version = _run_docker(["buildx", "version"], timeout=30, allow_fail=True)
         if version.returncode != 0:
@@ -250,27 +302,81 @@ def prepare_trial_builder(
         )
         if existing.returncode == 0:
             # The assignment lock proves this same home cannot be running the
-            # assignment concurrently. A matching builder is stale residue
-            # from a crashed prior attempt and is safe to replace exactly.
-            _run_docker(["buildx", "rm", name], timeout=180)
-        created = _run_docker([
-            "buildx", "create", "--name", name,
-            "--driver", "docker-container",
-        ], timeout=120, allow_fail=True)
-        if created.returncode != 0:
-            detail = (created.stderr or created.stdout or "").strip()
-            return TrialBuilderLease(
-                None, False,
-                "无法创建隔离的临时构建空间"
-                + (f"：{detail[:160]}" if detail else ""),
+            # A matching assignment builder is stale residue from a crashed
+            # prior attempt and is safe to replace exactly.  The shared
+            # builder is deliberately retained so its content-addressed cache
+            # survives between tasks.
+            if not reusable:
+                _run_docker(["buildx", "rm", name], timeout=180)
+        if existing.returncode != 0:
+            created = _run_docker([
+                "buildx", "create", "--name", name,
+                "--driver", "docker-container",
+            ], timeout=120, allow_fail=True)
+            if created.returncode != 0:
+                # Two workers can race to create the same shared builder.  A
+                # short bounded inspect loop proves whether the first worker
+                # won; only a genuinely unavailable builder falls back.  This
+                # avoids turning a harmless create race into a missing lane in
+                # an eight-worker pool.
+                if reusable:
+                    raced = None
+                    for _ in range(8):
+                        raced = _run_docker(
+                            ["buildx", "inspect", name],
+                            timeout=10,
+                            allow_fail=True,
+                        )
+                        if raced.returncode == 0:
+                            break
+                        time.sleep(0.5)
+                    if raced is None or raced.returncode != 0:
+                        detail = (created.stderr or created.stdout or "").strip()
+                        return TrialBuilderLease(
+                            None, False,
+                            "无法创建共享构建缓存空间"
+                            + (f"：{detail[:160]}" if detail else ""),
+                        )
+                else:
+                    detail = (created.stderr or created.stdout or "").strip()
+                    return TrialBuilderLease(
+                        None, False,
+                        "无法创建隔离的临时构建空间"
+                        + (f"：{detail[:160]}" if detail else ""),
+                    )
+        if reusable:
+            # Bootstrap once before Pier starts its full environment timeout.
+            # This moves BuildKit image download/daemon startup out of the
+            # critical task build and amortizes it across all workers.
+            bootstrapped = _run_docker(
+                ["buildx", "inspect", name, "--bootstrap"],
+                timeout=180,
+                allow_fail=True,
             )
+            if bootstrapped.returncode != 0:
+                detail = (bootstrapped.stderr or bootstrapped.stdout or "").strip()
+                return TrialBuilderLease(
+                    None, False,
+                    "共享构建缓存空间未能启动"
+                    + (f"：{detail[:160]}" if detail else ""),
+                )
     except DockerUnavailable as exc:
-        return TrialBuilderLease(None, False, f"临时构建空间不可用：{exc}")
+        label = "共享构建缓存空间" if reusable else "临时构建空间"
+        return TrialBuilderLease(None, False, f"{label}不可用：{exc}")
+    if reusable:
+        return TrialBuilderLease(
+            name, True, "共享 BuildKit 缓存已预热；仅限当前 DRadar 主目录", True,
+        )
     return TrialBuilderLease(name, True)
 
 
-def remove_trial_builder(home: Path, assignment_id: str) -> tuple[bool, str | None]:
-    """Remove only the deterministic builder owned by one assignment."""
+def remove_trial_builder(
+    home: Path, assignment_id: str, *, mode: str = DEFAULT_BUILD_CACHE_MODE,
+) -> tuple[bool, str | None]:
+    """Remove only an assignment builder; retain a scoped shared cache."""
+
+    if normalize_build_cache_mode(mode) == "shared":
+        return True, None
     name = trial_builder_name(home, assignment_id)
     try:
         inspected = _run_docker(
@@ -1010,7 +1116,8 @@ def _remove_project_runtime(project: str, job_dir: Path) -> tuple[int, int, int]
 
 def cleanup_trial_resources(
     home: Path, *, assignment_id: str, job_dir: Path, trial_name: str,
-    builder_isolated: bool, keep_images: bool = False,
+    builder_isolated: bool, builder_reusable: bool = False,
+    builder_name: str | None = None, keep_images: bool = False,
 ) -> TaskCleanupResult:
     """Delete one settled task's exact Docker resources before any refill.
 
@@ -1051,7 +1158,14 @@ def cleanup_trial_resources(
                 result.success = False
                 notes.append(image_note)
 
-    builder_removed, builder_note = remove_trial_builder(home, assignment_id)
+    if builder_reusable:
+        builder_removed, builder_note = remove_trial_builder(
+            home, assignment_id, mode="shared",
+        )
+    else:
+        # Preserve the narrow legacy call shape for embedders that provide a
+        # small test double around the assignment-scoped cleanup helper.
+        builder_removed, builder_note = remove_trial_builder(home, assignment_id)
     result.builder_removed = builder_removed
     if not builder_isolated:
         result.success = False
@@ -1059,6 +1173,8 @@ def cleanup_trial_resources(
     elif not builder_removed:
         result.success = False
         notes.append(f"临时构建空间清理失败：{builder_note or 'unknown error'}")
+    # A host-user-scoped shared builder is intentionally retained for the next
+    # task; only this task's Compose objects/images are cleaned above.
     result.note = "；".join(notes) if notes else None
     return result
 
@@ -1173,6 +1289,12 @@ def cmd_config_show(args) -> int:
     print(f"  limit: {policy.limit_bytes / GIB:.1f} GiB ({source})")
     print(f"  cleanup target: {policy.target_bytes / GIB:.1f} GiB")
     print(f"  minimum free disk: {policy.min_free_bytes / GIB:.0f} GiB")
+    print(f"  build cache mode: {configured_build_cache_mode(cfg)}")
+    build_timeout = cfg.get("environment_build_timeout_multiplier")
+    print(
+        "  environment build timeout multiplier: "
+        f"{build_timeout if build_timeout is not None else '2 (default)'}"
+    )
     print(f"  proxy environment detected: {'yes' if proxy_detected() else 'no'}")
     return 0
 
@@ -1181,7 +1303,27 @@ def cmd_config_set(args) -> int:
     from . import local_config
 
     cfg = local_config._load_config()
-    if args.key == "image-cache-mode":
+    if args.key == "environment-build-timeout-multiplier":
+        try:
+            value = float(args.value.strip())
+        except (TypeError, ValueError) as exc:
+            raise SystemExit(
+                "environment-build-timeout-multiplier must be between 1 and 8"
+            ) from exc
+        if not (value == value and value not in (float("inf"), float("-inf"))
+                and 1.0 <= value <= 8.0):
+            raise SystemExit(
+                "environment-build-timeout-multiplier must be between 1 and 8"
+            )
+        cfg["environment_build_timeout_multiplier"] = value
+        shown = f"{value:g}"
+    elif args.key == "build-cache-mode":
+        value = args.value.strip().lower()
+        if value not in BUILD_CACHE_MODES:
+            raise SystemExit("build-cache-mode must be isolated or shared")
+        cfg["build_cache_mode"] = value
+        shown = value
+    elif args.key == "image-cache-mode":
         value = args.value.strip().lower()
         if value not in {"balanced", "metered", "disk"}:
             raise SystemExit("image-cache-mode must be balanced, metered, or disk")
@@ -1214,6 +1356,7 @@ __all__ = [
     "effective_policy", "is_wsl", "load", "plan_cleanup",
     "prepare_trial_builder", "proxy_detected", "record_trial_images",
     "remove_assignment_images", "remove_images", "remove_trial_builder",
-    "trial_builder_name",
+    "trial_builder_name", "shared_builder_name", "normalize_build_cache_mode",
+    "configured_build_cache_mode", "BUILD_CACHE_MODES", "DEFAULT_BUILD_CACHE_MODE",
     "wsl_host_disk_free_bytes", "cmd_config_set", "cmd_config_show",
 ]

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -98,6 +98,7 @@ from .runner import (
     local_deep_swe_commit,
     prepare_pinned_deep_swe_tasks,
     pompeii_agent_timeout_sec, run_trial,
+    resolve_environment_build_timeout_multiplier,
     summarize_result, task_content_mismatch_diagnostic,
     trial_artifact_paths,
 )
@@ -289,6 +290,21 @@ def _run_config(args) -> dict:
             if len(normalized) != len(parsed):
                 sys.exit("invalid internal worker capability snapshot")
             cfg["client_capabilities"] = normalized
+    try:
+        args._environment_build_timeout_multiplier = (
+            resolve_environment_build_timeout_multiplier(
+                getattr(args, "environment_build_timeout_multiplier", None)
+                if getattr(args, "environment_build_timeout_multiplier", None)
+                is not None
+                else cfg.get("environment_build_timeout_multiplier")
+            )
+        )
+    except RunnerError as exc:
+        sys.exit(str(exc))
+    args._build_cache_mode = image_cache.normalize_build_cache_mode(
+        getattr(args, "build_cache_mode", None)
+        or image_cache.configured_build_cache_mode(cfg)
+    )
     return cfg
 
 
@@ -2499,15 +2515,38 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
             try:
                 art = run_trial(
                     assignment, tasks_root, work_dir, dev_agent=args.dev_agent,
-                    on_started=bind_owner)
-            finally:
-                # A per-assignment builder owns only this trial's BuildKit
-                # state. Remove it as soon as Pier exits, including exception
-                # paths; task images/runtime objects are handled after the
-                # durable patch has been staged below.
-                builder_removed, builder_note = image_cache.remove_trial_builder(
-                    HOME, assignment["assignment_id"],
+                    on_started=bind_owner,
+                    environment_build_timeout_multiplier=(
+                        getattr(
+                            args, "_environment_build_timeout_multiplier", None,
+                        )
+                    ),
+                    build_cache_mode=(
+                        getattr(args, "_build_cache_mode", None)
+                        or getattr(args, "build_cache_mode", None)
+                        or image_cache.DEFAULT_BUILD_CACHE_MODE
+                    ),
                 )
+            finally:
+                # Assignment-scoped builders own only this trial's BuildKit
+                # state and are removed on every exit path. A shared builder
+                # is deliberately retained so its immutable layers serve the
+                # next worker; image/runtime objects are still cleaned below.
+                cache_mode = (
+                    getattr(args, "_build_cache_mode", None)
+                    or getattr(args, "build_cache_mode", None)
+                    or image_cache.DEFAULT_BUILD_CACHE_MODE
+                )
+                if cache_mode == "shared":
+                    builder_removed, builder_note = (
+                        image_cache.remove_trial_builder(
+                            HOME, assignment["assignment_id"], mode="shared",
+                        )
+                    )
+                else:
+                    builder_removed, builder_note = image_cache.remove_trial_builder(
+                        HOME, assignment["assignment_id"],
+                    )
                 if not builder_removed:
                     args._docker_cleanup_blocked = (
                         "临时构建空间未能删除："
@@ -2655,6 +2694,8 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
         job_dir=art.job_dir,
         trial_name=art.trial_dir.name,
         builder_isolated=art.builder_isolated,
+        builder_reusable=art.builder_reusable,
+        builder_name=art.builder_name,
         keep_images=bool(args.keep),
     )
     removed_objects = (
@@ -3856,6 +3897,16 @@ def _worker_command(args) -> list[str]:
         command.extend(("--benchmark", args.benchmark))
     if getattr(args, "batch_id", None):
         command.extend(("--batch-id", args.batch_id))
+    build_timeout = getattr(
+        args, "_environment_build_timeout_multiplier", None,
+    )
+    if build_timeout is not None:
+        command.extend((
+            "--environment-build-timeout-multiplier", f"{build_timeout:g}",
+        ))
+    build_cache_mode = getattr(args, "_build_cache_mode", None)
+    if build_cache_mode:
+        command.extend(("--build-cache-mode", build_cache_mode))
     if getattr(args, "credentials_file", None):
         command.extend(("--credentials-file", args.credentials_file))
     if getattr(args, "refill", False):

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -3336,11 +3336,15 @@ def cmd_cleanup(args) -> int:
     lease list, a local job may be a finished trial that crashed immediately
     before its upload ledger was recorded.
     """
+    shared_cache_requested = bool(getattr(args, "shared_build_cache", False))
     docker_requested = bool(
         getattr(args, "docker", False) or getattr(args, "all_task_images", False)
     )
     if getattr(args, "all_task_images", False) and not getattr(args, "docker", False):
         print("--all-task-images requires --docker")
+        return 1
+    if shared_cache_requested and not getattr(args, "docker", False):
+        print("--shared-build-cache requires --docker")
         return 1
     cfg = _load_config()
     client = _client(cfg)
@@ -3419,13 +3423,40 @@ def cmd_cleanup(args) -> int:
             print(f"  protected {image_plan.protected} image tag(s) used by a "
                   "container, active/pending task, or kept job")
 
+    shared_cache_limit = image_cache.effective_policy(HOME, cfg).limit_bytes
+    if shared_cache_requested:
+        shared_name = image_cache.shared_builder_name(HOME)
+        print("Shared BuildKit cache:")
+        if args.dry_run:
+            print(
+                f"  would prune builder {shared_name} to "
+                f"{_format_size(shared_cache_limit)} maximum"
+            )
+        elif active_ids:
+            print(
+                f"  protected while {len(active_ids)} active/resumable assignment(s) "
+                "exist; no shared cache was pruned"
+            )
+        else:
+            print(
+                f"  ready to prune builder {shared_name} to "
+                f"{_format_size(shared_cache_limit)} maximum"
+            )
+
     has_images = bool(
         image_plan and image_plan.docker_available and image_plan.candidates
     )
-    if (not candidates and not has_images) or args.dry_run:
+    if (not candidates and not has_images and not shared_cache_requested) or args.dry_run:
         return 1 if docker_requested and image_plan and not image_plan.docker_available else 0
     if not args.yes:
-        subject = "settled local files and Docker task images" if has_images else "settled local task files"
+        subjects = []
+        if candidates:
+            subjects.append("settled local files")
+        if has_images:
+            subjects.append("Docker task images")
+        if shared_cache_requested:
+            subjects.append("the DRadar shared BuildKit cache")
+        subject = " and ".join(subjects)
         answer = input(f"remove these {subject}? [Y/n] ").strip().lower()
         if answer not in ("", "y", "yes"):
             print("nothing was deleted")
@@ -3442,7 +3473,16 @@ def cmd_cleanup(args) -> int:
         if removed != len(image_plan.candidates):
             image_failed = True
             print("some images changed or became active during cleanup and were safely skipped")
-    return 1 if image_failed else 0
+    shared_failed = False
+    if shared_cache_requested and not active_ids:
+        shared_ok, shared_note = image_cache.prune_shared_build_cache(
+            HOME, max_used_bytes=shared_cache_limit,
+        )
+        print(f"  {shared_note or 'shared BuildKit cache cleanup finished'}")
+        shared_failed = not shared_ok
+    elif shared_cache_requested:
+        shared_failed = True
+    return 1 if image_failed or shared_failed else 0
 
 
 def _maintain_image_cache(client: ApiClient, cfg: dict, *, phase: str) -> bool:

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -97,14 +97,17 @@ from .providers import (
     deepseek_catalog_error,
     deepseek_catalog_path,
     grok_cli_path,
+    grok_live_error,
     grok_subscription_session,
     kimi_auth_path,
     kimi_cli_path,
     kimi_home,
+    kimi_live_error,
     kimi_subscription_session,
     parse_kimi_cli_version,
     parse_grok_cli_version,
     parse_zcode_cli_version,
+    prepare_antigravity_auth,
     zcode_cli_error,
     zcode_cli_path,
     zcode_cli_version_is_compatible,
@@ -216,6 +219,10 @@ CODEBUDDY_AGENT_IMPORT_PATH = (
 )
 CODEBUDDY_AGENT_MODULE_FILENAME = "_dradar_pier_codebuddy.py"
 BETA_SUBSCRIPTION_TRIAL_TIMEOUT_FLOOR_SEC = 120 * 60
+DEFAULT_ENVIRONMENT_BUILD_TIMEOUT_MULTIPLIER = 2.0
+DEFAULT_ENVIRONMENT_BUILD_TIMEOUT_SEC = 600.0
+PIER_ENVIRONMENT_START_ATTEMPTS = 2
+ENVIRONMENT_BUILD_WATCHDOG_SLACK_SEC = 120
 BETA_SUBSCRIPTION_AGENTS = frozenset({
     CLAUDE_AGENT, GROK_AGENT, KIMI_AGENT, ZCODE_AGENT, ANTIGRAVITY_AGENT,
     CODEBUDDY_AGENT,
@@ -334,6 +341,8 @@ class TrialArtifacts:
     # always sets this explicitly from prepare_trial_builder.
     builder_isolated: bool = True
     builder_note: str | None = None
+    builder_reusable: bool = False
+    builder_name: str | None = None
 
 
 class RunnerError(RuntimeError):
@@ -1065,6 +1074,57 @@ def _task_agent_timeout_sec(task_path: Path) -> float | None:
     return data.get("agent", {}).get("timeout_sec")
 
 
+def _task_environment_build_timeout_sec(task_path: Path) -> float | None:
+    """Read the task's declared Pier environment build timeout.
+
+    This value is used only to size DRadar's outer watchdog when the longer
+    build profile is enabled.  Pier remains the source of truth for the actual
+    environment timeout; malformed task metadata never weakens the historical
+    watchdog.
+    """
+
+    try:
+        with (task_path / "task.toml").open("rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    value = data.get("environment", {}).get("build_timeout_sec")
+    if (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+        and float(value) > 0
+    ):
+        return float(value)
+    return None
+
+
+def resolve_environment_build_timeout_multiplier(value: object = None) -> float:
+    """Return a bounded environment-build timeout multiplier.
+
+    A default of two gives slow mirrors and cold builders another window while
+    keeping the upper bound finite. Passing ``1`` explicitly restores the
+    previous behavior; values above eight are refused so a wedged daemon
+    cannot keep a paid lease alive indefinitely.
+    """
+
+    if value is None:
+        return DEFAULT_ENVIRONMENT_BUILD_TIMEOUT_MULTIPLIER
+    try:
+        multiplier = float(value)
+    except (TypeError, ValueError) as exc:
+        raise RunnerError(
+            "environment build timeout multiplier must be a finite number "
+            "between 1 and 8"
+        ) from exc
+    if not math.isfinite(multiplier) or not 1.0 <= multiplier <= 8.0:
+        raise RunnerError(
+            "environment build timeout multiplier must be a finite number "
+            "between 1 and 8"
+        )
+    return multiplier
+
+
 def pompeii_agent_timeout_sec(assignment: dict) -> int:
     """Return the hard agent budget for one Pompeii assignment."""
     if assignment.get("agent") == KIMI_AGENT:
@@ -1116,6 +1176,9 @@ def build_pier_command(
     dev_agent: str | None = None,
     provider_auth_path: Path | None = None,
     provider_cli_path: Path | None = None,
+    environment_build_timeout_multiplier: float | None = (
+        DEFAULT_ENVIRONMENT_BUILD_TIMEOUT_MULTIPLIER
+    ),
 ) -> list[str]:
     task_path = tasks_root / assignment["task_id"]
     if not task_path.is_dir():
@@ -1233,6 +1296,15 @@ def build_pier_command(
     multiplier = _agent_timeout_multiplier(assignment, task_path)
     if not math.isclose(multiplier, 1.0):
         cmd += ["--agent-timeout-multiplier", f"{multiplier:.6f}"]
+    if environment_build_timeout_multiplier is not None:
+        build_multiplier = resolve_environment_build_timeout_multiplier(
+            environment_build_timeout_multiplier,
+        )
+        if not math.isclose(build_multiplier, 1.0):
+            cmd += [
+                "--environment-build-timeout-multiplier",
+                f"{build_multiplier:.6f}",
+            ]
     # Task containers ship no git identity, so an agent's final `git commit`
     # dies with "Author identity unknown" unless the model thinks to configure
     # one (volunteer report, 2026-07-13). These ride pier's --ae into the
@@ -1540,6 +1612,37 @@ def _validated_zcode_cli_path(*, model: str | None = None) -> tuple[Path, str]:
     ):
         raise RunnerError("could not determine a compatible ZCode CLI version")
     return cli, version
+
+
+def _preflight_subscription_before_build(
+    agent: str,
+    *,
+    grok_cli: Path | None = None,
+    kimi_cli: Path | None = None,
+) -> None:
+    """Run a bounded, no-prompt provider check before any Docker build.
+
+    Subscription OAuth failures are account/setup failures, not environment
+    failures.  Running the provider's existing live check first prevents a
+    worker from spending tens of minutes pulling/building an image only to
+    discover an invalid refresh grant.  The helpers use their normal
+    account-scoped locks and redacted diagnostics; no prompt/model turn is
+    started here.
+    """
+
+    issue: str | None = None
+    if agent == GROK_AGENT:
+        if grok_cli is None:
+            raise RunnerError("Grok CLI was not prepared for provider preflight")
+        issue = grok_live_error(grok_cli)
+    elif agent == KIMI_AGENT:
+        if kimi_cli is None:
+            raise RunnerError("Kimi CLI was not prepared for provider preflight")
+        issue = kimi_live_error(kimi_cli)
+    if issue is not None:
+        raise RunnerError(
+            f"{agent} provider preflight failed before Docker build: {issue}"
+        )
 
 
 def locate_artifacts(jobs_dir: Path, job_name: str) -> tuple[Path, Path]:
@@ -2773,6 +2876,39 @@ def _effective_trial_timeout_sec(assignment: dict) -> int:
     return _trial_timeout_sec(assignment)
 
 
+def _effective_run_timeout_sec(
+    assignment: dict,
+    task_path: Path,
+    environment_build_timeout_multiplier: float,
+) -> int:
+    """Include the bounded two-attempt build allowance in DRadar's watchdog.
+
+    Pier retries ``EnvironmentStartTimeoutError`` once.  The old outer
+    watchdog started before image setup and could therefore kill a run while
+    Pier was still within its enlarged build window.  Account for both build
+    attempts, then retain the task/agent budget as the minimum.  For Pompeii
+    the model's hard deadline and the setup allowance are additive: a full
+    build must not steal the agent's promised execution time.
+    """
+
+    base = _task_environment_build_timeout_sec(task_path)
+    if base is None:
+        base = DEFAULT_ENVIRONMENT_BUILD_TIMEOUT_SEC
+    build_allowance = int(math.ceil(
+        base * environment_build_timeout_multiplier
+        * PIER_ENVIRONMENT_START_ATTEMPTS
+    )) + ENVIRONMENT_BUILD_WATCHDOG_SLACK_SEC
+    current = _effective_trial_timeout_sec(assignment)
+    # Test/integration adapters may deliberately return a non-positive
+    # watchdog to force the first heartbeat path.  Preserve that explicit
+    # override rather than replacing it with the normal build allowance.
+    if current <= 0:
+        return current
+    if assignment.get("benchmark_id") == POMPEII_BENCHMARK_ID:
+        return current + build_allowance
+    return max(current, build_allowance)
+
+
 def _zcode_runtime_diagnostic(jobs_dir: Path, job_name: str) -> dict[str, object]:
     """Read the adapter's allowlisted lifecycle snapshot, never its raw logs."""
     try:
@@ -3513,6 +3649,8 @@ def run_trial(
     work_dir: Path,
     dev_agent: str | None = None,
     on_started: Callable[[], None] | None = None,
+    environment_build_timeout_multiplier: float | None = None,
+    build_cache_mode: str = image_cache.DEFAULT_BUILD_CACHE_MODE,
 ) -> TrialArtifacts:
     effective_assignment = assignment
     codex_cli_version = None
@@ -3524,6 +3662,10 @@ def run_trial(
     codebuddy_cli_version = None
     codex_provider = None
     effective_agent = dev_agent or assignment["agent"]
+    environment_build_timeout_multiplier = resolve_environment_build_timeout_multiplier(
+        environment_build_timeout_multiplier,
+    )
+    build_cache_mode = image_cache.normalize_build_cache_mode(build_cache_mode)
     if effective_agent == "codex":
         codex_provider = (
             assignment_codex_provider(assignment) or DEFAULT_CODEX_PROVIDER
@@ -3623,6 +3765,32 @@ def run_trial(
         print(f"verified pinned CodeBuddy CLI: {codebuddy_cli_version}")
 
     work_dir.mkdir(parents=True, exist_ok=True)
+    provider_auth_path = None
+    provider_cli_path = None
+    provider_stack = ExitStack()
+    # Resolve subscription credentials before touching Docker.  A rejected
+    # OAuth grant is an account problem and must not consume a full image
+    # build window before it becomes visible to the worker.
+    if effective_agent == GROK_AGENT:
+        provider_cli_path = _validated_grok_cli_path()
+        _preflight_subscription_before_build(
+            effective_agent, grok_cli=provider_cli_path,
+        )
+        print("Grok provider preflight passed before Docker build")
+    elif effective_agent == KIMI_AGENT:
+        provider_cli_path = _validated_kimi_cli_path()
+        _preflight_subscription_before_build(
+            effective_agent, kimi_cli=provider_cli_path,
+        )
+        print("Kimi provider preflight passed before Docker build")
+    elif effective_agent == ANTIGRAVITY_AGENT:
+        issue = prepare_antigravity_auth()
+        if issue is not None:
+            raise RunnerError(
+                "antigravity provider preflight failed before Docker build: "
+                + issue
+            )
+        print("Antigravity provider preflight passed before Docker build")
     try:
         egress_environment = egress.prepare_egress_proxy_runtime(announce=True)
     except egress.EgressProxyError as exc:
@@ -3635,9 +3803,13 @@ def run_trial(
         work_dir.parent,
         assignment_id=str(assignment["assignment_id"]),
         runtime=egress_environment,
+        mode=build_cache_mode,
     )
     if builder_lease.isolated:
-        print("已为本题准备独立的临时运行环境")
+        if builder_lease.reusable:
+            print("已为本题准备共享的 DRadar BuildKit 缓存")
+        else:
+            print("已为本题准备独立的临时运行环境")
     else:
         print(
             "提示：本题可以继续运行，但临时环境暂时无法安全隔离；"
@@ -3654,7 +3826,11 @@ def run_trial(
     # A mid-task rate-limit death just ends the run (no sleep-and-resume) --
     # it surfaces as a nonzero pier rc, which _run_and_submit reports as
     # `interrupted` -> the server marks it invalid and the cell reopens.
-    timeout_sec = _effective_trial_timeout_sec(effective_assignment)
+    timeout_sec = _effective_run_timeout_sec(
+        effective_assignment,
+        tasks_root / str(effective_assignment["task_id"]),
+        environment_build_timeout_multiplier,
+    )
     terminal_error: RunnerError | None = None
     live_error_offsets: dict[Path, int] = {}
     live_error_counts: dict[str, int] = {}
@@ -3665,9 +3841,6 @@ def run_trial(
         )
     )
 
-    provider_auth_path = None
-    provider_cli_path = None
-    provider_stack = ExitStack()
     try:
         if codex_provider == DEEPSEEK_PROVIDER:
             try:
@@ -3688,7 +3861,7 @@ def run_trial(
                 raise RunnerError(str(exc)) from exc
         elif effective_agent == GROK_AGENT:
             try:
-                provider_cli_path = _validated_grok_cli_path()
+                provider_cli_path = provider_cli_path or _validated_grok_cli_path()
                 provider_auth_path = provider_stack.enter_context(
                     grok_subscription_session(work_dir)
                 )
@@ -3696,7 +3869,7 @@ def run_trial(
                 raise RunnerError(str(exc)) from exc
         elif effective_agent == KIMI_AGENT:
             try:
-                provider_cli_path = _validated_kimi_cli_path()
+                provider_cli_path = provider_cli_path or _validated_kimi_cli_path()
                 provider_auth_path = provider_stack.enter_context(
                     kimi_subscription_session(work_dir)
                 )
@@ -3782,9 +3955,21 @@ def run_trial(
                     job_name,
                 )
             )
+        build_options = dict(provider_kwargs)
+        # Keep the default path compatible with small embedders/test doubles
+        # that still implement the historical positional builder signature;
+        # build_pier_command itself carries the production default. Explicit
+        # non-default policies are forwarded so operators can tune them.
+        if not math.isclose(
+            environment_build_timeout_multiplier,
+            DEFAULT_ENVIRONMENT_BUILD_TIMEOUT_MULTIPLIER,
+        ):
+            build_options[
+                "environment_build_timeout_multiplier"
+            ] = environment_build_timeout_multiplier
         cmd = build_pier_command(
             effective_assignment, pier_tasks_root, jobs_dir, job_name, work_dir,
-            dev_agent, **provider_kwargs,
+            dev_agent, **build_options,
         )
         env = _pier_process_env(
             effective_assignment,
@@ -3819,6 +4004,20 @@ def run_trial(
         started = time.time()
         with log_path.open("w") as log:
             log.write("cmd=" + " ".join(cmd) + "\n")
+            log.write(
+                "build_cache_mode="
+                + ("shared" if builder_lease.reusable else "isolated")
+                + "\n"
+            )
+            log.write(
+                "build_cache_builder="
+                + (builder_lease.name or "default-fallback")
+                + "\n"
+            )
+            log.write(
+                "environment_build_timeout_multiplier="
+                + f"{environment_build_timeout_multiplier:g}\n"
+            )
             log.flush()
             # Heartbeat loop instead of a blocking run: image build + a long
             # agent turn can be silent for many minutes, and volunteers couldn't
@@ -4080,6 +4279,8 @@ def run_trial(
         dsh_artifact_binding=dsh_artifact_binding,
         builder_isolated=builder_lease.isolated,
         builder_note=builder_lease.note,
+        builder_reusable=builder_lease.reusable,
+        builder_name=builder_lease.name,
     )
 
 

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -2905,8 +2905,36 @@ def _effective_run_timeout_sec(
     if current <= 0:
         return current
     if assignment.get("benchmark_id") == POMPEII_BENCHMARK_ID:
-        return current + build_allowance
-    return max(current, build_allowance)
+        # ``current`` already includes Pompeii's hard agent deadline plus its
+        # finalization slack.  Keep that complete budget, then add the build
+        # allowance before the outer watchdog is armed.
+        agent_budget = current
+    else:
+        # For ordinary tasks Pier's inner watchdog is the task timeout scaled
+        # by _agent_timeout_multiplier.  The old outer watchdog may be either
+        # below that declared timeout (short server estimate) or above it
+        # (long estimate), so account for the actual inner budget rather than
+        # merely taking max(current, build_allowance).
+        declared = _task_agent_timeout_sec(task_path)
+        if (
+            isinstance(declared, (int, float))
+            and not isinstance(declared, bool)
+            and math.isfinite(float(declared))
+            and float(declared) > 0
+        ):
+            multiplier = _agent_timeout_multiplier(assignment, task_path)
+            agent_budget = max(
+                float(current),
+                math.ceil(float(declared) * multiplier),
+            )
+        else:
+            # If task metadata cannot prove an inner budget, retain the old
+            # outer watchdog as the conservative model-time allowance.
+            agent_budget = float(current)
+    return max(
+        current,
+        int(math.ceil(agent_budget + build_allowance)),
+    )
 
 
 def _zcode_runtime_diagnostic(jobs_dir: Path, job_name: str) -> dict[str, object]:

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -128,12 +128,40 @@ def test_shared_trial_builder_is_bootstrapped_and_reusable(
 
     assert lease.isolated and lease.reusable
     assert lease.name == image_cache.shared_builder_name(tmp_path)
+    # Fleet gives harnesses separate DRADAR_HOME paths, but the shared cache
+    # intentionally crosses those paths within one OS user's Docker context.
+    assert image_cache.shared_builder_name(tmp_path / "other-harness") == lease.name
     assert calls[-1] == ["buildx", "inspect", lease.name, "--bootstrap"]
     assert image_cache.remove_trial_builder(
         tmp_path, "a1", mode="shared",
     ) == (True, None)
     # Shared cleanup must not remove the persistent BuildKit cache.
     assert calls[-1] == ["buildx", "inspect", lease.name, "--bootstrap"]
+
+
+def test_shared_build_cache_prune_targets_only_dradar_builder(
+    tmp_path: Path, monkeypatch,
+):
+    calls = []
+
+    def run(command, **_kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, "reclaimed 2GB", "")
+
+    monkeypatch.setattr(image_cache, "_run_docker", run)
+    ok, note = image_cache.prune_shared_build_cache(
+        tmp_path, max_used_bytes=50 * image_cache.GIB,
+    )
+
+    name = image_cache.shared_builder_name(tmp_path)
+    assert ok and "2GB" in note
+    assert calls == [
+        ["buildx", "inspect", name],
+        [
+            "buildx", "prune", "--builder", name, "--force", "--all",
+            "--max-used-space", str(50 * image_cache.GIB),
+        ],
+    ]
 
 
 def test_trial_builder_falls_back_without_exposing_loopback_proxy(
@@ -595,6 +623,33 @@ def test_cleanup_docker_dry_run_never_removes_images(tmp_path: Path, monkeypatch
     assert runloop.cmd_cleanup(args) == 0
     out = capsys.readouterr().out
     assert MAIN_REF in out and "would remove" in out
+
+
+def test_shared_build_cache_cleanup_dry_run_is_non_destructive(
+    tmp_path: Path, monkeypatch, capsys,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    monkeypatch.setattr(runloop, "_load_config", lambda: {})
+    monkeypatch.setattr(runloop, "_client", lambda _cfg: object())
+    monkeypatch.setattr(runloop, "_active_by_id", lambda _client: {})
+    monkeypatch.setattr(
+        image_cache, "plan_cleanup",
+        lambda *_a, **_k: image_cache.CleanupPlan([], set(), 0, 0, 0),
+    )
+    monkeypatch.setattr(
+        image_cache, "prune_shared_build_cache",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("dry-run must not prune shared cache")
+        ),
+    )
+
+    args = argparse.Namespace(
+        dry_run=True, include_kept=False, docker=True,
+        all_task_images=False, shared_build_cache=True, yes=True,
+    )
+    assert runloop.cmd_cleanup(args) == 0
+    out = capsys.readouterr().out
+    assert "Shared BuildKit cache" in out and "would prune builder" in out
 
 
 def test_cleanup_requires_explicit_docker_flag_for_legacy_sweep(tmp_path: Path, monkeypatch):

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -110,6 +110,32 @@ def test_trial_builder_is_assignment_scoped_and_never_selected_globally(
     assert "--use" not in calls[-1]
 
 
+def test_shared_trial_builder_is_bootstrapped_and_reusable(
+    tmp_path: Path, monkeypatch,
+):
+    calls = []
+
+    def run(command, **_kwargs):
+        calls.append(command)
+        if command[:2] == ["buildx", "inspect"] and "--bootstrap" not in command:
+            return subprocess.CompletedProcess(command, 1, "", "not found")
+        return subprocess.CompletedProcess(command, 0, "ok", "")
+
+    monkeypatch.setattr(image_cache, "_run_docker", run)
+    lease = image_cache.prepare_trial_builder(
+        tmp_path, assignment_id="a1", runtime={}, mode="shared",
+    )
+
+    assert lease.isolated and lease.reusable
+    assert lease.name == image_cache.shared_builder_name(tmp_path)
+    assert calls[-1] == ["buildx", "inspect", lease.name, "--bootstrap"]
+    assert image_cache.remove_trial_builder(
+        tmp_path, "a1", mode="shared",
+    ) == (True, None)
+    # Shared cleanup must not remove the persistent BuildKit cache.
+    assert calls[-1] == ["buildx", "inspect", lease.name, "--bootstrap"]
+
+
 def test_trial_builder_falls_back_without_exposing_loopback_proxy(
     tmp_path: Path, monkeypatch,
 ):

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -368,6 +368,40 @@ def test_build_pier_command_stretches_90_minute_pompeii_pack(tmp_path, monkeypat
     assert cmd[index + 1] == "1.333333"
 
 
+def test_build_pier_command_passes_environment_build_timeout_multiplier(
+    tmp_path, monkeypatch,
+):
+    _stub_pier(monkeypatch)
+    _task_with_toml(
+        tmp_path, task_id="abs-module-cache-flags", timeout_sec=5400.0,
+    )
+    auth = _claude_auth(tmp_path)
+    cmd = build_pier_command(
+        _claude_assignment(), tmp_path, tmp_path / "jobs", "j", tmp_path / "home",
+        provider_auth_path=auth,
+        environment_build_timeout_multiplier=2,
+    )
+    index = cmd.index("--environment-build-timeout-multiplier")
+    assert cmd[index + 1] == "2.000000"
+
+
+def test_effective_run_timeout_adds_two_attempt_build_allowance(tmp_path):
+    task = _task_with_toml(
+        tmp_path, task_id="build-timeout", timeout_sec=5400.0,
+    )
+    (task / "task.toml").write_text(
+        "[agent]\ntimeout_sec = 5400.0\n"
+        "[environment]\nbuild_timeout_sec = 5400.0\n",
+    )
+    assignment = {"agent": "codex", "est_minutes": 5}
+    expected = max(
+        runner_mod._effective_trial_timeout_sec(assignment),
+        5400 * 2 * runner_mod.PIER_ENVIRONMENT_START_ATTEMPTS
+        + runner_mod.ENVIRONMENT_BUILD_WATCHDOG_SLACK_SEC,
+    )
+    assert runner_mod._effective_run_timeout_sec(assignment, task, 2) == expected
+
+
 
 # --- self-bootstrap (ensure_pier / ensure_tasks_root) ------------------------
 import subprocess
@@ -1152,6 +1186,10 @@ def _prepare_fake_antigravity(monkeypatch, tmp_path):
     monkeypatch.setattr(
         runner_mod, "_antigravity_tasks_overlay", passthrough_overlay,
     )
+    # The runner now performs the same structural OAuth preflight that the
+    # real provider session performs.  These tests exercise process/artifact
+    # cleanup, so make the provider credential check an explicit no-op.
+    monkeypatch.setattr(runner_mod, "prepare_antigravity_auth", lambda: None)
 
 
 def test_antigravity_rc0_reaps_live_exact_job_runtime_and_keeps_patch(

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -1,4 +1,5 @@
 import os
+import math
 import tomllib
 
 import dradar.runner as runner_mod
@@ -394,12 +395,36 @@ def test_effective_run_timeout_adds_two_attempt_build_allowance(tmp_path):
         "[environment]\nbuild_timeout_sec = 5400.0\n",
     )
     assignment = {"agent": "codex", "est_minutes": 5}
-    expected = max(
-        runner_mod._effective_trial_timeout_sec(assignment),
-        5400 * 2 * runner_mod.PIER_ENVIRONMENT_START_ATTEMPTS
-        + runner_mod.ENVIRONMENT_BUILD_WATCHDOG_SLACK_SEC,
+    expected = (
+        5400
+        + 5400 * 2 * runner_mod.PIER_ENVIRONMENT_START_ATTEMPTS
+        + runner_mod.ENVIRONMENT_BUILD_WATCHDOG_SLACK_SEC
     )
     assert runner_mod._effective_run_timeout_sec(assignment, task, 2) == expected
+
+
+def test_effective_run_timeout_preserves_scaled_inner_agent_budget(tmp_path):
+    task = _task_with_toml(
+        tmp_path, task_id="build-timeout-scaled", timeout_sec=5400.0,
+    )
+    (task / "task.toml").write_text(
+        "[agent]\ntimeout_sec = 5400.0\n"
+        "[environment]\nbuild_timeout_sec = 600.0\n",
+    )
+    assignment = {"agent": "codex", "est_minutes": 40}
+    current = runner_mod._effective_trial_timeout_sec(assignment)
+    inner = int(
+        math.ceil(
+            5400.0 * runner_mod._agent_timeout_multiplier(assignment, task)
+        )
+    )
+    allowance = (
+        600 * 2 * runner_mod.PIER_ENVIRONMENT_START_ATTEMPTS
+        + runner_mod.ENVIRONMENT_BUILD_WATCHDOG_SLACK_SEC
+    )
+    assert runner_mod._effective_run_timeout_sec(assignment, task, 2) == max(
+        current, inner + allowance,
+    )
 
 
 


### PR DESCRIPTION
## 变更
- 为 Pier 环境构建增加可配置的 1–8 倍超时倍率（默认 2），并让 DRadar 外层 watchdog 覆盖 Pier 的两次环境启动尝试。
- 在 Docker 构建前执行 Grok/Kimi 订阅预检与 Antigravity 结构预检，避免 OAuth 失败先消耗长时间构建窗口。
- 增加同一 DRadar 用户范围内的共享 BuildKit builder（显式配置 `build-cache-mode shared`），复用不可变基础/依赖层；任务运行时资源仍精确清理，凭据不进入缓存。
- 共享 builder 的并发创建有界重试，运行日志记录缓存模式、builder 和超时倍率；默认仍保持 assignment-scoped 隔离，可按机器逐步启用。
- 更新 CLI/README 与回归测试。

## 验证
- `python -m py_compile src/dradar/runner.py src/dradar/runloop.py src/dradar/image_cache.py src/dradar/cli.py`
- `pytest -q`（1353 passed, 2 skipped）
- `git diff --check`

## 发布交接
请雷达任务调度器先审查超时边界、共享 BuildKit 缓存隔离和预检顺序；审核通过后由唯一发布角色发布。发布后请雷达哨兵只读验证正式环境的构建超时、并发构建缓存复用和 OAuth 预检日志。当前 ds0 运行批次未被本 PR 改动。