### PR TITLE
fix: reject unsafe task base commits before build

### DIFF
--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -3376,7 +3376,18 @@ def _validate_task_base_commit_before_build(
     task_id = assignment.get("task_id")
     if not isinstance(task_id, str) or not task_id or Path(task_id).name != task_id:
         raise RunnerError(f"unsafe task id {task_id!r}")
-    task_toml = tasks_root / task_id / "task.toml"
+    task_root = tasks_root / task_id
+    hook = task_root / "pre_artifacts.sh"
+    # A reviewed task-owned hook does not use DRadar's generated base-ref
+    # substitution. Antigravity is the exception because its overlay replaces
+    # even an existing hook and therefore still consumes base_commit_hash.
+    if (
+        effective_agent != ANTIGRAVITY_AGENT
+        and hook.is_file()
+        and not hook.is_symlink()
+    ):
+        return
+    task_toml = task_root / "task.toml"
     if not task_toml.is_file():
         return
     try:

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -3366,6 +3366,42 @@ def _artifact_tasks_overlay(
         yield overlay_root
 
 
+def _validate_task_base_commit_before_build(
+    assignment: dict,
+    tasks_root: Path,
+    effective_agent: str,
+) -> None:
+    """Reject unsafe artifact base refs before creating any BuildKit state."""
+
+    task_id = assignment.get("task_id")
+    if not isinstance(task_id, str) or not task_id or Path(task_id).name != task_id:
+        raise RunnerError(f"unsafe task id {task_id!r}")
+    task_toml = tasks_root / task_id / "task.toml"
+    if not task_toml.is_file():
+        return
+    try:
+        task_config = tomllib.loads(task_toml.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+        raise RunnerError(f"task.toml is unreadable: {exc}") from exc
+    metadata = task_config.get("metadata", {})
+    if not isinstance(metadata, dict):
+        raise RunnerError("task has an invalid metadata.base_commit_hash")
+    base_commit = metadata.get("base_commit_hash", "")
+    valid_commit = (
+        isinstance(base_commit, str)
+        and (not base_commit or re.fullmatch(r"[0-9a-f]{40}", base_commit) is not None)
+    )
+    valid_pompeii_tag = (
+        effective_agent == ANTIGRAVITY_AGENT
+        and base_commit == "pompeii-base"
+        and task_id.startswith(POMPEII_BENCHMARK_ID + "-")
+    )
+    if effective_agent == ANTIGRAVITY_AGENT and not base_commit:
+        valid_commit = False
+    if not (valid_commit or valid_pompeii_tag):
+        raise RunnerError("task has an invalid metadata.base_commit_hash")
+
+
 @contextmanager
 def _antigravity_tasks_overlay(
     assignment: dict,
@@ -3702,6 +3738,12 @@ def run_trial(
         environment_build_timeout_multiplier,
     )
     build_cache_mode = image_cache.normalize_build_cache_mode(build_cache_mode)
+    # The selected task pack is the authoritative source for artifact base
+    # metadata. Reject a bad ref before version discovery, provider preflight,
+    # credential materialization, or any BuildKit state is touched.
+    _validate_task_base_commit_before_build(
+        effective_assignment, tasks_root, effective_agent
+    )
     if effective_agent == "codex":
         codex_provider = (
             assignment_codex_provider(assignment) or DEFAULT_CODEX_PROVIDER

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -761,6 +761,31 @@ def test_artifact_task_overlay_rejects_untrusted_base_ref(tmp_path):
             pass
 
 
+def test_invalid_base_commit_is_rejected_before_builder_creation(
+    tmp_path, monkeypatch,
+):
+    task_id = "abs-module-cache-flags"
+    task = tmp_path / task_id
+    task.mkdir()
+    (task / "task.toml").write_text(
+        '[metadata]\nbase_commit_hash = "main; touch /tmp/pwned"\n'
+    )
+    builder_calls = []
+
+    def forbidden_builder(*_args, **_kwargs):
+        builder_calls.append(True)
+        raise AssertionError("builder must not start for invalid task metadata")
+
+    monkeypatch.setattr(
+        runner_mod.image_cache, "prepare_trial_builder", forbidden_builder
+    )
+
+    with pytest.raises(RunnerError, match="invalid metadata.base_commit_hash"):
+        run_trial(_assignment("codex"), tmp_path, tmp_path)
+
+    assert builder_calls == []
+
+
 def _fake_pier(monkeypatch, work_dir, *, patch=True, trajectory=True,
                trajectory_payload=None, runtime_diagnostic=None,
                zcode_outcome=None, provider_usage_sidecar=None,

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -786,6 +786,51 @@ def test_invalid_base_commit_is_rejected_before_builder_creation(
     assert builder_calls == []
 
 
+@pytest.mark.parametrize(
+    ("base_commit", "hook_kind", "agent", "accepted"),
+    [
+        ("a" * 40, None, "codex", True),
+        ("legacy-reviewed-hook-ref", "regular", "codex", True),
+        ("main; touch /tmp/pwned", "regular", "codex", True),
+        ("legacy-reviewed-hook-ref", None, "codex", False),
+        ("main; touch /tmp/pwned", None, "codex", False),
+        ("legacy-reviewed-hook-ref", "symlink", "codex", False),
+        (
+            "legacy-reviewed-hook-ref",
+            "regular",
+            runner_mod.ANTIGRAVITY_AGENT,
+            False,
+        ),
+    ],
+)
+def test_prebuild_base_commit_contract_matches_task_hook_semantics(
+    tmp_path, base_commit, hook_kind, agent, accepted,
+):
+    task_id = "deep-task"
+    task = tmp_path / task_id
+    task.mkdir()
+    (task / "task.toml").write_text(
+        '[metadata]\nbase_commit_hash = "' + base_commit + '"\n'
+    )
+    if hook_kind == "regular":
+        (task / "pre_artifacts.sh").write_text("#!/bin/sh\nexit 0\n")
+    elif hook_kind == "symlink":
+        target = tmp_path / "reviewed-hook.sh"
+        target.write_text("#!/bin/sh\nexit 0\n")
+        (task / "pre_artifacts.sh").symlink_to(target)
+
+    def check():
+        return runner_mod._validate_task_base_commit_before_build(
+            {"task_id": task_id}, tmp_path, agent
+        )
+
+    if accepted:
+        check()
+    else:
+        with pytest.raises(RunnerError, match="invalid metadata.base_commit_hash"):
+            check()
+
+
 def _fake_pier(monkeypatch, work_dir, *, patch=True, trajectory=True,
                trajectory_payload=None, runtime_diagnostic=None,
                zcode_outcome=None, provider_usage_sidecar=None,


### PR DESCRIPTION
## 事故背景

65 题编排链路遇到不可信或损坏的 `metadata.base_commit_hash` 时，可能在进入构建阶段后才失败；另经独立诊断确认，旧私有计划器查询参数与 Server 不一致会造成 benchmark 串线。

## 范围

- 在版本发现、Provider 预检、凭据物化或 builder 创建之前校验任务包中的 base commit。
- 对需要 DRadar 生成或替换 artifact hook 的任务，仅接受规则允许的 commit 标识。
- 保留受审普通 `pre_artifacts.sh` 的既有契约；符号链接 hook 不得绕过校验。
- Antigravity 会替换现有 hook，因此仍严格校验；`pompeii-base` 仅限受审 Pompeii 任务。
- 增加构建前拒绝与 hook/hash 契约回归测试。

## QA 与计划证据

- CLI 与 Server 的 hook/hash 跨仓组合矩阵 `7/7 PASS`。
- 私有计划器已改用规范 `benchmark` 查询，对响应基准 fail closed，并冻结全局唯一主计划与整批补位储备。
- 事故配置只读实测生成 `65` 个主任务 + `12` 个储备，共 `77/77` 裸任务全局唯一，基准串线 `0`，taskpack 目录 `77/77` 存在；计划 SHA-256 为 `4e8cd63fae1cfa019daaaf3c3aecbea5ad9c698052f435005303e0442133cab3`。
- 本地 5-worker 高保真闭环验证坏题导致整批普通释放后仍补足 `65` 个唯一成功认领位；未领取真实题。

## 验证

- CLI 全量：`1417 passed`
- 私有编排器：`40 passed`，Ruff 通过
- Server 配套 PR：`1174 passed`
- `git diff --check` 和敏感模式检查通过

## 尚未执行

以上是只读计划证据和纯本地合成 E2E，不是真实 65 题运行终态。未合并、未发布、未部署、未操作 Cloudflare、未领取真实题；本 PR 保持 OPEN，不据此宣称生产事故闭环。

## 风险与非目标

- 更严格的 fail-closed 校验会暴露错误任务元数据。
- 未改变领取、上传、判分、账号、并发或生产配置。
- 合并与生产验证仍需后续明确授权和独立验收。

## 第二轮 QA 返工（2026-09-02）

- 私有编排器候选更新为 `04c5cbc286caf09b735c42806cf63f98be60d8a3`：Provider 初始化改为 per-harness 非阻塞状态机；首 lane 永久等待期间，健康 lane 可独立完成 claim→runner→submit，等待 lane 恢复后只加入一次。
- claim 前先持久化客户端预分配 batch intent；HTTP claim 响应丢失时从服务端精确恢复同 batch assignments。恢复会重新附着同 batch 存活子进程，并为死进程提供提交可见性宽限；计数从持久化批次事实重算。
- 三类 crash 回归覆盖 claim 后、runner 启动后、upload 后 API 可见前；不重 claim、不重复 runner、不重复 submission/计数。
- 事故配置与 ds0 权威 taskpack 的只读 preflight 检查 1208 个候选，剔除 6 个坏 base commit，冻结 65 主任务 + 12 储备；77/77 task 哈希唯一、目录存在、0 benchmark 串线，选中项为 49 个 SHA40 与 28 个受审 Pompeii base。脱敏计划 SHA-256：`a267d208e5f98fda9c07cc653df169b2b3b87e095874cbe0552de7186991f7d4`。
- 全量本地回归：私有 45、CLI 1417、Server 1174，全部通过；Server 仅保留 1 条 TestClient 依赖迁移警告。
- GitHub 证据缺口保持透明：本 PR 的 `statusCheckRollup=[]`。Server 无 workflow；CLI 唯一 workflow 不监听 pull_request，因此未伪造 CI 通过。
- 仍未合并、发布、部署、操作 Cloudflare 或领取真实题。
- 最终私有候选与证据封装提交：04c5cbc286caf09b735c42806cf63f98be60d8a3；树：0f5c8768ba18aeeae1dc1bb9929d0e46a3a90f0b。
- 最终归档 candidate-0.2.0.tar.gz SHA-256：111b85a55a50f198a6c7753a601ee5fa3092b5b337b96de960ea35e2665bc1c7；清单文件 SHA-256：0e096f6bc1a367a55fa8f0d757f1320f3119c26065006a270432c475019eec3b。归档解包后源码、测试、README 与最终候选逐字节一致，隔离环境再次验证 45 passed，Ruff 与全量清单校验通过。