### PR TITLE
优化并发环境准备、超时与共享构建缓存

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,8 +574,8 @@ dradar resume --assignment <ASSIGNMENT_ID>
 | `--allow-task-drift` | 显式允许本地 benchmark 版本或任务内容与服务端不一致；这类运行不可可靠比较，默认会在消耗模型额度前停止 |
 | `--workers N` | 由一个父进程管理 N 个并发 worker，范围 1–40，默认 1 |
 | `--workers auto` | 检测 Docker、磁盘和账号限制后选择保守并发数 |
-| `--environment-build-timeout-multiplier N` | 将 Pier 的环境构建超时乘以 N，范围 1–8，默认 2 |
-| `--build-cache-mode {isolated,shared}` | 本次运行覆盖构建缓存策略；默认读取 `dradar config`，未配置时为 `isolated` |
+| `--environment-build-timeout-multiplier N` | 将 Pier 的环境构建超时乘以 N，范围 1–8，默认 3 |
+| `--build-cache-mode {isolated,shared}` | 本次运行覆盖构建缓存策略；默认读取 `dradar config`；未配置时单 worker 为 `isolated`，多 worker 自动为 `shared` |
 | `--parallel` | 高级选项：允许手工启动另一个独立 DRadar 会话；隐含 `-y` |
 | `--refill` | 显式开启持续自动补题；必须同时给出额度或题数硬上限 |
 | `--refill-to N` | 持有/运行队列目标；传入时自动启用 `--refill`，但仍需硬上限 |
@@ -793,13 +793,14 @@ dradar cleanup --docker --shared-build-cache -y
 上传失败只保留 Docker 外部的待补传结果，不需要保留整套题目环境。`--keep` 可以保留
 本地诊断文件和题目镜像，但仍会停止容器并删除临时构建空间。
 
-默认每道题使用独立、一次性的 Docker 构建空间，题目结束时直接删除该构建空间，因此
-不会清理或占用用户其他项目的 BuildKit 缓存。需要多 worker 并发、且希望复用相同基础层
-时，可以显式启用同一操作系统用户范围内的共享 BuildKit 缓存：
+默认每道题使用独立、一次性的 Docker 构建空间，单 worker 题目结束时直接删除该构建空间，
+因此不会清理或占用用户其他项目的 BuildKit 缓存。多 worker 并发时，如果没有显式配置，CLI
+会自动启用同一操作系统用户范围内的共享 BuildKit 缓存，以便公共基础镜像和依赖层只下载/构建
+一次；也可以显式指定策略：
 
 ```bash
 dradar config set build-cache-mode shared
-dradar config set environment-build-timeout-multiplier 2
+dradar config set environment-build-timeout-multiplier 3
 dradar config show
 ```
 
@@ -811,7 +812,9 @@ dradar config show
 `docker system prune`、`docker image prune` 或默认 builder 的全局缓存清理。任何一步无法
 确认时，本题结果仍会保存，但该 worker 会停止继续领取或运行下一题，并显示可操作的原因。
 
-共享 builder 不会在每道题结束时删除，否则无法复用公共层；使用
+共享 builder 在首次使用时只做一次受锁保护的 BuildKit bootstrap，并在就绪戳有效时复用，
+避免八个 worker 重复拉起构建守护进程；Docker 守护进程重启、builder 被删除或就绪戳过期后会
+自动重新预热。共享 builder 不会在每道题结束时删除，否则无法复用公共层；使用
 `cleanup --docker --shared-build-cache` 可按当前 image-cache 上限显式回收它。`--dry-run`
 只展示目标 builder 和上限，`-y` 才执行 BuildKit GC；只要服务端仍有活动或可恢复租约，
 命令会保护并跳过共享缓存，避免打断在途构建。该选项只命中当前操作系统用户的

--- a/src/dradar/cli.py
+++ b/src/dradar/cli.py
@@ -509,14 +509,15 @@ def main(argv: list[str] | None = None) -> int:
             default=None,
             metavar="N",
             help="multiply each task's Docker environment build timeout "
-                 "(default: 2; allowed range 1..8)",
+                 "(default: 3; allowed range 1..8)",
         )
         p.add_argument(
             "--build-cache-mode",
             choices=("isolated", "shared"),
             default=None,
             help="use an assignment-only BuildKit cache or an OS-user-scoped "
-                 "shared immutable cache (default: saved setting, isolated)",
+                 "shared immutable cache (default: shared for multi-worker "
+                 "runs, isolated for one worker unless configured)",
         )
         p.add_argument(
             "--batch-id", type=_batch_id_value, metavar="UUID",

--- a/src/dradar/image_cache.py
+++ b/src/dradar/image_cache.py
@@ -19,6 +19,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import time
 import urllib.parse
 from contextlib import contextmanager
@@ -34,6 +35,14 @@ LOCK_NAME = "image-cache.lock"
 MAINTENANCE_STAMP_NAME = "image-cache-maintenance.stamp"
 BUILDER_PREFIX = "dradar-task-"
 SHARED_BUILDER_PREFIX = "dradar-cache-"
+SHARED_BUILDER_LOCK_NAME = "shared-build-cache.lock"
+SHARED_BUILDER_READY_STAMP_NAME = "shared-build-cache.ready.json"
+SHARED_BUILDER_READY_STAMP_VERSION = 1
+# A fresh stamp avoids repeating the expensive BuildKit daemon/bootstrap work
+# for every harness, but it is deliberately finite so a daemon restart or a
+# manually removed builder is revalidated and warmed again.
+SHARED_BUILDER_READY_MAX_AGE_SEC = 6 * 60 * 60
+SHARED_BUILDER_STATE_DIR_ENV = "DRADAR_SHARED_BUILDER_STATE_DIR"
 BUILD_CACHE_MODES = frozenset({"isolated", "shared"})
 DEFAULT_BUILD_CACHE_MODE = "isolated"
 GIB = 1024 ** 3
@@ -248,6 +257,200 @@ def configured_build_cache_mode(cfg: dict | None) -> str:
     )
 
 
+def _shared_builder_state_dir() -> Path:
+    """Return the host-user state directory for the persistent builder.
+
+    Fleet workers intentionally use different ``DRADAR_HOME`` directories,
+    so this state must live outside those per-harness homes.  The optional
+    environment override exists for tests and for an explicitly managed
+    alternate local state root; it never carries credentials.
+    """
+
+    raw = os.environ.get(SHARED_BUILDER_STATE_DIR_ENV)
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".dradar" / "build-cache"
+
+
+def _shared_builder_ready_path() -> Path:
+    return _shared_builder_state_dir() / SHARED_BUILDER_READY_STAMP_NAME
+
+
+def _shared_builder_is_ready(name: str, *, now: float | None = None) -> bool:
+    """Whether the bounded, non-sensitive bootstrap stamp is still fresh."""
+
+    try:
+        payload = json.loads(_shared_builder_ready_path().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema_version") != SHARED_BUILDER_READY_STAMP_VERSION
+        or payload.get("builder") != name
+    ):
+        return False
+    try:
+        bootstrapped_at = float(payload["bootstrapped_at"])
+    except (KeyError, TypeError, ValueError):
+        return False
+    current = time.time() if now is None else float(now)
+    age = current - bootstrapped_at
+    return 0 <= age <= SHARED_BUILDER_READY_MAX_AGE_SEC
+
+
+def _mark_shared_builder_ready(name: str) -> None:
+    """Atomically write a tiny readiness stamp without any secret material."""
+
+    state_dir = _shared_builder_state_dir()
+    state_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path = _shared_builder_ready_path()
+    temporary = path.with_name(
+        f".{path.name}.{os.getpid()}.{time.time_ns()}"
+    )
+    fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(
+                {
+                    "schema_version": SHARED_BUILDER_READY_STAMP_VERSION,
+                    "builder": name,
+                    "bootstrapped_at": time.time(),
+                },
+                stream,
+            )
+            stream.write("\n")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _buildx_inspect_is_usable(result: subprocess.CompletedProcess) -> bool:
+    """Treat an explicit non-running BuildKit status as needing bootstrap."""
+
+    output = "\n".join((result.stdout or "", result.stderr or "")).lower()
+    if "status:" not in output:
+        # Older Docker/buildx versions and test doubles omit the status line;
+        # a successful inspect is the best evidence available there.
+        return True
+    return bool(re.search(r"status:\s*running\b", output))
+
+
+@contextmanager
+def _shared_builder_lock() -> Iterator[None]:
+    """Serialize shared-builder creation/bootstrap across all harness homes."""
+
+    state_dir = _shared_builder_state_dir()
+    state_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path = state_dir / SHARED_BUILDER_LOCK_NAME
+    fh = open(path, "a+b")
+    try:
+        if os.name == "nt":
+            import msvcrt
+            fh.seek(0, os.SEEK_END)
+            if fh.tell() == 0:
+                fh.write(b"\0")
+                fh.flush()
+            fh.seek(0)
+            msvcrt.locking(fh.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            if os.name == "nt":
+                import msvcrt
+                fh.seek(0)
+                msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        finally:
+            fh.close()
+
+
+def _ensure_named_builder(name: str, *, reusable: bool) -> str | None:
+    """Create/refresh one builder and return a bounded failure reason."""
+
+    existing = _run_docker(
+        ["buildx", "inspect", name], timeout=30, allow_fail=True,
+    )
+    if existing.returncode == 0:
+        # Assignment builders are disposable residue from a crashed attempt;
+        # the shared builder is retained so its content-addressed cache
+        # survives between tasks.
+        if not reusable:
+            _run_docker(["buildx", "rm", name], timeout=180)
+            existing = subprocess.CompletedProcess(["buildx", "inspect", name], 1)
+        elif _shared_builder_is_ready(name) and _buildx_inspect_is_usable(existing):
+            return None
+
+    if existing.returncode != 0:
+        created = _run_docker([
+            "buildx", "create", "--name", name,
+            "--driver", "docker-container",
+        ], timeout=120, allow_fail=True)
+        if created.returncode != 0:
+            # This is normally a harmless create race.  The shared lock makes
+            # it rare, but the bounded inspect proves whether Docker already
+            # has the named builder before reporting a real failure.
+            if reusable:
+                raced = None
+                for _ in range(8):
+                    raced = _run_docker(
+                        ["buildx", "inspect", name],
+                        timeout=10,
+                        allow_fail=True,
+                    )
+                    if raced.returncode == 0:
+                        existing = raced
+                        break
+                    time.sleep(0.5)
+                if raced is None or raced.returncode != 0:
+                    detail = (created.stderr or created.stdout or "").strip()
+                    return (
+                        "无法创建共享构建缓存空间"
+                        + (f"：{detail[:160]}" if detail else "")
+                    )
+            else:
+                detail = (created.stderr or created.stdout or "").strip()
+                return (
+                    "无法创建隔离的临时构建空间"
+                    + (f"：{detail[:160]}" if detail else "")
+                )
+
+    if reusable:
+        # Bootstrap only when the stamp is absent/stale or the builder was
+        # recreated.  The host-user lock prevents eight workers from all
+        # downloading the same BuildKit daemon/image metadata at once.
+        if not _shared_builder_is_ready(name) or not _buildx_inspect_is_usable(
+            existing,
+        ):
+            bootstrapped = _run_docker(
+                ["buildx", "inspect", name, "--bootstrap"],
+                timeout=180,
+                allow_fail=True,
+            )
+            if bootstrapped.returncode != 0:
+                detail = (bootstrapped.stderr or bootstrapped.stdout or "").strip()
+                return (
+                    "共享构建缓存空间未能启动"
+                    + (f"：{detail[:160]}" if detail else "")
+                )
+            try:
+                _mark_shared_builder_ready(name)
+            except OSError as exc:
+                # A missing readiness stamp is safe (the next worker will
+                # bootstrap again), but never turn a successful Docker start
+                # into a false runner failure because local bookkeeping could
+                # not be written.
+                print(
+                    f"warning: shared BuildKit readiness stamp unavailable: {exc}",
+                    file=sys.stderr,
+                )
+    return None
+
+
 def _builder_proxy_is_safe(runtime: dict[str, str]) -> tuple[bool, str | None]:
     """Whether a dedicated bridge builder can use the configured build proxy.
 
@@ -299,72 +502,22 @@ def prepare_trial_builder(
             return TrialBuilderLease(
                 None, False, "Docker 的临时构建空间功能不可用",
             )
-        existing = _run_docker(
-            ["buildx", "inspect", name], timeout=30, allow_fail=True,
-        )
-        if existing.returncode == 0:
-            # The assignment lock proves this same home cannot be running the
-            # A matching assignment builder is stale residue from a crashed
-            # prior attempt and is safe to replace exactly.  The shared
-            # builder is deliberately retained so its content-addressed cache
-            # survives between tasks.
-            if not reusable:
-                _run_docker(["buildx", "rm", name], timeout=180)
-        if existing.returncode != 0:
-            created = _run_docker([
-                "buildx", "create", "--name", name,
-                "--driver", "docker-container",
-            ], timeout=120, allow_fail=True)
-            if created.returncode != 0:
-                # Two workers can race to create the same shared builder.  A
-                # short bounded inspect loop proves whether the first worker
-                # won; only a genuinely unavailable builder falls back.  This
-                # avoids turning a harmless create race into a missing lane in
-                # an eight-worker pool.
-                if reusable:
-                    raced = None
-                    for _ in range(8):
-                        raced = _run_docker(
-                            ["buildx", "inspect", name],
-                            timeout=10,
-                            allow_fail=True,
-                        )
-                        if raced.returncode == 0:
-                            break
-                        time.sleep(0.5)
-                    if raced is None or raced.returncode != 0:
-                        detail = (created.stderr or created.stdout or "").strip()
-                        return TrialBuilderLease(
-                            None, False,
-                            "无法创建共享构建缓存空间"
-                            + (f"：{detail[:160]}" if detail else ""),
-                        )
-                else:
-                    detail = (created.stderr or created.stdout or "").strip()
-                    return TrialBuilderLease(
-                        None, False,
-                        "无法创建隔离的临时构建空间"
-                        + (f"：{detail[:160]}" if detail else ""),
-                    )
         if reusable:
-            # Bootstrap once before Pier starts its full environment timeout.
-            # This moves BuildKit image download/daemon startup out of the
-            # critical task build and amortizes it across all workers.
-            bootstrapped = _run_docker(
-                ["buildx", "inspect", name, "--bootstrap"],
-                timeout=180,
-                allow_fail=True,
-            )
-            if bootstrapped.returncode != 0:
-                detail = (bootstrapped.stderr or bootstrapped.stdout or "").strip()
-                return TrialBuilderLease(
-                    None, False,
-                    "共享构建缓存空间未能启动"
-                    + (f"：{detail[:160]}" if detail else ""),
-                )
+            # All harness homes converge on this host-user lock.  This keeps
+            # builder creation/bootstrap outside the per-assignment lock but
+            # still prevents a parallel cold-start herd.
+            with _shared_builder_lock():
+                failure = _ensure_named_builder(name, reusable=True)
+        else:
+            failure = _ensure_named_builder(name, reusable=False)
+        if failure is not None:
+            return TrialBuilderLease(None, False, failure)
     except DockerUnavailable as exc:
         label = "共享构建缓存空间" if reusable else "临时构建空间"
         return TrialBuilderLease(None, False, f"{label}不可用：{exc}")
+    except OSError as exc:
+        label = "共享构建缓存空间" if reusable else "临时构建空间"
+        return TrialBuilderLease(None, False, f"{label}本地锁不可用：{exc}")
     if reusable:
         return TrialBuilderLease(
             name, True, "共享 BuildKit 缓存已预热；仅限当前 OS 用户的 Docker 环境", True,
@@ -1334,11 +1487,16 @@ def cmd_config_show(args) -> int:
     print(f"  limit: {policy.limit_bytes / GIB:.1f} GiB ({source})")
     print(f"  cleanup target: {policy.target_bytes / GIB:.1f} GiB")
     print(f"  minimum free disk: {policy.min_free_bytes / GIB:.0f} GiB")
-    print(f"  build cache mode: {configured_build_cache_mode(cfg)}")
+    configured_build_cache = cfg.get("build_cache_mode")
+    if configured_build_cache is None:
+        build_cache_display = "auto (isolated for 1 worker; shared for multi-worker)"
+    else:
+        build_cache_display = configured_build_cache_mode(cfg)
+    print(f"  build cache mode: {build_cache_display}")
     build_timeout = cfg.get("environment_build_timeout_multiplier")
     print(
         "  environment build timeout multiplier: "
-        f"{build_timeout if build_timeout is not None else '2 (default)'}"
+        f"{build_timeout if build_timeout is not None else '3 (default)'}"
     )
     print(f"  proxy environment detected: {'yes' if proxy_detected() else 'no'}")
     return 0
@@ -1404,5 +1562,6 @@ __all__ = [
     "prune_shared_build_cache",
     "trial_builder_name", "shared_builder_name", "normalize_build_cache_mode",
     "configured_build_cache_mode", "BUILD_CACHE_MODES", "DEFAULT_BUILD_CACHE_MODE",
+    "SHARED_BUILDER_READY_MAX_AGE_SEC", "SHARED_BUILDER_READY_STAMP_NAME",
     "wsl_host_disk_free_bytes", "cmd_config_set", "cmd_config_show",
 ]

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -301,11 +301,38 @@ def _run_config(args) -> dict:
         )
     except RunnerError as exc:
         sys.exit(str(exc))
-    args._build_cache_mode = image_cache.normalize_build_cache_mode(
-        getattr(args, "build_cache_mode", None)
-        or image_cache.configured_build_cache_mode(cfg)
-    )
+    args._build_cache_mode = _resolve_build_cache_mode(args, cfg)
     return cfg
+
+
+def _resolve_build_cache_mode(args, cfg: dict) -> str:
+    """Select a safe cache policy for this invocation.
+
+    Explicit CLI/config values always win.  If neither is present, a pool
+    with more than one local worker uses the host-user-scoped shared BuildKit
+    cache so immutable base/install layers are downloaded once; a single
+    worker keeps the historical assignment-isolated default.  ``auto`` is
+    resolved again after capacity inspection, because its final worker count
+    is not known when ``_run_config`` first runs.
+    """
+    cli_value = getattr(args, "build_cache_mode", None)
+    if cli_value is not None:
+        return image_cache.normalize_build_cache_mode(cli_value)
+    if "build_cache_mode" in cfg:
+        return image_cache.configured_build_cache_mode(cfg)
+    workers = getattr(args, "workers", 1)
+    if workers != "auto":
+        try:
+            if int(workers) > 1:
+                return "shared"
+        except (TypeError, ValueError):
+            pass
+    return image_cache.DEFAULT_BUILD_CACHE_MODE
+
+
+def _refresh_build_cache_mode(args, cfg: dict) -> None:
+    """Re-evaluate the dynamic multi-worker default after ``auto`` sizing."""
+    args._build_cache_mode = _resolve_build_cache_mode(args, cfg)
 
 
 def _is_trajectory_bundle_rejection(exc: ApiError) -> bool:
@@ -4365,6 +4392,11 @@ def _run_worker_pool(args) -> int:
         print_report(report)
         args.workers = report.recommended_workers
         _align_refill_target_with_workers(args)
+        # ``auto`` did not know the final pool size when _run_config first
+        # resolved defaults. Re-evaluate now so a multi-worker pool shares
+        # immutable BuildKit layers unless the user/config explicitly chose a
+        # different policy.
+        _refresh_build_cache_mode(args, cfg)
     elif not fleet_pool:
         from .capacity import docker_resources, worker_resource_warnings
 

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -219,7 +219,12 @@ CODEBUDDY_AGENT_IMPORT_PATH = (
 )
 CODEBUDDY_AGENT_MODULE_FILENAME = "_dradar_pier_codebuddy.py"
 BETA_SUBSCRIPTION_TRIAL_TIMEOUT_FLOOR_SEC = 120 * 60
-DEFAULT_ENVIRONMENT_BUILD_TIMEOUT_MULTIPLIER = 2.0
+# A cold multi-worker BuildKit start can spend tens of minutes pulling base
+# images and package layers.  Three task windows (90 minutes for the common
+# 1800s task declaration) gives slow mirrors room to recover while the
+# bounded 1..8 override and two-attempt Pier retry still prevent a wedged
+# daemon from holding a lease forever.
+DEFAULT_ENVIRONMENT_BUILD_TIMEOUT_MULTIPLIER = 3.0
 DEFAULT_ENVIRONMENT_BUILD_TIMEOUT_SEC = 600.0
 PIER_ENVIRONMENT_START_ATTEMPTS = 2
 ENVIRONMENT_BUILD_WATCHDOG_SLACK_SEC = 120
@@ -1102,8 +1107,8 @@ def _task_environment_build_timeout_sec(task_path: Path) -> float | None:
 def resolve_environment_build_timeout_multiplier(value: object = None) -> float:
     """Return a bounded environment-build timeout multiplier.
 
-    A default of two gives slow mirrors and cold builders another window while
-    keeping the upper bound finite. Passing ``1`` explicitly restores the
+    A default of three gives slow mirrors and cold builders a long recovery
+    window while keeping the upper bound finite. Passing ``1`` explicitly restores the
     previous behavior; values above eight are refused so a wedged daemon
     cannot keep a paid lease alive indefinitely.
     """
@@ -2737,7 +2742,10 @@ def _tail(log_path: Path, n: int = 15) -> str:
     return "\n".join(lines[-n:])
 
 
-HEARTBEAT_SEC = 60
+# Keep the local progress signal aligned with the preparation heartbeat.  A
+# build can be silent while Docker pulls layers, so a one-minute cadence made
+# a healthy cold start look abandoned in the radar UI.
+HEARTBEAT_SEC = 30
 TRIAL_TIMEOUT_RETURNCODE = 124
 LIVE_ACCOUNT_ERROR_CONFIRMATIONS = 3
 _LIVE_ACCOUNT_TERMINAL_KINDS = {

--- a/src/dradar/telemetry.py
+++ b/src/dradar/telemetry.py
@@ -31,8 +31,11 @@ def platform_family() -> str:
     return "other"
 
 
+PREPARATION_HEARTBEAT_SEC = 30
+
+
 class RunnerTelemetry:
-    """A daemon heartbeat with adaptive 60/120-second cadence.
+    """A daemon heartbeat with a fast preparation cadence.
 
     Background telemetry is best effort and can never abort a running trial.
     The synchronous pre-checkout registration path is strict because checkout
@@ -63,7 +66,10 @@ class RunnerTelemetry:
         self._batch_id: str | None = None
         self._seq = 0
         self._progress_counter = 0
-        self._interval = 120
+        # The first heartbeat is sent immediately by ``start``.  Keep the
+        # fallback short while cloning/building/queuing so a stalled setup is
+        # noticed quickly even when the server response is unavailable.
+        self._interval = PREPARATION_HEARTBEAT_SEC
         self._failures = 0
         self._warned = False
         self._disabled = False
@@ -222,7 +228,16 @@ class RunnerTelemetry:
                     self._batch_id = response["batch_id"]
             requested = response.get("next_heartbeat_sec", self._interval)
             try:
-                self._interval = min(600, max(30, int(requested)))
+                requested_interval = min(600, max(30, int(requested)))
+                with self._lock:
+                    phase = self._phase
+                if phase in {"preparing", "queued"}:
+                    # Preparation has no model output to act as a liveness
+                    # signal. Do not let an adaptive server interval stretch
+                    # this phase beyond the operator-visible 30s cadence.
+                    self._interval = PREPARATION_HEARTBEAT_SEC
+                else:
+                    self._interval = requested_interval
             except (TypeError, ValueError):
                 pass
             return self._interval

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -113,12 +113,19 @@ def test_trial_builder_is_assignment_scoped_and_never_selected_globally(
 def test_shared_trial_builder_is_bootstrapped_and_reusable(
     tmp_path: Path, monkeypatch,
 ):
+    monkeypatch.setenv("DRADAR_SHARED_BUILDER_STATE_DIR", str(tmp_path / "shared-state"))
     calls = []
+    builder_exists = False
 
     def run(command, **_kwargs):
+        nonlocal builder_exists
         calls.append(command)
         if command[:2] == ["buildx", "inspect"] and "--bootstrap" not in command:
-            return subprocess.CompletedProcess(command, 1, "", "not found")
+            if not builder_exists:
+                return subprocess.CompletedProcess(command, 1, "", "not found")
+            return subprocess.CompletedProcess(command, 0, "Name: shared\nStatus: running\n", "")
+        if command[:2] == ["buildx", "create"]:
+            builder_exists = True
         return subprocess.CompletedProcess(command, 0, "ok", "")
 
     monkeypatch.setattr(image_cache, "_run_docker", run)
@@ -132,11 +139,17 @@ def test_shared_trial_builder_is_bootstrapped_and_reusable(
     # intentionally crosses those paths within one OS user's Docker context.
     assert image_cache.shared_builder_name(tmp_path / "other-harness") == lease.name
     assert calls[-1] == ["buildx", "inspect", lease.name, "--bootstrap"]
+    calls.clear()
+    second = image_cache.prepare_trial_builder(
+        tmp_path / "other-harness", assignment_id="a2", runtime={}, mode="shared",
+    )
+    assert second.name == lease.name and second.reusable
+    assert [command for command in calls if "--bootstrap" in command] == []
     assert image_cache.remove_trial_builder(
         tmp_path, "a1", mode="shared",
     ) == (True, None)
     # Shared cleanup must not remove the persistent BuildKit cache.
-    assert calls[-1] == ["buildx", "inspect", lease.name, "--bootstrap"]
+    assert calls[-1] == ["buildx", "inspect", lease.name]
 
 
 def test_shared_build_cache_prune_targets_only_dradar_builder(

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -223,6 +223,10 @@ def test_task_agent_timeout_sec_none_when_malformed(tmp_path):
     assert runner_mod._task_agent_timeout_sec(task) is None
 
 
+def test_environment_build_timeout_default_is_three_windows():
+    assert runner_mod.resolve_environment_build_timeout_multiplier() == 3.0
+
+
 def test_multiplier_stretches_pier_to_match_drader_outer_cap(tmp_path):
     # est_minutes=68 -> outer = max(1800, 68*60*4) = 16320s; base 5400s ->
     # pier must be stretched so its own timeout is >= outer, plus slack.

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -65,11 +65,14 @@ def test_target_worker_count_is_bounded():
 def test_server_can_slow_cadence_but_not_make_it_pathological():
     client = FakeClient([
         {"next_heartbeat_sec": 99999},
-        {"next_heartbeat_sec": 1},
+        {"next_heartbeat_sec": 99999},
     ])
     telemetry = RunnerTelemetry(client, jitter=False)
-    assert telemetry._send_once() == 600
+    # Preparation/queueing is operator-visible and must stay on the fast
+    # cadence even if the server asks for a much slower interval.
     assert telemetry._send_once() == 30
+    telemetry.set_phase("running")
+    assert telemetry._send_once() == 600
 
 
 def test_server_notices_are_bounded_validated_and_printed_once(capsys):

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -661,6 +661,34 @@ def test_worker_child_uses_parent_capabilities_without_reprobing(monkeypatch):
     )
 
 
+def test_multi_worker_pool_defaults_to_shared_build_cache(monkeypatch):
+    monkeypatch.setattr(runloop, "_load_config", lambda: {
+        "server": "https://api.example.com", "token": "token",
+    })
+    args = _args(workers=8)
+    runloop._run_config(args)
+    assert args._build_cache_mode == "shared"
+
+
+def test_single_worker_keeps_isolated_build_cache_default(monkeypatch):
+    monkeypatch.setattr(runloop, "_load_config", lambda: {
+        "server": "https://api.example.com", "token": "token",
+    })
+    args = _args(workers=1)
+    runloop._run_config(args)
+    assert args._build_cache_mode == "isolated"
+
+
+def test_explicit_build_cache_setting_wins_over_multi_worker_default(monkeypatch):
+    monkeypatch.setattr(runloop, "_load_config", lambda: {
+        "server": "https://api.example.com", "token": "token",
+        "build_cache_mode": "isolated",
+    })
+    args = _args(workers=8)
+    runloop._run_config(args)
+    assert args._build_cache_mode == "isolated"
+
+
 def test_worker_child_rejects_malformed_parent_capability_snapshot(monkeypatch):
     monkeypatch.setattr(runloop, "_load_config", lambda: {
         "server": "https://api.example.com", "token": "token",


### PR DESCRIPTION
## 目的

改善多 Harness 并发时的环境准备稳定性和可观测性：延长有界的 Docker 环境构建窗口、在准备阶段更快发送心跳、并复用宿主用户范围内的公共 BuildKit 层，避免每辆车重复冷启动。

## 变更

- 环境构建超时默认乘数从 2 调整为 3，仍限制在 1–8，并计入外层 watchdog。
- runner 本地进度日志改为 30 秒；preparing/queued 心跳固定不超过 30 秒，running 仍遵守服务端自适应间隔。
- 多 worker 未显式配置缓存策略时自动选择 shared；单 worker 和显式 isolated 保持隔离行为。
- shared BuildKit builder 以宿主 OS 用户为边界，首次 bootstrap 采用跨 Harness 文件锁和有时效就绪戳；builder/daemon 重启或戳失效会重新预热。
- 私有 ds0 编排改为新批次使用 `/home/aloha/dradar-cli-runtime/current`，在途子进程不受热切换影响，并显式传递 shared/timeout 配置（私有变更不在本 PR 中公开）。

## 验证

- `python -m pytest -q`：1359 passed, 2 skipped
- `python -m compileall -q src tests`
- `git diff --check`

## 发布边界

请由雷达任务调度器审核、构建并发布；发布后请由雷达哨兵只读验证新的 CLI、准备阶段心跳、共享 builder 以及端到端运行闭环。当前没有直接修改 ds0 活动批次。
