### PR TITLE
fix: circuit-break repeated environment builds

### DIFF
--- a/src/dradar/fleet.py
+++ b/src/dradar/fleet.py
@@ -98,6 +98,7 @@ REQUEST_TIMEOUT_SECONDS = 60.0
 HEARTBEAT_SECONDS = 1.0
 HEARTBEAT_STALE_SECONDS = 60.0
 IDLE_EXIT_SECONDS = 30.0
+ENVIRONMENT_BUILD_FAILED_EXIT_CODE = 78
 SETTLED_BATCH_STATUSES = {"completed", "failed", "interrupted", "stopped"}
 STARTUP_OBSERVE_SECONDS = 3.0
 
@@ -1272,13 +1273,21 @@ def _settle_pool(
     requested_stop = item.get("status") == "stopping"
     startup_failed = item.get("startup_status") == "failed"
     run_plan_item = _is_run_plan_item(item)
+    environment_build_failed = bool(
+        returncode == ENVIRONMENT_BUILD_FAILED_EXIT_CODE
+        and not startup_failed
+        and not requested_stop
+    )
     device_stop_warning: str | None = None
     if run_plan_item and (returncode != 0 or startup_failed) and not requested_stop:
         device_stop_warning = _stop_run_plan_device(
             item,
             (
                 f"local startup failed ({item.get('startup_error_code')})"
-                if startup_failed else f"local runner exit code {returncode}"
+                if startup_failed else
+                "local isolated environment build failed before model start"
+                if environment_build_failed else
+                f"local runner exit code {returncode}"
             ),
         )
         if device_stop_warning:
@@ -1317,6 +1326,17 @@ def _settle_pool(
         item["detail"] = (
             "active work stopped with a local recovery item still requiring attention"
         )
+    elif environment_build_failed:
+        item.update({
+            "failure_kind": "environment_build_failed",
+            "failure_state": "needs_attention",
+            "retryable": True,
+            "detail": (
+                "The isolated task environment could not resolve its base image; "
+                "the model did not start. Check Docker registry access and retry."
+            ),
+            "occurred_at": _now(),
+        })
     item["updated_at"] = _now()
     log_handle = logs.pop(batch_id, None)
     if log_handle is not None:
@@ -1686,6 +1706,8 @@ def cmd_fleet_status(args) -> int:
             )
             + suffix
         )
+        if item.get("failure_state") == "needs_attention" and item.get("detail"):
+            print(f"    needs attention: {item['detail']}")
     return 0
 
 

--- a/src/dradar/image_cache.py
+++ b/src/dradar/image_cache.py
@@ -20,6 +20,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.parse
 from contextlib import contextmanager
@@ -34,6 +35,8 @@ LEDGER_NAME = "image-cache.json"
 LOCK_NAME = "image-cache.lock"
 MAINTENANCE_STAMP_NAME = "image-cache-maintenance.stamp"
 BUILDER_PREFIX = "dradar-task-"
+BUILDER_MIRRORS_ENV = "DRADAR_BUILDKIT_REGISTRY_MIRRORS_V1"
+BUILDER_PREFLIGHT_IMAGE = "node:22-bookworm"
 SHARED_BUILDER_PREFIX = "dradar-cache-"
 SHARED_BUILDER_LOCK_NAME = "shared-build-cache.lock"
 SHARED_BUILDER_READY_STAMP_NAME = "shared-build-cache.ready.json"
@@ -112,6 +115,16 @@ class TrialBuilderLease:
     # survives one trial so BuildKit can reuse immutable layers for the next
     # task, even when Fleet gives each harness a separate DRADAR_HOME.
     reusable: bool = False
+
+
+@dataclass(frozen=True)
+class TrialBuilderPreflight:
+    ok: bool
+    returncode: int
+    stage: str
+    failure_code: str | None
+    detail: str
+    registry_mirrors: tuple[str, ...] = ()
 
 
 @dataclass
@@ -216,6 +229,192 @@ def trial_builder_name(home: Path, assignment_id: str) -> str:
     """Return a deterministic builder name scoped to one home and assignment."""
     identity = f"{home.resolve()}\0{assignment_id}".encode("utf-8", "surrogatepass")
     return BUILDER_PREFIX + hashlib.sha256(identity).hexdigest()[:20]
+
+
+def _validated_registry_mirror(value: object) -> str:
+    """Return one credential-free HTTPS registry mirror URL."""
+
+    if not isinstance(value, str):
+        raise DockerUnavailable("Docker returned a non-string registry mirror")
+    raw = value.strip().rstrip("/")
+    try:
+        parsed = urllib.parse.urlsplit(raw)
+    except ValueError as exc:
+        raise DockerUnavailable("Docker returned an invalid registry mirror") from exc
+    if (
+        parsed.scheme.lower() != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise DockerUnavailable(
+            "the Docker registry mirror is not a credential-free HTTPS URL"
+        )
+    return raw
+
+
+def docker_registry_mirrors() -> tuple[str, ...]:
+    """Snapshot the daemon's reviewed mirrors for a child BuildKit."""
+
+    inherited = os.environ.get(BUILDER_MIRRORS_ENV)
+    if inherited is not None:
+        try:
+            values = json.loads(inherited)
+        except json.JSONDecodeError as exc:
+            raise DockerUnavailable(
+                "the inherited BuildKit registry mirror snapshot is invalid"
+            ) from exc
+    else:
+        proc = _run_docker(
+            ["info", "--format", "{{json .RegistryConfig.Mirrors}}"],
+            timeout=30,
+            allow_fail=True,
+        )
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "Docker info failed").strip()
+            raise DockerUnavailable(redact_docker_diagnostic(detail, limit=300))
+        try:
+            values = json.loads(proc.stdout.strip() or "[]")
+        except json.JSONDecodeError as exc:
+            raise DockerUnavailable(
+                "Docker returned malformed registry mirror metadata"
+            ) from exc
+    if not isinstance(values, list) or len(values) > 8:
+        raise DockerUnavailable("Docker returned invalid registry mirror metadata")
+    return tuple(dict.fromkeys(_validated_registry_mirror(value) for value in values))
+
+
+@contextmanager
+def _buildkit_registry_config(
+    registry_mirrors: tuple[str, ...],
+) -> Iterator[Path | None]:
+    if not registry_mirrors:
+        yield None
+        return
+    with tempfile.TemporaryDirectory(prefix="dradar-buildkit-config-") as directory:
+        path = Path(directory) / "buildkitd.toml"
+        encoded = ", ".join(json.dumps(value) for value in registry_mirrors)
+        path.write_text(
+            '[registry."docker.io"]\n'
+            f"  mirrors = [{encoded}]\n",
+            encoding="utf-8",
+        )
+        try:
+            path.chmod(0o600)
+        except OSError:
+            pass
+        yield path
+
+
+def redact_docker_diagnostic(output: object, *, limit: int = 1200) -> str:
+    """Bound Docker/BuildKit diagnostics after removing credential material."""
+
+    text = re.sub(r"(?i)https?://[^\s]+", "<url>", str(output or ""))
+    text = re.sub(
+        r"(?im)\b((?:proxy-)?authorization|x-registry-auth)\b"
+        r"(\s*[:=]\s*)[^\r\n]*",
+        r"\1\2<redacted>",
+        text,
+    )
+    text = re.sub(
+        r"(?i)\b(bearer|basic)\s+[^\s,;]+",
+        r"\1 <redacted>",
+        text,
+    )
+    text = re.sub(
+        r'''(?ix)
+        (?P<prefix>["']?(?:
+            access[_-]?token|refresh[_-]?token|identity[_-]?token|
+            registry[_-]?token|token|password|passwd|secret|
+            client[_-]?secret|api[_-]?key|credential(?:s)?|
+            docker[_-]?auth[_-]?config|auth
+        )["']?\s*[:=]\s*)
+        (?P<quote>["']?)[^"'\s,;}]+(?P=quote)
+        ''',
+        r"\g<prefix>\g<quote><redacted>\g<quote>",
+        text,
+    )
+    text = re.sub(r"sha256:[0-9a-f]{64}", "sha256:<digest>", text)
+    lines = [
+        _truncate_diagnostic_middle(line, 500)
+        for line in text.splitlines()
+        if line.strip()
+    ]
+    return "\n".join(lines[-12:])[-limit:]
+
+
+def _truncate_diagnostic_middle(text: str, limit: int) -> str:
+    """Keep a diagnostic's source prefix and terminal cause within a bound."""
+
+    if len(text) <= limit:
+        return text
+    if limit <= 1:
+        return text[:limit]
+    marker = "…"
+    content = limit - len(marker)
+    head = (content * 2) // 3
+    tail = content - head
+    return text[:head] + marker + text[-tail:]
+
+
+def _bounded_cleanup_diagnostics(
+    notes: list[str], *, total_limit: int = 1200,
+) -> str | None:
+    """Fairly bound cleanup sources without allowing a tail slice to erase one."""
+
+    if not notes:
+        return None
+    separator = "；"
+    available = max(0, total_limit - len(separator) * (len(notes) - 1))
+    safe = [
+        # redact_docker_diagnostic keeps at most 12 lines of 500 characters.
+        # Request that complete safe envelope here; this helper, not the
+        # redactor's tail bound, owns the fair per-source allocation.
+        redact_docker_diagnostic(note, limit=max(total_limit, 6000))
+        for note in notes
+    ]
+    allocations = [0] * len(safe)
+    remaining = available
+    active = set(range(len(safe)))
+    while active and remaining > 0:
+        share = max(1, remaining // len(active))
+        completed: list[int] = []
+        for index in sorted(active):
+            needed = len(safe[index]) - allocations[index]
+            grant = min(needed, share, remaining)
+            allocations[index] += grant
+            remaining -= grant
+            if allocations[index] >= len(safe[index]):
+                completed.append(index)
+            if remaining == 0:
+                break
+        active.difference_update(completed)
+    parts = [
+        _truncate_diagnostic_middle(value, allocations[index])
+        for index, value in enumerate(safe)
+    ]
+    return separator.join(parts)
+
+
+def _redacted_build_excerpt(output: str, *, limit: int = 1200) -> str:
+    return redact_docker_diagnostic(output, limit=limit)
+
+
+def _build_failure_code(output: str) -> str:
+    low = output.lower()
+    if "network is unreachable" in low or "connection refused" in low:
+        return "registry_network_unreachable"
+    if "i/o timeout" in low or "deadline exceeded" in low or "timed out" in low:
+        return "registry_timeout"
+    if "no such host" in low or "temporary failure resolving" in low:
+        return "registry_dns_failed"
+    if "x509" in low or "tls handshake" in low:
+        return "registry_tls_failed"
+    if "failed to fetch anonymous token" in low or "toomanyrequests" in low:
+        return "registry_auth_or_limit"
+    return "registry_metadata_failed"
 
 
 def shared_builder_name(home: Path) -> str:
@@ -369,7 +568,12 @@ def _shared_builder_lock() -> Iterator[None]:
             fh.close()
 
 
-def _ensure_named_builder(name: str, *, reusable: bool) -> str | None:
+def _ensure_named_builder(
+    name: str,
+    *,
+    reusable: bool,
+    registry_mirrors: tuple[str, ...] = (),
+) -> str | None:
     """Create/refresh one builder and return a bounded failure reason."""
 
     existing = _run_docker(
@@ -386,10 +590,14 @@ def _ensure_named_builder(name: str, *, reusable: bool) -> str | None:
             return None
 
     if existing.returncode != 0:
-        created = _run_docker([
-            "buildx", "create", "--name", name,
-            "--driver", "docker-container",
-        ], timeout=120, allow_fail=True)
+        with _buildkit_registry_config(registry_mirrors) as config_path:
+            command = [
+                "buildx", "create", "--name", name,
+                "--driver", "docker-container",
+            ]
+            if config_path is not None:
+                command += ["--buildkitd-config", str(config_path)]
+            created = _run_docker(command, timeout=120, allow_fail=True)
         if created.returncode != 0:
             # This is normally a harmless create race.  The shared lock makes
             # it rare, but the bounded inspect proves whether Docker already
@@ -410,13 +618,19 @@ def _ensure_named_builder(name: str, *, reusable: bool) -> str | None:
                     detail = (created.stderr or created.stdout or "").strip()
                     return (
                         "无法创建共享构建缓存空间"
-                        + (f"：{detail[:160]}" if detail else "")
+                        + (
+                            f"：{redact_docker_diagnostic(detail, limit=160)}"
+                            if detail else ""
+                        )
                     )
             else:
                 detail = (created.stderr or created.stdout or "").strip()
                 return (
                     "无法创建隔离的临时构建空间"
-                    + (f"：{detail[:160]}" if detail else "")
+                    + (
+                        f"：{redact_docker_diagnostic(detail, limit=160)}"
+                        if detail else ""
+                    )
                 )
 
     if reusable:
@@ -478,6 +692,7 @@ def _builder_proxy_is_safe(runtime: dict[str, str]) -> tuple[bool, str | None]:
 def prepare_trial_builder(
     home: Path, *, assignment_id: str, runtime: dict[str, str] | None = None,
     mode: str = DEFAULT_BUILD_CACHE_MODE,
+    registry_mirrors: tuple[str, ...] | None = None,
 ) -> TrialBuilderLease:
     """Create a BuildKit builder for one assignment or a scoped shared cache.
 
@@ -492,6 +707,19 @@ def prepare_trial_builder(
     safe, note = _builder_proxy_is_safe(runtime)
     if not safe:
         return TrialBuilderLease(None, False, note)
+    try:
+        mirrors = (
+            docker_registry_mirrors()
+            if registry_mirrors is None else
+            tuple(_validated_registry_mirror(value) for value in registry_mirrors)
+        )
+    except DockerUnavailable as exc:
+        return TrialBuilderLease(
+            None,
+            False,
+            "临时构建镜像源不可用："
+            + redact_docker_diagnostic(exc, limit=300),
+        )
     reusable = mode == "shared"
     name = shared_builder_name(home) if reusable else trial_builder_name(
         home, assignment_id,
@@ -507,14 +735,22 @@ def prepare_trial_builder(
             # builder creation/bootstrap outside the per-assignment lock but
             # still prevents a parallel cold-start herd.
             with _shared_builder_lock():
-                failure = _ensure_named_builder(name, reusable=True)
+                failure = _ensure_named_builder(
+                    name, reusable=True, registry_mirrors=mirrors,
+                )
         else:
-            failure = _ensure_named_builder(name, reusable=False)
+            failure = _ensure_named_builder(
+                name, reusable=False, registry_mirrors=mirrors,
+            )
         if failure is not None:
             return TrialBuilderLease(None, False, failure)
     except DockerUnavailable as exc:
         label = "共享构建缓存空间" if reusable else "临时构建空间"
-        return TrialBuilderLease(None, False, f"{label}不可用：{exc}")
+        return TrialBuilderLease(
+            None,
+            False,
+            f"{label}不可用：" + redact_docker_diagnostic(exc, limit=300),
+        )
     except OSError as exc:
         label = "共享构建缓存空间" if reusable else "临时构建空间"
         return TrialBuilderLease(None, False, f"{label}本地锁不可用：{exc}")
@@ -523,6 +759,80 @@ def prepare_trial_builder(
             name, True, "共享 BuildKit 缓存已预热；仅限当前 OS 用户的 Docker 环境", True,
         )
     return TrialBuilderLease(name, True)
+
+
+def preflight_trial_builder(
+    home: Path,
+    *,
+    image: str = BUILDER_PREFLIGHT_IMAGE,
+    registry_mirrors: tuple[str, ...] | None = None,
+) -> TrialBuilderPreflight:
+    """Resolve one base image through an isolated builder without a model."""
+
+    try:
+        mirrors = (
+            docker_registry_mirrors()
+            if registry_mirrors is None else
+            tuple(_validated_registry_mirror(value) for value in registry_mirrors)
+        )
+    except DockerUnavailable as exc:
+        return TrialBuilderPreflight(
+            False, 1, "registry_configuration", "registry_config_invalid",
+            redact_docker_diagnostic(exc, limit=500),
+        )
+    preflight_id = f"preflight-{os.getpid()}-{time.time_ns()}"
+    lease = prepare_trial_builder(
+        home,
+        assignment_id=preflight_id,
+        mode="isolated",
+        registry_mirrors=mirrors,
+    )
+    if not lease.isolated or lease.name is None:
+        return TrialBuilderPreflight(
+            False, 1, "builder_create", "builder_create_failed",
+            redact_docker_diagnostic(
+                lease.note or "isolated builder unavailable", limit=500,
+            ),
+            mirrors,
+        )
+    result: TrialBuilderPreflight
+    try:
+        with tempfile.TemporaryDirectory(
+            prefix="dradar-buildkit-preflight-",
+        ) as context:
+            dockerfile = Path(context) / "Dockerfile"
+            dockerfile.write_text(f"FROM {image}\n", encoding="utf-8")
+            proc = _run_docker(
+                [
+                    "buildx", "build", "--builder", lease.name,
+                    "--check", "--pull", "--progress=plain",
+                    "--file", str(dockerfile), context,
+                ],
+                timeout=90,
+                allow_fail=True,
+            )
+        output = f"{proc.stdout}\n{proc.stderr}"
+        result = TrialBuilderPreflight(
+            proc.returncode == 0,
+            proc.returncode,
+            "base_image_metadata",
+            None if proc.returncode == 0 else _build_failure_code(output),
+            "" if proc.returncode == 0 else _redacted_build_excerpt(output),
+            mirrors,
+        )
+    except DockerUnavailable as exc:
+        result = TrialBuilderPreflight(
+            False, 1, "base_image_metadata", "builder_preflight_unavailable",
+            _redacted_build_excerpt(str(exc)), mirrors,
+        )
+    removed, removal_note = remove_trial_builder(home, preflight_id)
+    if not removed:
+        return TrialBuilderPreflight(
+            False, 1, "builder_cleanup", "builder_cleanup_failed",
+            _redacted_build_excerpt(removal_note or "builder cleanup failed"),
+            mirrors,
+        )
+    return result
 
 
 def remove_trial_builder(
@@ -543,10 +853,10 @@ def remove_trial_builder(
             ["buildx", "rm", name], timeout=180, allow_fail=True,
         )
     except DockerUnavailable as exc:
-        return False, str(exc)
+        return False, redact_docker_diagnostic(exc, limit=300)
     if removed.returncode != 0:
         detail = (removed.stderr or removed.stdout or "Docker 拒绝清理").strip()
-        return False, detail[:300]
+        return False, redact_docker_diagnostic(detail, limit=300)
     return True, None
 
 
@@ -1373,7 +1683,7 @@ def cleanup_trial_resources(
         notes.append(f"临时构建空间清理失败：{builder_note or 'unknown error'}")
     # A host-user-scoped shared builder is intentionally retained for the next
     # task; only this task's Compose objects/images are cleaned above.
-    result.note = "；".join(notes) if notes else None
+    result.note = _bounded_cleanup_diagnostics(notes)
     return result
 
 
@@ -1552,12 +1862,16 @@ def cmd_config_set(args) -> int:
 
 
 __all__ = [
+    "BUILDER_MIRRORS_ENV", "BUILDER_PREFLIGHT_IMAGE",
     "CachePolicy", "CleanupPlan", "DockerImage", "DockerUnavailable",
     "MaintenanceResult", "TaskCleanupResult", "TrialBuilderLease",
+    "TrialBuilderPreflight",
     "automatic_maintenance", "cleanup_trial_resources", "discover_pier_images",
     "claim_periodic_maintenance", "disk_allows_new_tasks", "disk_free_bytes",
     "effective_policy", "is_wsl", "load", "plan_cleanup",
+    "docker_registry_mirrors", "preflight_trial_builder",
     "prepare_trial_builder", "proxy_detected", "record_trial_images",
+    "redact_docker_diagnostic",
     "remove_assignment_images", "remove_images", "remove_trial_builder",
     "prune_shared_build_cache",
     "trial_builder_name", "shared_builder_name", "normalize_build_cache_mode",

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -151,6 +151,11 @@ _POOL_DRAIN_PREFIX = "drain:"
 # EX_TEMPFAIL: a supervised child uses this to distinguish one unsafe slot
 # from a generic failure that must freeze the pool's shared waiting queue.
 _WORKER_SLOT_QUARANTINED_EXIT_CODE = 75
+# EX_CONFIG: a task never reached the model because its isolated BuildKit
+# could not resolve the base image. Fleet and shell callers must see a
+# non-zero, distinguishable result instead of a clean account-drain exit.
+_ENVIRONMENT_BUILD_FAILED_EXIT_CODE = 78
+_ENVIRONMENT_BUILD_ABORT_PREFIX = "environment build unavailable:"
 _POOL_SUPERVISOR_POLL_SECONDS = 0.2
 _POOL_BACKFILL_REFRESH_SECONDS = 2.0
 _POOL_BACKFILL_ERROR_RETRY_SECONDS = 10.0
@@ -2398,6 +2403,32 @@ def _mark_stopped_quietly(
         None if isinstance(assignment, str)
         else assignment.get("_runner_session_id")
     )
+    if failure_diagnostic is not None:
+        sensitive_key_parts = {
+            "auth", "authorization", "token", "secret", "password", "passwd",
+        }
+
+        def is_sensitive_key(key: object) -> bool:
+            normalized = re.sub(
+                r"[^a-z0-9]+", "_", str(key).strip().lower(),
+            ).strip("_")
+            return bool(set(normalized.split("_")) & sensitive_key_parts)
+
+        def sanitize_value(value: object, *, key: object | None = None) -> object:
+            if key is not None and is_sensitive_key(key):
+                return "<redacted>"
+            if isinstance(value, str):
+                return image_cache.redact_docker_diagnostic(value, limit=1000)
+            if isinstance(value, dict):
+                return {
+                    item_key: sanitize_value(item, key=item_key)
+                    for item_key, item in value.items()
+                }
+            if isinstance(value, (list, tuple)):
+                return [sanitize_value(item) for item in value]
+            return value
+
+        failure_diagnostic = sanitize_value(failure_diagnostic)
     last_error: Exception | None = None
     for attempt in range(3):
         try:
@@ -2517,7 +2548,20 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
     work_dir = HOME / "work"
     print("running trial (this can take a while)...")
 
+    ownership_state = "needs_bind"
+
     def bind_owner() -> None:
+        nonlocal ownership_state
+        if ownership_state == "bound":
+            # BuildFlake retry is still the same logical assignment attempt.
+            # The first successful bind already fenced this process/session;
+            # never replay the ownership write merely because Pier rebuilds.
+            return
+        if ownership_state == "stop_unconfirmed":
+            raise RunnerError(
+                "server ownership stop was not confirmed; refusing to rebind "
+                "the assignment for another model attempt"
+            )
         try:
             response = client.mark_started(
                 assignment["assignment_id"],
@@ -2527,6 +2571,7 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
             raise RunnerError(
                 f"server ownership bind failed before model start: {exc}"
             ) from exc
+        ownership_state = "bound"
         if response.get("owner_epoch") is not None:
             assignment["owner_epoch"] = int(response["owner_epoch"])
         if telemetry is not None:
@@ -2575,9 +2620,10 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
                         HOME, assignment["assignment_id"],
                     )
                 if not builder_removed:
-                    args._docker_cleanup_blocked = (
+                    args._docker_cleanup_blocked = image_cache.redact_docker_diagnostic(
                         "临时构建空间未能删除："
-                        + (builder_note or "Docker 未返回具体原因")
+                        + (builder_note or "Docker 未返回具体原因"),
+                        limit=1200,
                     )
             break
         except BuildFlakeError as exc:
@@ -2586,16 +2632,23 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
             # attempt, so retry once automatically instead of bouncing the
             # volunteer. A second flake in a row is likely a real network
             # problem worth a human look.
+            safe_exc = image_cache.redact_docker_diagnostic(exc, limit=1200)
             if attempt == 1:
-                print(f"environment build failed ({exc})\n"
+                print(f"environment build failed ({safe_exc})\n"
                       "no quota was consumed — retrying once automatically...")
                 continue
-            print(f"trial failed: {exc}\n"
+            print(f"trial failed: {safe_exc}\n"
                   "the build failed twice — check your network/proxy and re-run "
                   "`dradar resume` (still free: the agent never started), or "
                   "use `dradar release` if you do not want to keep the cell")
+            _signal_pool_abort(
+                _ENVIRONMENT_BUILD_ABORT_PREFIX
+                + " repeated isolated builder failure",
+                interrupt_siblings=False,
+            )
             _mark_stopped_quietly(
                 client, assignment, failure_kind="environment_build_failed",
+                failure_diagnostic=exc.failure_diagnostic,
             )
             return "environment-build-failed"
         except RunnerCleanupUnconfirmedError as exc:
@@ -2631,6 +2684,9 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
                     defer_seconds=0,
                     failure_kind="provider-transport",
                     failure_diagnostic=exc.failure_diagnostic,
+                )
+                ownership_state = (
+                    "needs_bind" if stopped else "stop_unconfirmed"
                 )
                 if stopped:
                     print(
@@ -2736,7 +2792,10 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
             f"预计释放 {reclaimed}）"
         )
     else:
-        args._docker_cleanup_blocked = cleanup.note or "题目运行环境未能完整清理"
+        args._docker_cleanup_blocked = image_cache.redact_docker_diagnostic(
+            cleanup.note or "题目运行环境未能完整清理",
+            limit=1200,
+        )
         print(
             "  提示：本题运行环境没有清理完整；这一路运行不会继续下一题"
         )
@@ -4468,6 +4527,32 @@ def _run_worker_pool(args) -> int:
     maximum = args.workers
     target_file = _pool_target_file(args)
     target = _read_pool_target(target_file, default=maximum, maximum=maximum)
+    registry_mirrors: tuple[str, ...] = ()
+    if target > 1:
+        builder_preflight = image_cache.preflight_trial_builder(HOME)
+        if not builder_preflight.ok:
+            print(
+                "isolated BuildKit preflight failed before worker sessions or "
+                "task checkout: "
+                f"stage={builder_preflight.stage} "
+                f"failure={builder_preflight.failure_code or 'unknown'} "
+                f"exit={builder_preflight.returncode}"
+            )
+            if builder_preflight.detail:
+                print(builder_preflight.detail)
+            print(
+                "no worker was started; check Docker registry access or its "
+                "credential-free HTTPS mirror, then run `dradar resume`"
+            )
+            return _ENVIRONMENT_BUILD_FAILED_EXIT_CODE
+        registry_mirrors = builder_preflight.registry_mirrors
+        print(
+            "isolated BuildKit preflight passed before parallel checkout"
+            + (
+                f" ({len(registry_mirrors)} HTTPS mirror(s) inherited)"
+                if registry_mirrors else " (direct Docker Hub path)"
+            )
+        )
     active, _free_pick = _prepare_batch(args, client)
     if _scoped_fleet_refill(args):
         pending_now = _pending_uploads_for_batch(args.batch_id)
@@ -4602,6 +4687,9 @@ def _run_worker_pool(args) -> int:
         # shared provider state and accidentally dropping one capability.
         env[_POOL_CAPABILITIES_ENV] = json.dumps(
             list(parent_capabilities), separators=(",", ":"),
+        )
+        env[image_cache.BUILDER_MIRRORS_ENV] = json.dumps(
+            list(registry_mirrors), separators=(",", ":"),
         )
         if boundary_path is not None:
             env[_ASSIGNMENT_BOUNDARY_ENV] = str(boundary_path)
@@ -4924,9 +5012,17 @@ def _run_worker_pool(args) -> int:
         cleanup_abort_file()
         return 1
     cleanup_abort_file()
+    environment_build_failures = [
+        (slot, rc) for slot, rc in returncodes
+        if rc == _ENVIRONMENT_BUILD_FAILED_EXIT_CODE
+    ]
     failed = [
         (slot, rc) for slot, rc in returncodes
         if rc not in (0, _WORKER_SLOT_QUARANTINED_EXIT_CODE)
+    ]
+    non_environment_failures = [
+        (slot, rc) for slot, rc in failed
+        if rc != _ENVIRONMENT_BUILD_FAILED_EXIT_CODE
     ]
     if not fleet_pool:
         _maintain_image_cache(client, cfg, phase="after worker pool")
@@ -4951,7 +5047,20 @@ def _run_worker_pool(args) -> int:
         if abort_interrupts_siblings:
             print(f"worker pool stopped cleanly by circuit breaker: {abort_reason}")
         else:
-            print(f"worker pool drained cleanly after account stop: {abort_reason}")
+            print(
+                "worker pool drained after "
+                + (
+                    "a shared environment build failure: "
+                    if abort_reason.startswith(_ENVIRONMENT_BUILD_ABORT_PREFIX)
+                    else "account stop: "
+                )
+                + abort_reason
+            )
+        if (
+            abort_reason.startswith(_ENVIRONMENT_BUILD_ABORT_PREFIX)
+            or (environment_build_failures and not non_environment_failures)
+        ):
+            return _ENVIRONMENT_BUILD_FAILED_EXIT_CODE
         return 0
     if backfill_error:
         print("worker pool finished after a backfill spawn error; completed uploads "
@@ -4963,6 +5072,12 @@ def _run_worker_pool(args) -> int:
             "failures; held assignments remain waiting for a later resume"
         )
         return 1
+    if environment_build_failures and not non_environment_failures:
+        print(
+            "worker pool needs attention after repeated isolated environment "
+            "build failures; held assignments remain retryable"
+        )
+        return _ENVIRONMENT_BUILD_FAILED_EXIT_CODE
     if failed:
         detail = ", ".join(f"worker {i}=exit {rc}" for i, rc in failed)
         print(f"worker pool finished with errors: {detail}")
@@ -5168,6 +5283,8 @@ def _run_batch(args, client: ApiClient, tasks_root: Path, active: list[dict],
                 "task checkout"
             )
             break
+    if "environment-build-failed" in results:
+        return _ENVIRONMENT_BUILD_FAILED_EXIT_CODE
     ok = all(o in _NON_FAULT_RUNNER_OUTCOMES for o in results)
     return 0 if ok else 1
 
@@ -5465,6 +5582,8 @@ def _run_checkout_loop(args, client: ApiClient, tasks_root: Path,
         if outcome == "failed" or outcome in _TERMINAL_LOCAL_OUTCOMES:
             failed_ids.add(assignment["assignment_id"])
         results.append(outcome)
+    if "environment-build-failed" in results:
+        return _ENVIRONMENT_BUILD_FAILED_EXIT_CODE
     ok = all(o in _NON_FAULT_RUNNER_OUTCOMES for o in results)
     return 0 if ok else 1
 

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -452,13 +452,78 @@ class BuildFlakeError(RunnerError):
 # would auto-retry a run that DID burn quota.
 _BUILD_FLAKE_MARKERS = (
     "ports.ubuntu.com", "archive.ubuntu.com", "failed to solve",
-    "apt-get update", "Temporary failure resolving", "proxyconnect",
-    "TLS handshake timeout", "error getting credentials",
+    "apt-get update", "temporary failure resolving", "proxyconnect",
+    "tls handshake timeout", "error getting credentials",
+    "no space left on device", "cannot connect to the docker daemon",
+)
+
+_BUILD_REGISTRY_MARKERS = (
+    "load metadata for", "resolve source metadata", "registry-1.docker.io",
+    "docker.io/library/", "failed to fetch anonymous token",
+)
+_BUILD_NETWORK_MARKERS = (
+    "i/o timeout", "deadline exceeded", "timed out", "timeout",
+    "network is unreachable", "connection refused", "no such host",
+    "temporary failure resolving", "tls handshake timeout", "proxyconnect",
 )
 
 
 def _looks_like_build_flake(log_tail: str) -> bool:
-    return any(m in log_tail for m in _BUILD_FLAKE_MARKERS)
+    low = log_tail.lower()
+    return bool(
+        any(marker in low for marker in _BUILD_FLAKE_MARKERS)
+        or (
+            any(marker in low for marker in _BUILD_REGISTRY_MARKERS)
+            and any(marker in low for marker in _BUILD_NETWORK_MARKERS)
+        )
+    )
+
+
+def environment_build_failure_diagnostic(
+    diagnostic_text: str, *, exit_status: int | None,
+) -> dict[str, object]:
+    """Return a bounded, credential-free pre-model build diagnosis."""
+
+    low = diagnostic_text.lower()
+    if "load metadata for" in low or "resolve source metadata" in low:
+        stage = "base_image_metadata"
+    elif "apt-get update" in low:
+        stage = "package_install"
+    elif "docker daemon" in low:
+        stage = "builder_start"
+    else:
+        stage = "image_build"
+    if "network is unreachable" in low or "connection refused" in low:
+        failure_code = "registry_network_unreachable"
+    elif "i/o timeout" in low or "deadline exceeded" in low or "timed out" in low:
+        failure_code = "registry_timeout"
+    elif "no such host" in low or "temporary failure resolving" in low:
+        failure_code = "registry_dns_failed"
+    elif "x509" in low or "tls handshake" in low:
+        failure_code = "registry_tls_failed"
+    elif "no space left on device" in low:
+        failure_code = "disk_space_exhausted"
+    elif "docker daemon" in low:
+        failure_code = "docker_daemon_unavailable"
+    else:
+        failure_code = "container_build_failed"
+    excerpt = image_cache.redact_docker_diagnostic(
+        diagnostic_text,
+        limit=1000,
+    )
+    return {
+        "schema": "dradar-environment-build-failure-v1",
+        "stage": stage,
+        "failure_code": failure_code,
+        "exit_status": (
+            int(exit_status)
+            if isinstance(exit_status, int) and not isinstance(exit_status, bool)
+            else None
+        ),
+        "model_started": False,
+        "quota_consumed": False,
+        "stderr_excerpt": excerpt,
+    }
 
 
 def _result_exception_text(result_path: Path | None) -> str:
@@ -4200,7 +4265,11 @@ def run_trial(
             raise BuildFlakeError(
                 f"the task environment failed to BUILD (mirror/network flake) — "
                 f"the agent never started and no quota was used.\n"
-                f"last lines of the log:\n{tail}")
+                f"last lines of the log:\n{tail}",
+                failure_diagnostic=environment_build_failure_diagnostic(
+                    tail, exit_status=proc.returncode,
+                ),
+            )
         raise
     patch, trajectory, result = trial_artifact_paths(trial_dir)
     if effective_agent == ZCODE_AGENT:
@@ -4245,7 +4314,11 @@ def run_trial(
             raise BuildFlakeError(
                 f"the task environment failed to BUILD (mirror/network flake) — "
                 f"the agent never started and no quota was used.\n"
-                f"build diagnostic:\n{_diagnostic_tail(diagnostic)}")
+                f"build diagnostic:\n{_diagnostic_tail(diagnostic)}",
+                failure_diagnostic=environment_build_failure_diagnostic(
+                    diagnostic, exit_status=proc.returncode,
+                ),
+            )
         raise RunnerError(
             f"model.patch missing (agent likely failed; see {log_path} and {trial_dir})\n"
             f"last lines of the log:\n{tail}",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,3 +51,11 @@ def _disable_live_egress_image_pull(monkeypatch):
         "ensure_egress_runtime_ready",
         lambda *_args, **_kwargs: dict(runtime),
     )
+    from dradar import image_cache
+    monkeypatch.setattr(
+        image_cache,
+        "preflight_trial_builder",
+        lambda *_args, **_kwargs: image_cache.TrialBuilderPreflight(
+            True, 0, "base_image_metadata", None, "", (),
+        ),
+    )

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -630,7 +630,7 @@ def test_checkout_loop_fuses_after_environment_build_failure(
 
     rc = runloop._go_menu(_args(), {}, client, tmp_path)
 
-    assert rc == 1
+    assert rc == 78
     assert client.checkout_exclusions == [set()]
     assert len(client._checkouts) == 1
     assert "before the next checkout" in capsys.readouterr().out

--- a/tests/test_feedback_round2.py
+++ b/tests/test_feedback_round2.py
@@ -190,26 +190,56 @@ def test_run_and_submit_retries_build_flake_once(monkeypatch, capsys, tmp_path):
     from test_go_menu import ASSIGNMENT, SubmitClient, _fake_art
     monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
     calls = {"n": 0}
+    credentials = (
+        "bearer-" + "T" * 48,
+        "basic-" + "U" * 48,
+    )
 
     def flaky_run(*a, **kw):
         calls["n"] += 1
         if calls["n"] == 1:
-            raise BuildFlakeError("mirror flake")
+            raise BuildFlakeError(
+                f"Authorization: Bearer {credentials[0]}",
+            )
         return _fake_art(tmp_path, rc=0)
 
     monkeypatch.setattr(runloop, "run_trial", flaky_run)
+    monkeypatch.setattr(
+        runloop.image_cache,
+        "cleanup_trial_resources",
+        lambda *_a, **_k: runloop.image_cache.TaskCleanupResult(
+            success=False,
+            note=f"Proxy-Authorization: Basic {credentials[1]}",
+        ),
+    )
     client = SubmitClient({})
-    tag = runloop._run_and_submit(client, ASSIGNMENT, tmp_path, _args(), "abc")
+    args = _args()
+    tag = runloop._run_and_submit(client, ASSIGNMENT, tmp_path, args, "abc")
     assert tag == "submitted" and calls["n"] == 2
-    assert "retrying once automatically" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "retrying once automatically" in output
+    assert all(output.find(value) == -1 for value in credentials)
+    assert all(
+        args._docker_cleanup_blocked.find(value) == -1
+        for value in credentials
+    )
+    assert "<redacted>" in args._docker_cleanup_blocked
 
 
 def test_run_and_submit_gives_up_after_second_flake(monkeypatch, capsys, tmp_path):
     from test_go_menu import ASSIGNMENT, SubmitClient
     monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
+    abort = tmp_path / "pool-abort"
+    monkeypatch.setenv(runloop._POOL_ABORT_ENV, str(abort))
+    credentials = (
+        "bearer-" + "V" * 48,
+        "basic-" + "W" * 48,
+    )
 
     def always_flaky(*a, **kw):
-        raise BuildFlakeError("mirror flake")
+        raise BuildFlakeError(
+            f"Authorization: Bearer {credentials[0]}, Basic {credentials[1]}",
+        )
 
     monkeypatch.setattr(runloop, "run_trial", always_flaky)
     client = SubmitClient({})
@@ -221,4 +251,252 @@ def test_run_and_submit_gives_up_after_second_flake(monkeypatch, capsys, tmp_pat
         ASSIGNMENT["assignment_id"],
         {"defer_seconds": 300, "failure_kind": "environment_build_failed"},
     )]
-    assert "failed twice" in capsys.readouterr().out
+    assert abort.read_text().startswith(
+        "drain:" + runloop._ENVIRONMENT_BUILD_ABORT_PREFIX
+    )
+    output = capsys.readouterr().out
+    assert "failed twice" in output
+    assert all(output.find(value) == -1 for value in credentials)
+
+
+def test_build_flake_retry_binds_started_once_per_logical_assignment(
+    monkeypatch, tmp_path,
+):
+    from test_go_menu import ASSIGNMENT
+
+    monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
+    monkeypatch.setenv(runloop._POOL_ABORT_ENV, str(tmp_path / "pool-abort"))
+    counts = {"run_trial": 0, "mark_started": 0, "mark_stopped": 0, "release": 0}
+
+    class LifecycleClient:
+        def mark_started(self, assignment_id, **kwargs):
+            counts["mark_started"] += 1
+            return {"owner_epoch": 7}
+
+        def mark_stopped(self, assignment_id, **kwargs):
+            counts["mark_stopped"] += 1
+            return {"ok": True}
+
+        def release_assignments(self, *args, **kwargs):
+            counts["release"] += 1
+            return {"released": 1}
+
+    def always_flaky(*args, on_started=None, **kwargs):
+        counts["run_trial"] += 1
+        assert on_started is not None
+        on_started()
+        raise BuildFlakeError(
+            "isolated environment build failed",
+            failure_diagnostic={"failure_code": "registry_timeout"},
+        )
+
+    monkeypatch.setattr(runloop, "run_trial", always_flaky)
+    monkeypatch.setattr(
+        runloop.image_cache,
+        "remove_trial_builder",
+        lambda *_a, **_k: (True, None),
+    )
+
+    outcome = runloop._run_and_submit(
+        LifecycleClient(), dict(ASSIGNMENT), tmp_path, _args(), "abc",
+    )
+
+    assert outcome == "environment-build-failed"
+    assert counts == {
+        "run_trial": 2,
+        "mark_started": 1,
+        "mark_stopped": 1,
+        "release": 0,
+    }
+
+
+def test_zcode_retry_rebinds_started_after_confirmed_stop(
+    monkeypatch, tmp_path,
+):
+    from test_go_menu import ASSIGNMENT, SubmitClient, _fake_art
+
+    monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
+    monkeypatch.setattr(runloop, "_ZCODE_NETWORK_RETRY_DELAY_SECONDS", 0)
+    counts = {"run_trial": 0, "mark_started": 0, "mark_stopped": 0}
+
+    class LifecycleClient(SubmitClient):
+        def mark_started(self, assignment_id, **kwargs):
+            counts["mark_started"] += 1
+            return {"owner_epoch": counts["mark_started"]}
+
+        def mark_stopped(self, assignment_id, **kwargs):
+            counts["mark_stopped"] += 1
+            return {"ok": True}
+
+    def network_then_success(*args, on_started=None, **kwargs):
+        counts["run_trial"] += 1
+        assert on_started is not None
+        on_started()
+        if counts["run_trial"] == 1:
+            raise RunnerError(
+                "structured ZCode transport failure",
+                failure_diagnostic={
+                    "schema": "dradar-runner-failure-v1",
+                    "zcode_provider_failure_reason": "network_error",
+                },
+            )
+        return _fake_art(
+            tmp_path,
+            rc=0,
+            zcode_cli_sha256="a" * 64,
+        )
+
+    monkeypatch.setattr(runloop, "run_trial", network_then_success)
+    monkeypatch.setattr(
+        runloop.image_cache,
+        "remove_trial_builder",
+        lambda *_a, **_k: (True, None),
+    )
+    monkeypatch.setattr(
+        runloop.image_cache,
+        "cleanup_trial_resources",
+        lambda *_a, **_k: runloop.image_cache.TaskCleanupResult(),
+    )
+    client = LifecycleClient({})
+    assignment = {**ASSIGNMENT, "agent": "zcode"}
+
+    outcome = runloop._run_and_submit(
+        client, assignment, tmp_path, _args(), "abc",
+    )
+
+    assert outcome == "submitted"
+    assert counts == {
+        "run_trial": 2,
+        "mark_started": 2,
+        "mark_stopped": 1,
+    }
+    assert len(client.submissions) == 1
+
+
+def test_zcode_retry_never_rebinds_when_stop_is_unconfirmed(
+    monkeypatch, tmp_path,
+):
+    from test_go_menu import ASSIGNMENT
+
+    monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
+    counts = {"run_trial": 0, "mark_started": 0, "mark_stopped": 0}
+
+    class LifecycleClient:
+        def mark_started(self, assignment_id, **kwargs):
+            counts["mark_started"] += 1
+            return {"owner_epoch": 1}
+
+    def network_failure(*args, on_started=None, **kwargs):
+        counts["run_trial"] += 1
+        assert counts["run_trial"] == 1, "unsafe second provider attempt"
+        assert on_started is not None
+        on_started()
+        raise RunnerError(
+            "structured ZCode transport failure",
+            failure_diagnostic={
+                "schema": "dradar-runner-failure-v1",
+                "zcode_provider_failure_reason": "network_error",
+            },
+        )
+
+    def stop_unconfirmed(*args, **kwargs):
+        counts["mark_stopped"] += 1
+        return False
+
+    monkeypatch.setattr(runloop, "run_trial", network_failure)
+    monkeypatch.setattr(runloop, "_mark_stopped_quietly", stop_unconfirmed)
+    monkeypatch.setattr(
+        runloop.image_cache,
+        "remove_trial_builder",
+        lambda *_a, **_k: (True, None),
+    )
+
+    outcome = runloop._run_and_submit(
+        LifecycleClient(),
+        {**ASSIGNMENT, "agent": "zcode"},
+        tmp_path,
+        _args(),
+        "abc",
+    )
+
+    assert outcome == "failed"
+    assert counts == {
+        "run_trial": 1,
+        "mark_started": 1,
+        "mark_stopped": 1,
+    }
+
+
+def test_mark_stopped_redacts_nested_failure_diagnostic_before_upload():
+    credentials = (
+        "bearer-" + "I" * 48,
+        "basic-" + "J" * 48,
+        "proxy-" + "K" * 48,
+        "config-" + "L" * 48,
+    )
+    captured = {}
+
+    class Client:
+        def mark_stopped(self, assignment_id, **kwargs):
+            captured["assignment_id"] = assignment_id
+            captured.update(kwargs)
+            return {"ok": True}
+
+    diagnostic = {
+        "schema": "dradar-environment-build-failure-v1",
+        "stderr_excerpt": (
+            f"Authorization: Bearer {credentials[0]}, Basic {credentials[1]}\n"
+            f"Proxy-Authorization: Basic {credentials[2]}"
+        ),
+        "nested": [{"auth": f'auth="{credentials[3]}"'}],
+    }
+
+    assert runloop._mark_stopped_quietly(
+        Client(),
+        "assignment-1",
+        failure_kind="environment_build_failed",
+        failure_diagnostic=diagnostic,
+    )
+    payload = repr(captured)
+    assert all(payload.find(value) == -1 for value in credentials)
+    assert "<redacted>" in payload
+
+
+def test_mark_stopped_redacts_sensitive_keys_even_for_opaque_values():
+    opaque_values = {
+        "auth": "opaque-auth-value",
+        "authorization": "opaque-authorization-value",
+        "access_token": "opaque-token-value",
+        "client-secret": "opaque-secret-value",
+        "password": "opaque-password-value",
+    }
+    captured = {}
+
+    class Client:
+        def mark_stopped(self, assignment_id, **kwargs):
+            captured.update(kwargs)
+            return {"ok": True}
+
+    diagnostic = {
+        "schema": "dradar-environment-build-failure-v1",
+        "failure_code": "registry_timeout",
+        "safe": {"stage": "base_image_metadata", "attempt": 2},
+        "credentials": opaque_values,
+    }
+
+    assert runloop._mark_stopped_quietly(
+        Client(),
+        "assignment-1",
+        failure_kind="environment_build_failed",
+        failure_diagnostic=diagnostic,
+    )
+    uploaded = captured["failure_diagnostic"]
+    payload = repr(uploaded)
+    assert all(value not in payload for value in opaque_values.values())
+    assert all(
+        uploaded["credentials"][key] == "<redacted>"
+        for key in opaque_values
+    )
+    assert uploaded["schema"] == diagnostic["schema"]
+    assert uploaded["failure_code"] == "registry_timeout"
+    assert uploaded["safe"] == diagnostic["safe"]

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -573,6 +573,48 @@ def test_structured_startup_failure_survives_parent_exit(
     ]
 
 
+def test_environment_build_exit_is_persisted_as_retryable_needs_attention(
+    tmp_path, monkeypatch,
+):
+    fleet._prepare_dirs(tmp_path)
+    state = fleet._initial_state("controller-1", None)
+    state["status"] = "active"
+    state["batches"][BATCH_A] = {
+        "batch_id": BATCH_A,
+        "workers": 40,
+        "status": "running",
+        "refill": True,
+        "plan_id": "plan-a",
+        "credentials_file": str(tmp_path / "plan-a.json"),
+    }
+    stopped = []
+    monkeypatch.setattr(
+        fleet,
+        "_stop_run_plan_device",
+        lambda item, reason: stopped.append((item["plan_id"], reason)),
+    )
+
+    fleet._settle_pool(
+        tmp_path,
+        state,
+        {BATCH_A: object()},
+        {BATCH_A: io.StringIO()},
+        BATCH_A,
+        fleet.ENVIRONMENT_BUILD_FAILED_EXIT_CODE,
+    )
+
+    item = state["batches"][BATCH_A]
+    assert item["status"] == "failed"
+    assert item["returncode"] == 78
+    assert item["failure_kind"] == "environment_build_failed"
+    assert item["failure_state"] == "needs_attention"
+    assert item["retryable"] is True
+    assert "model did not start" in item["detail"]
+    assert stopped == [(
+        "plan-a", "local isolated environment build failed before model start",
+    )]
+
+
 def test_refill_pool_command_keeps_exact_batch_and_total_cap(tmp_path, monkeypatch):
     fleet._prepare_dirs(tmp_path)
     captured = {}

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -11,6 +11,7 @@ import pytest
 PROJECT = "some-task__abc1234"
 MAIN_REF = f"{PROJECT}-main:latest"
 PROXY_REF = f"{PROJECT}-pier-egress-proxy:latest"
+_REAL_PREFLIGHT_TRIAL_BUILDER = image_cache.preflight_trial_builder
 
 
 def _inspect(reference=MAIN_REF, *, project=PROJECT, service="main", image_id="sha256:abc"):
@@ -99,7 +100,7 @@ def test_trial_builder_is_assignment_scoped_and_never_selected_globally(
 
     monkeypatch.setattr(image_cache, "_run_docker", run)
     lease = image_cache.prepare_trial_builder(
-        tmp_path, assignment_id="a1", runtime={},
+        tmp_path, assignment_id="a1", runtime={}, registry_mirrors=(),
     )
 
     assert lease.isolated and lease.name == image_cache.trial_builder_name(tmp_path, "a1")
@@ -131,6 +132,7 @@ def test_shared_trial_builder_is_bootstrapped_and_reusable(
     monkeypatch.setattr(image_cache, "_run_docker", run)
     lease = image_cache.prepare_trial_builder(
         tmp_path, assignment_id="a1", runtime={}, mode="shared",
+        registry_mirrors=(),
     )
 
     assert lease.isolated and lease.reusable
@@ -142,6 +144,7 @@ def test_shared_trial_builder_is_bootstrapped_and_reusable(
     calls.clear()
     second = image_cache.prepare_trial_builder(
         tmp_path / "other-harness", assignment_id="a2", runtime={}, mode="shared",
+        registry_mirrors=(),
     )
     assert second.name == lease.name and second.reusable
     assert [command for command in calls if "--bootstrap" in command] == []
@@ -175,6 +178,158 @@ def test_shared_build_cache_prune_targets_only_dradar_builder(
             "--max-used-space", str(50 * image_cache.GIB),
         ],
     ]
+
+
+def test_trial_builder_passes_only_valid_https_mirrors_to_buildkit(
+    tmp_path: Path, monkeypatch,
+):
+    calls = []
+    config = []
+
+    def run(command, **_kwargs):
+        calls.append(command)
+        if command[:2] == ["buildx", "inspect"]:
+            return subprocess.CompletedProcess(command, 1, "", "not found")
+        if command[:2] == ["buildx", "create"]:
+            path = Path(command[command.index("--buildkitd-config") + 1])
+            config.append(path.read_text(encoding="utf-8"))
+        return subprocess.CompletedProcess(command, 0, "ok", "")
+
+    monkeypatch.setattr(image_cache, "_run_docker", run)
+    lease = image_cache.prepare_trial_builder(
+        tmp_path,
+        assignment_id="a1",
+        runtime={},
+        registry_mirrors=("https://mirror.example",),
+    )
+
+    assert lease.isolated
+    assert "--buildkitd-config" in calls[-1]
+    assert config == [
+        (
+            '[registry."docker.io"]\n'
+            '  mirrors = ["https://mirror.example"]\n'
+        )
+    ]
+
+
+@pytest.mark.parametrize("mirror", [
+    "http://mirror.example",
+    "https://user:secret@mirror.example",
+    "ftp://mirror.example",
+    "https://mirror.example?token=secret",
+])
+def test_trial_builder_rejects_insecure_or_credentialed_mirror(
+    tmp_path: Path, monkeypatch, mirror,
+):
+    monkeypatch.setattr(
+        image_cache,
+        "_run_docker",
+        lambda *_a, **_k: pytest.fail("invalid mirror must fail before Docker"),
+    )
+
+    lease = image_cache.prepare_trial_builder(
+        tmp_path,
+        assignment_id="a1",
+        runtime={},
+        registry_mirrors=(mirror,),
+    )
+
+    assert not lease.isolated
+    assert "HTTPS" in (lease.note or "")
+
+
+def test_builder_preflight_preserves_stage_exit_and_redacted_stderr(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(
+        image_cache, "preflight_trial_builder", _REAL_PREFLIGHT_TRIAL_BUILDER,
+    )
+    removed = []
+    monkeypatch.setattr(
+        image_cache,
+        "prepare_trial_builder",
+        lambda *_a, **_k: image_cache.TrialBuilderLease("probe", True),
+    )
+    monkeypatch.setattr(
+        image_cache,
+        "remove_trial_builder",
+        lambda home, assignment_id: removed.append((home, assignment_id))
+        or (True, None),
+    )
+    monkeypatch.setattr(
+        image_cache,
+        "_run_docker",
+        lambda command, **_kwargs: subprocess.CompletedProcess(
+            command,
+            1,
+            "",
+            "load metadata for docker.io/library/node:22-bookworm\n"
+            "Head https://user:secret@registry-1.docker.io/v2/token: "
+            "network is unreachable",
+        ),
+    )
+
+    result = image_cache.preflight_trial_builder(
+        tmp_path, registry_mirrors=(),
+    )
+
+    assert not result.ok
+    assert result.returncode == 1
+    assert result.stage == "base_image_metadata"
+    assert result.failure_code == "registry_network_unreachable"
+    assert "secret" not in result.detail
+    assert "https://" not in result.detail
+    assert len(removed) == 1
+
+
+def test_docker_diagnostic_redacts_multisegment_auth_values():
+    credentials = (
+        "bearer-" + "A" * 48,
+        "basic-" + "B" * 48,
+        "proxy-" + "C" * 48,
+        "config-" + "D" * 48,
+        "challenge-" + "M" * 48,
+        "fallback-" + "N" * 48,
+    )
+    diagnostic = "\n".join((
+        f"Authorization: Bearer {credentials[0]}, Basic {credentials[1]}",
+        f"Proxy-Authorization: Basic {credentials[2]}",
+        f'client response {{"auth":"{credentials[3]}"}}',
+        f"registry challenge Bearer {credentials[4]}; Basic {credentials[5]}",
+    ))
+
+    redacted = image_cache.redact_docker_diagnostic(diagnostic)
+
+    assert all(value not in redacted for value in credentials)
+    assert redacted.count("<redacted>") >= 3
+
+
+def test_preflight_redacts_docker_info_failure_before_returning_detail(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(
+        image_cache, "preflight_trial_builder", _REAL_PREFLIGHT_TRIAL_BUILDER,
+    )
+    credentials = ("bearer-" + "E" * 48, "basic-" + "F" * 48)
+    monkeypatch.setattr(
+        image_cache,
+        "_run_docker",
+        lambda command, **_kwargs: subprocess.CompletedProcess(
+            command,
+            1,
+            "",
+            "docker info failed\n"
+            f"Authorization: Bearer {credentials[0]}, Basic {credentials[1]}",
+        ),
+    )
+
+    result = image_cache.preflight_trial_builder(tmp_path)
+
+    assert not result.ok
+    assert result.stage == "registry_configuration"
+    assert all(value not in result.detail for value in credentials)
+    assert "<redacted>" in result.detail
 
 
 def test_trial_builder_falls_back_without_exposing_loopback_proxy(
@@ -266,6 +421,55 @@ def test_remove_trial_builder_deletes_only_deterministic_assignment_builder(
         ["buildx", "inspect", name],
         ["buildx", "rm", name],
     ]
+
+
+@pytest.mark.parametrize("output_channel", ["stderr", "stdout"])
+def test_remove_trial_builder_redacts_failed_cleanup_output(
+    tmp_path: Path, monkeypatch, output_channel,
+):
+    credentials = ("bearer-" + "P" * 48, "basic-" + "Q" * 48)
+
+    def run(command, **_kwargs):
+        if command[1] == "inspect":
+            return subprocess.CompletedProcess(command, 0, "", "")
+        output = (
+            f"Proxy-Authorization: Bearer {credentials[0]}, "
+            f"Basic {credentials[1]}"
+        )
+        return subprocess.CompletedProcess(
+            command,
+            1,
+            output if output_channel == "stdout" else "",
+            output if output_channel == "stderr" else "",
+        )
+
+    monkeypatch.setattr(image_cache, "_run_docker", run)
+
+    removed, detail = image_cache.remove_trial_builder(tmp_path, "a1")
+
+    assert not removed
+    assert detail is not None
+    assert all(value not in detail for value in credentials)
+    assert "<redacted>" in detail
+
+
+def test_remove_trial_builder_redacts_docker_unavailable(
+    tmp_path: Path, monkeypatch,
+):
+    credential = "opaque-" + "Z" * 48
+    monkeypatch.setattr(
+        image_cache,
+        "_run_docker",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            image_cache.DockerUnavailable(f"Authorization: Bearer {credential}")
+        ),
+    )
+
+    removed, detail = image_cache.remove_trial_builder(tmp_path, "a1")
+
+    assert not removed
+    assert credential not in (detail or "")
+    assert "<redacted>" in (detail or "")
 
 
 def test_invalid_trial_name_never_queries_docker(tmp_path: Path, monkeypatch):
@@ -443,6 +647,56 @@ def test_task_cleanup_refuses_a_directory_outside_managed_jobs(
 
     assert not result.success
     assert "不属于 DRadar" in result.note
+
+
+def test_task_cleanup_diagnostics_are_fairly_bounded_across_sources(
+    tmp_path: Path, monkeypatch,
+):
+    assignment_id = "a1"
+    job_dir = tmp_path / "work" / "jobs" / f"a{assignment_id}"
+    trial_dir = job_dir / PROJECT
+    trial_dir.mkdir(parents=True)
+    secret = "never-expose-this-token"
+    runtime_detail = "runtime-marker " + ("r" * 500) + f" token={secret}"
+    image_detail = "image-marker " + ("i" * 500) + f" password={secret}"
+    builder_detail = "builder-marker " + ("b" * 500) + f" secret={secret}"
+
+    monkeypatch.setattr(
+        image_cache,
+        "_remove_project_runtime",
+        lambda *_a: (_ for _ in ()).throw(
+            image_cache.DockerUnavailable(runtime_detail)
+        ),
+    )
+    monkeypatch.setattr(
+        image_cache,
+        "remove_assignment_images",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            image_cache.DockerUnavailable(image_detail)
+        ),
+    )
+    monkeypatch.setattr(
+        image_cache,
+        "remove_trial_builder",
+        lambda *_a, **_k: (False, builder_detail),
+    )
+
+    result = image_cache.cleanup_trial_resources(
+        tmp_path,
+        assignment_id=assignment_id,
+        job_dir=job_dir,
+        trial_name=PROJECT,
+        builder_isolated=True,
+    )
+
+    assert not result.success
+    assert result.note is not None
+    assert len(result.note) <= 1200
+    assert "运行环境清理失败" in result.note
+    assert "题目镜像检查失败" in result.note
+    assert "临时构建空间清理失败" in result.note
+    assert secret not in result.note
+    assert result.note.count("<redacted>") == 3
 
 
 def test_remove_revalidates_id_and_never_uses_force(monkeypatch):

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -2042,6 +2042,34 @@ def test_run_trial_classifies_build_failure_from_nested_result(tmp_path, monkeyp
     assert "failed to solve" in str(exc.value)
 
 
+def test_registry_io_timeout_is_a_build_failure_with_bounded_diagnostic():
+    credentials = (
+        "bearer-" + "G" * 48,
+        "basic-" + "H" * 48,
+    )
+    output = (
+        "#3 [internal] load metadata for docker.io/library/node:22-bookworm\n"
+        f"Authorization: Bearer {credentials[0]}, Basic {credentials[1]}\n"
+        "Head https://registry-1.docker.io/v2/: "
+        "dial tcp 203.0.113.10:443: i/o timeout"
+    )
+
+    assert runner_mod._looks_like_build_flake(output)
+    diagnostic = runner_mod.environment_build_failure_diagnostic(
+        output, exit_status=1,
+    )
+
+    assert diagnostic["stage"] == "base_image_metadata"
+    assert diagnostic["failure_code"] == "registry_timeout"
+    assert diagnostic["exit_status"] == 1
+    assert diagnostic["model_started"] is False
+    assert all(
+        diagnostic["stderr_excerpt"].find(value) == -1
+        for value in credentials
+    )
+    assert "https://" not in diagnostic["stderr_excerpt"]
+
+
 def test_run_trial_missing_patch_message_includes_log_tail(tmp_path, monkeypatch):
     captured = {}
     def fake_build(assignment, tasks_root, jobs_dir, job_name, home, dev_agent=None):

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -511,6 +511,74 @@ def _patch_pool_setup(monkeypatch, active_count=5):
     )
 
 
+def test_isolated_builder_preflight_fails_before_batch_or_worker_session(
+    monkeypatch, capsys,
+):
+    _patch_pool_setup(monkeypatch, active_count=40)
+    monkeypatch.setattr(
+        runloop.image_cache,
+        "preflight_trial_builder",
+        lambda *_a, **_k: runloop.image_cache.TrialBuilderPreflight(
+            False,
+            1,
+            "base_image_metadata",
+            "registry_timeout",
+            "load metadata for docker.io/library/node:22-bookworm: i/o timeout",
+            (),
+        ),
+    )
+    monkeypatch.setattr(
+        runloop,
+        "_prepare_batch",
+        lambda *_a, **_k: pytest.fail("preflight must happen before batch preparation"),
+    )
+    monkeypatch.setattr(
+        runloop.subprocess,
+        "Popen",
+        lambda *_a, **_k: pytest.fail("preflight must happen before worker sessions"),
+    )
+
+    rc = runloop._run_worker_pool(_args(workers=40))
+
+    assert rc == runloop._ENVIRONMENT_BUILD_FAILED_EXIT_CODE
+    output = capsys.readouterr().out
+    assert "before worker sessions or task checkout" in output
+    assert "stage=base_image_metadata" in output
+    assert "exit=1" in output
+
+
+def test_pool_children_inherit_the_preflighted_https_mirror_snapshot(monkeypatch):
+    _patch_pool_setup(monkeypatch, active_count=2)
+    monkeypatch.setattr(
+        runloop.image_cache,
+        "preflight_trial_builder",
+        lambda *_a, **_k: runloop.image_cache.TrialBuilderPreflight(
+            True,
+            0,
+            "base_image_metadata",
+            None,
+            "",
+            ("https://mirror.example",),
+        ),
+    )
+    calls = []
+    monkeypatch.setattr(
+        runloop.subprocess,
+        "Popen",
+        lambda command, env, **kwargs: (
+            calls.append(_Process(command, env, **kwargs)) or calls[-1]
+        ),
+    )
+
+    assert runloop._run_worker_pool(_args(workers=2)) == 0
+    assert len(calls) == 2
+    assert all(
+        process.env[runloop.image_cache.BUILDER_MIRRORS_ENV]
+        == '["https://mirror.example"]'
+        for process in calls
+    )
+
+
 def test_auto_workers_use_capacity_recommendation(monkeypatch, capsys):
     _patch_pool_setup(monkeypatch, active_count=5)
     from dradar.capacity import CapacityReport
@@ -1749,9 +1817,11 @@ def test_pool_abort_never_restores_a_worker(monkeypatch):
         polls = [None, 0]
         if len(calls) == 1:
             polls = [0]
-            on_poll = lambda: runloop.Path(
-                env["DRADAR_POOL_ABORT_FILE"]
-            ).write_text("account stop")
+
+            def on_poll():
+                runloop.Path(env["DRADAR_POOL_ABORT_FILE"]).write_text(
+                    "account stop",
+                )
         process = _ScriptedProcess(
             command, env, polls, on_poll=on_poll, **kwargs,
         )
@@ -1798,7 +1868,49 @@ def test_pool_drain_keeps_active_siblings_running_without_backfill(
     assert len(calls) == 2
     out = capsys.readouterr().out
     assert "active workers will finish" in out
-    assert "drained cleanly" in out
+    assert "worker pool drained after account stop" in out
+
+
+def test_environment_build_drain_keeps_siblings_and_returns_distinct_failure(
+        monkeypatch, capsys):
+    _patch_pool_setup(monkeypatch, active_count=2)
+    monkeypatch.setattr(runloop.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        runloop, "_pool_ready_work_count",
+        lambda _client: pytest.fail("environment drain must not backfill"),
+    )
+    monkeypatch.setattr(
+        runloop, "_signal_workers",
+        lambda _processes: pytest.fail("environment drain must not signal siblings"),
+    )
+    calls = []
+
+    def popen(command, env, **kwargs):
+        if not calls:
+            def mark_environment_drain():
+                runloop.Path(env["DRADAR_POOL_ABORT_FILE"]).write_text(
+                    "drain:environment build unavailable: registry timeout",
+                )
+
+            process = _ScriptedProcess(
+                command,
+                env,
+                [runloop._ENVIRONMENT_BUILD_FAILED_EXIT_CODE],
+                on_poll=mark_environment_drain,
+                **kwargs,
+            )
+        else:
+            process = _ScriptedProcess(command, env, [None, 0], **kwargs)
+        calls.append(process)
+        return process
+
+    monkeypatch.setattr(runloop.subprocess, "Popen", popen)
+
+    assert runloop._run_worker_pool(_args(workers=2)) == 78
+    assert len(calls) == 2
+    out = capsys.readouterr().out
+    assert "active workers will finish" in out
+    assert "shared environment build failure" in out
 
 
 def test_scoped_plan_drain_with_lost_upload_settles_as_recoverable_failure(


### PR DESCRIPTION
## 目标

修复隔离环境构建反复失败时继续补位/重试的问题：在模型启动前预检基础镜像，构建失败使用可区分的非零退出码，安全停止并回传脱敏诊断；停止确认失败时禁止二次模型尝试。

## 范围

- 仅包含已独立 QA 的 11 文件稳定候选
- 基线：`origin/main@9712e6cfd2a2ff2b571fc0a6372dba907c928768`
- diff SHA-256：`dd08e5d1fc31390d2cd22aa5969cb4d5f087693d48cdda65ad2fbb6a886fb3ad`
- 不包含版本号、账号/OAuth、runner 并发、真实凭据或 Cloudflare 变更

## 验证

- `uv run --extra dev pytest -q` → 1409 passed
- `python -m py_compile ...` → passed
- `git diff --check` → passed
- `uv build` → sdist/wheel built
- `uvx --from . dradar --version` → 0.5.175
- 敏感信息扫描命中仅为测试用合成凭据与脱敏断言

## 回滚

如正式验证异常，基于本 PR 的单一提交 `b2b5cf70e3e49aca3076229ac21dbd3c52e585c4` 创建反向提交并走同样 PR/测试门槛；不 force push、不重写 main。