### PR TITLE
fix: classify Antigravity terminal failures locally

### DIFF
--- a/src/dradar/pier_antigravity.py
+++ b/src/dradar/pier_antigravity.py
@@ -97,6 +97,42 @@ def _usage_values(value: object) -> dict[str, int] | None:
     }
 
 
+def _antigravity_terminal_error_category(
+    terminal_status: object, terminal_error: object,
+) -> str | None:
+    """Reduce provider text to a credential-free, fixed diagnostic enum."""
+
+    if terminal_status == "SUCCESS":
+        return None
+    if terminal_status == "CANCELED":
+        return "canceled"
+    if terminal_status == "INTERRUPTED":
+        return "interrupted"
+    if terminal_status == "INVALID":
+        return "invalid"
+    if terminal_status != "ERROR":
+        return None
+    if terminal_error == ANTIGRAVITY_STREAM_INTERRUPTED_MESSAGE:
+        return "stream-interrupted"
+    low = terminal_error.casefold() if isinstance(terminal_error, str) else ""
+    if (
+        "eligibility check failed" in low
+        and "not eligible for antigravity" in low
+        and "not currently available in your location" in low
+    ):
+        return "eligibility-location"
+    if any(marker in low for marker in (
+        "individual quota reached",
+        "quota exhausted",
+        "quota exceeded",
+        "usage limit reached",
+        "you've hit your usage limit",
+        "you have hit your usage limit",
+    )):
+        return "quota-limit"
+    return "provider-error"
+
+
 def _antigravity_usage_facts(
     events: list[dict], *, expected_runtime_model: str,
 ) -> dict[str, object]:
@@ -226,6 +262,14 @@ def _antigravity_usage_facts(
     }
     terminal_response = terminal.get("response") if terminal is not None else None
     terminal_error = terminal.get("error") if terminal is not None else None
+    terminal_error_category = _antigravity_terminal_error_category(
+        terminal_status, terminal_error,
+    )
+    if terminal_error_category is not None:
+        # Never preserve the provider's raw error here. It may contain account,
+        # location, prompt, or request details; the fixed enum is sufficient for
+        # local outcome handling and authenticated operator diagnostics.
+        facts["terminal_error_category"] = terminal_error_category
     if (
         reconciled
         and terminal_status == "ERROR"

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -172,6 +172,39 @@ _POOL_SESSION_CAPACITY_RETRY_SECONDS = 10 * 60
 _POOL_IMAGE_CACHE_MAINTENANCE_SECONDS = 15 * 60
 _POOL_TARGET_CACHE: dict[Path, int] = {}
 _ZCODE_NETWORK_RETRY_DELAY_SECONDS = 2.0
+_ANTIGRAVITY_TERMINAL_RECOVERY_SCHEMA = (
+    "dradar-antigravity-terminal-recovery-v1"
+)
+_ANTIGRAVITY_TERMINAL_ERROR_CATEGORIES = {
+    "canceled",
+    "eligibility-location",
+    "interrupted",
+    "invalid",
+    "provider-error",
+    "quota-limit",
+    "stream-interrupted",
+}
+_ANTIGRAVITY_USAGE_SIDECAR_KEYS = {
+    "complete",
+    "model",
+    "n_cache_tokens",
+    "n_input_tokens",
+    "n_output_tokens",
+    "provider",
+    "provider_runtime_model",
+    "request_count",
+    "request_usage_complete",
+    "request_usage_observed",
+    "schema",
+    "terminal_error_category",
+    "terminal_recovery",
+    "terminal_status",
+    "thinking_tokens",
+    "timed_usage_complete",
+    "token_usage_events",
+    "usage_evidence_tier",
+    "usage_incomplete_reason",
+}
 
 
 def _retryable_zcode_network_failure(assignment: dict, exc: RunnerError) -> bool:
@@ -1147,6 +1180,50 @@ def _dsh_trial_usage(trial_dir: Path) -> dict | None:
     }
 
 
+def _antigravity_recovery_candidate(usage: dict) -> bool:
+    """Validate only the client-side shape; the server still binds artifacts."""
+
+    evidence = usage.get("terminal_recovery")
+    response_sha256 = (
+        evidence.get("response_sha256") if isinstance(evidence, dict) else None
+    )
+    return bool(
+        isinstance(evidence, dict)
+        and set(evidence) == {"schema", "reason", "response_sha256"}
+        and evidence.get("schema") == _ANTIGRAVITY_TERMINAL_RECOVERY_SCHEMA
+        and evidence.get("reason") == "stream_interrupted_after_final_response"
+        and isinstance(response_sha256, str)
+        and re.fullmatch(r"[0-9a-f]{64}", response_sha256)
+        and usage.get("terminal_status") == "ERROR"
+        and usage.get("complete") is True
+        and usage.get("request_usage_complete") is True
+        and usage.get("request_usage_observed") is True
+    )
+
+
+def _antigravity_terminal_observation(
+    trial_dir: Path, antigravity_cli_version: str | None,
+) -> tuple[bool, str | None]:
+    """Return (terminal failure, safe category) from a validated sidecar."""
+
+    if antigravity_cli_version is None:
+        return False, None
+    usage = _subscription_trial_usage(
+        trial_dir, {"antigravity_cli_version": antigravity_cli_version},
+    )
+    if usage is None:
+        # The pinned adapter always emits this sidecar. Missing or malformed
+        # evidence cannot turn an unknown official terminal into success.
+        return True, None
+    terminal_status = usage.get("terminal_status")
+    category = usage.get("terminal_error_category")
+    if terminal_status == "SUCCESS":
+        return False, None
+    if terminal_status == "ERROR" and _antigravity_recovery_candidate(usage):
+        return False, category if isinstance(category, str) else None
+    return True, category if isinstance(category, str) else None
+
+
 def _subscription_trial_usage(trial_dir: Path, meta: dict) -> dict | None:
     """Read normalized usage or a structurally checked observed ledger."""
 
@@ -1171,6 +1248,49 @@ def _subscription_trial_usage(trial_dir: Path, meta: dict) -> dict | None:
         or value.get("provider") != expected_provider
     ):
         return None
+    if expected_provider == "antigravity":
+        if set(value) - _ANTIGRAVITY_USAGE_SIDECAR_KEYS:
+            # The Antigravity upload contract intentionally has no free-form
+            # terminal/provider text fields. Unknown additions fail closed so
+            # raw account, location, prompt, or request content cannot hitch a
+            # ride through the embedded provider-usage object.
+            return None
+        terminal_status = value.get("terminal_status")
+        terminal_error_category = value.get("terminal_error_category")
+        allowed_categories = {
+            "SUCCESS": set(),
+            "ERROR": {
+                "eligibility-location", "provider-error", "quota-limit",
+                "stream-interrupted",
+            },
+            "CANCELED": {"canceled"},
+            "INTERRUPTED": {"interrupted"},
+            "INVALID": {"invalid"},
+        }
+        # Sidecars produced before this diagnostic field was introduced remain
+        # upload-compatible. Once present, however, the value must be one of
+        # the fixed status-bound enums; arbitrary provider/user text is rejected.
+        if (
+            "terminal_error_category" in value
+            and (
+                not isinstance(terminal_status, str)
+                or not isinstance(terminal_error_category, str)
+                or terminal_status not in allowed_categories
+                or terminal_error_category
+                not in allowed_categories[terminal_status]
+                or terminal_error_category
+                not in _ANTIGRAVITY_TERMINAL_ERROR_CATEGORIES
+            )
+        ):
+            return None
+        recovery = value.get("terminal_recovery")
+        if recovery is not None and not _antigravity_recovery_candidate(value):
+            return None
+        if (
+            recovery is not None
+            and terminal_error_category not in {None, "stream-interrupted"}
+        ):
+            return None
     complete = value.get("complete") is True
     incomplete_reason = value.get("usage_incomplete_reason")
     allowed_incomplete_reasons = {
@@ -1809,7 +1929,7 @@ def _upload_trial(
             "cache_creation_tokens", "subscription_reported_cost_usd",
             "subscription_reported_cost_basis", "resume_attempts",
             "thinking_tokens", "provider_runtime_model", "terminal_status",
-            "terminal_recovery",
+            "terminal_error_category", "terminal_recovery",
         ):
             source_key = "sessions" if key == "agent_session_usage" else key
             if source_key in usage:
@@ -2802,6 +2922,11 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
         print(f"  -> {args._docker_cleanup_blocked}")
 
     stats = summarize_result(art.result)
+    antigravity_terminal_failure, antigravity_terminal_category = (
+        _antigravity_terminal_observation(
+            art.trial_dir, art.antigravity_cli_version,
+        )
+    )
     # A recorded agent exception is always interrupted. A nonzero outer Pier
     # rc may happen after the agent completed and the task hook harvested its
     # patch. Accept that paid work only with independent DSH terminal evidence
@@ -2835,8 +2960,10 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
             assignment, art.trial_dir, art.patch, art.result,
         )
     postrun_completion = dsh_completion or grok_completion or bundled_completion
-    interrupted = bool(stats.get("exception_info")) or (
-        art.returncode != 0 and postrun_completion is None
+    interrupted = (
+        bool(stats.get("exception_info"))
+        or (art.returncode != 0 and postrun_completion is None)
+        or antigravity_terminal_failure
     )
     diag = diagnose_exception(art.result) if interrupted else {}
     failure_kind = diag.get("kind")
@@ -2846,6 +2973,8 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
         and _agent_exit_code(diag) is not None
     ):
         failure_kind = "agent-command-failed"
+    if failure_kind is None and antigravity_terminal_failure:
+        failure_kind = "agent-terminal-failure"
     repeat_failure = (
         _repeat_failure_signature(assignment, stats, diag, art)
         if interrupted and failure_kind == "agent-command-failed"
@@ -2878,6 +3007,11 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
             advice = DIAG_ADVICE.get(diag.get("kind"))
             if advice:
                 print(f"  -> {advice}")
+        elif antigravity_terminal_category is not None:
+            print(
+                "the official Antigravity terminal did not complete "
+                f"({antigravity_terminal_category})"
+            )
         else:
             print(f"no exception recorded; see the pier log: {art.log_path}")
 

--- a/tests/test_antigravity_subscription.py
+++ b/tests/test_antigravity_subscription.py
@@ -180,7 +180,10 @@ def test_antigravity_task_overlay_accepts_reviewed_pompeii_base_tag(
 def _usage_helper():
     source = Path(providers.__file__).with_name("pier_antigravity.py").read_text()
     module = ast.parse(source)
-    names = {"_nonnegative_int", "_usage_values", "_antigravity_usage_facts"}
+    names = {
+        "_nonnegative_int", "_usage_values",
+        "_antigravity_terminal_error_category", "_antigravity_usage_facts",
+    }
     helpers = [
         node for node in module.body
         if isinstance(node, ast.FunctionDef) and node.name in names
@@ -688,6 +691,7 @@ def test_stream_interrupted_after_final_response_emits_bound_recovery_evidence()
 
     assert facts["complete"] is True
     assert facts["terminal_status"] == "ERROR"
+    assert facts["terminal_error_category"] == "stream-interrupted"
     assert facts["terminal_recovery"] == {
         "schema": "dradar-antigravity-terminal-recovery-v1",
         "reason": "stream_interrupted_after_final_response",
@@ -726,7 +730,36 @@ def test_other_antigravity_errors_never_emit_recovery_evidence(mutation: str) ->
     facts = helper(events, expected_runtime_model=runtime)
 
     assert facts["complete"] is True
+    assert facts["terminal_error_category"] == (
+        "provider-error" if mutation == "different-error" else "stream-interrupted"
+    )
     assert "terminal_recovery" not in facts
+
+
+def test_terminal_error_category_is_allowlisted_and_drops_sensitive_text() -> None:
+    helper = _usage_helper()
+    runtime = ANTIGRAVITY_RUNTIME_MODELS["high"]
+    usage = _usage(1, 1, 0, 0)
+    private_error = (
+        "Eligibility check failed: account secret@example.invalid is not "
+        "eligible for Antigravity, because it is not currently available in "
+        "your location. request=private-request-body"
+    )
+    facts = helper([
+        {"event": "init", "init": {
+            "model": runtime, "cwd": "/app", "permission_mode": "always-proceed",
+        }},
+        {"event": "result", "result": {
+            "status": "ERROR", "num_turns": 0, "usage": usage,
+            "response": "", "error": private_error,
+        }},
+    ], expected_runtime_model=runtime)
+
+    assert facts["terminal_error_category"] == "eligibility-location"
+    serialized = json.dumps(facts)
+    assert "secret@example.invalid" not in serialized
+    assert "private-request-body" not in serialized
+    assert "not currently available" not in serialized
 
 
 def test_official_cache_can_exceed_uncached_input_and_still_reconcile() -> None:

--- a/tests/test_go_menu.py
+++ b/tests/test_go_menu.py
@@ -12,6 +12,10 @@ import pytest
 from dradar import runloop
 from dradar.api_client import ApiError
 from dradar.providers import (
+    ANTIGRAVITY_AGENT,
+    ANTIGRAVITY_CLI_VERSION,
+    ANTIGRAVITY_MODEL,
+    ANTIGRAVITY_PROVIDER,
     DEEPSEEK_CATALOG_SHA256,
     DEEPSEEK_RUN_CONFIG_VERSION,
     DEEPSEEK_RUNTIME_PROFILE,
@@ -580,6 +584,41 @@ def _fake_art(base: Path, rc: int = 0, result_data: dict | None = None,
                           zcode_cli_sha256=zcode_cli_sha256)
 
 
+def _write_antigravity_sidecar(
+    art: TrialArtifacts, *, status: str, category: str | None,
+) -> None:
+    art.codex_cli_version = None
+    art.antigravity_cli_version = ANTIGRAVITY_CLI_VERSION
+    payload = {
+        "schema": "dradar-subscription-provider-usage-v1",
+        "provider": "antigravity",
+        "model": ANTIGRAVITY_MODEL,
+        "complete": True,
+        "request_count": 1,
+        "n_input_tokens": 10,
+        "n_cache_tokens": 4,
+        "n_output_tokens": 2,
+        "thinking_tokens": 1,
+        "request_usage_complete": True,
+        "request_usage_observed": True,
+        "timed_usage_complete": False,
+        "usage_incomplete_reason": None,
+        "usage_evidence_tier": "complete_reconciled",
+        "token_usage_events": [{
+            "n_input_tokens": 10,
+            "n_cache_tokens": 4,
+            "n_output_tokens": 2,
+            "thinking_tokens": 1,
+        }],
+        "terminal_status": status,
+    }
+    if category is not None:
+        payload["terminal_error_category"] = category
+    agent = art.trial_dir / "agent"
+    agent.mkdir(exist_ok=True)
+    (agent / "provider-usage.json").write_text(json.dumps(payload))
+
+
 def test_clean_run_submits_outcome_completed(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
     art = _fake_art(tmp_path, rc=0)
@@ -589,6 +628,40 @@ def test_clean_run_submits_outcome_completed(monkeypatch, tmp_path: Path):
     assert tag == "submitted"
     assert client.submissions[0]["outcome"] == "completed"
     assert client.submissions[0]["meta"]["codex_cli_version"] == "0.145.0"
+
+
+def test_antigravity_official_error_with_clean_pier_submits_interrupted(
+    monkeypatch, tmp_path: Path, capsys,
+) -> None:
+    monkeypatch.setattr(runloop, "HOME", tmp_path / "home")
+    art = _fake_art(tmp_path, rc=0)
+    _write_antigravity_sidecar(
+        art, status="ERROR", category="provider-error",
+    )
+    monkeypatch.setattr(runloop, "run_trial", lambda *a, **kw: art)
+    client = SubmitClient({})
+    assignment = {
+        **ASSIGNMENT,
+        "agent": ANTIGRAVITY_AGENT,
+        "provider": ANTIGRAVITY_PROVIDER,
+        "model": ANTIGRAVITY_MODEL,
+        "effort": "low",
+        "agent_version": ANTIGRAVITY_CLI_VERSION,
+    }
+
+    tag = runloop._run_and_submit(
+        client, assignment, tmp_path, _args(), "abc123",
+    )
+
+    assert tag == "interrupted"
+    submission = client.submissions[0]
+    assert submission["outcome"] == "interrupted"
+    assert submission["meta"]["terminal_status"] == "ERROR"
+    assert submission["meta"]["terminal_error_category"] == "provider-error"
+    assert submission["meta"]["failure_kind"] == "agent-terminal-failure"
+    output = capsys.readouterr().out
+    assert "outcome=invalid/not-graded" in output
+    assert "official Antigravity terminal did not complete (provider-error)" in output
 
 
 def test_submission_attests_observed_zcode_cli_sha256(monkeypatch, tmp_path: Path):

--- a/tests/test_subscription_usage.py
+++ b/tests/test_subscription_usage.py
@@ -4,7 +4,141 @@ from __future__ import annotations
 
 import json
 
-from dradar.runloop import _subscription_trial_usage
+import pytest
+
+from dradar.runloop import (
+    _antigravity_terminal_observation,
+    _subscription_trial_usage,
+)
+
+
+def _antigravity_payload(
+    *, status: str, category: str | None = None, complete: bool = True,
+    recovery: dict | None = None,
+) -> dict:
+    request_count = 1 if complete else 0
+    payload = {
+        "schema": "dradar-subscription-provider-usage-v1",
+        "provider": "antigravity",
+        "model": "gemini-3.7-flash",
+        "provider_runtime_model": "gemini-3.7-flash-low",
+        "complete": complete,
+        "request_count": request_count,
+        "n_input_tokens": 10 if complete else 0,
+        "n_cache_tokens": 4 if complete else 0,
+        "n_output_tokens": 2 if complete else 0,
+        "thinking_tokens": 1 if complete else 0,
+        "request_usage_complete": complete,
+        "request_usage_observed": complete,
+        "timed_usage_complete": False,
+        "usage_incomplete_reason": (
+            None if complete else "request_ledger_unavailable_or_invalid"
+        ),
+        "usage_evidence_tier": (
+            "complete_reconciled" if complete else "unavailable"
+        ),
+        "token_usage_events": ([{
+            "n_input_tokens": 10,
+            "n_cache_tokens": 4,
+            "n_output_tokens": 2,
+            "thinking_tokens": 1,
+        }] if complete else []),
+        "terminal_status": status,
+    }
+    if category is not None:
+        payload["terminal_error_category"] = category
+    if recovery is not None:
+        payload["terminal_recovery"] = recovery
+    return payload
+
+
+def _write_antigravity_payload(tmp_path, payload: dict) -> None:
+    agent = tmp_path / "agent"
+    agent.mkdir(exist_ok=True)
+    (agent / "provider-usage.json").write_text(json.dumps(payload))
+
+
+def test_antigravity_terminal_observation_is_fail_closed_and_stateless(
+    tmp_path,
+) -> None:
+    _write_antigravity_payload(
+        tmp_path,
+        _antigravity_payload(
+            status="ERROR", category="eligibility-location", complete=False,
+        ),
+    )
+    assert _antigravity_terminal_observation(tmp_path, "1.1.22") == (
+        True, "eligibility-location",
+    )
+
+    # A later SUCCESS, including a natural recovery on the same low tier, is
+    # evaluated from its own terminal sidecar and is not poisoned by history.
+    _write_antigravity_payload(
+        tmp_path,
+        _antigravity_payload(status="SUCCESS", complete=True),
+    )
+    assert _antigravity_terminal_observation(tmp_path, "1.1.22") == (
+        False, None,
+    )
+
+
+def test_antigravity_complete_error_requires_narrow_recovery_candidate(
+    tmp_path,
+) -> None:
+    ordinary = _antigravity_payload(
+        status="ERROR", category="provider-error", complete=True,
+    )
+    _write_antigravity_payload(tmp_path, ordinary)
+    assert _antigravity_terminal_observation(tmp_path, "1.1.22") == (
+        True, "provider-error",
+    )
+
+    ordinary.update({
+        "terminal_error_category": "stream-interrupted",
+        "terminal_recovery": {
+            "schema": "dradar-antigravity-terminal-recovery-v1",
+            "reason": "stream_interrupted_after_final_response",
+            "response_sha256": "a" * 64,
+        },
+    })
+    _write_antigravity_payload(tmp_path, ordinary)
+    assert _antigravity_terminal_observation(tmp_path, "1.1.22") == (
+        False, "stream-interrupted",
+    )
+
+
+def test_antigravity_bad_sidecar_cannot_upload_text_or_become_success(
+    tmp_path,
+) -> None:
+    payload = _antigravity_payload(
+        status="ERROR", category="account@example.invalid private prompt",
+    )
+    payload["terminal_error"] = "raw account/location/prompt must never upload"
+    _write_antigravity_payload(tmp_path, payload)
+
+    assert _subscription_trial_usage(
+        tmp_path, {"antigravity_cli_version": "1.1.22"},
+    ) is None
+    assert _antigravity_terminal_observation(tmp_path, "1.1.22") == (True, None)
+
+
+@pytest.mark.parametrize(
+    "dradar_version",
+    ["0.5.170", "0.5.171", "0.5.172", "0.5.173", "0.5.174", "0.5.175"],
+)
+def test_legacy_antigravity_sidecar_stays_compatible_and_fail_closed(
+    tmp_path, dradar_version: str,
+) -> None:
+    payload = _antigravity_payload(status="ERROR", complete=True)
+    assert "terminal_error_category" not in payload
+    _write_antigravity_payload(tmp_path, payload)
+
+    parsed = _subscription_trial_usage(tmp_path, {
+        "antigravity_cli_version": "1.1.22",
+        "dradar_version": dradar_version,
+    })
+    assert parsed is not None
+    assert _antigravity_terminal_observation(tmp_path, "1.1.22") == (True, None)
 
 
 def test_subscription_usage_requires_timed_events_to_match_aggregate(tmp_path) -> None:


### PR DESCRIPTION
## 背景

`#0010 / DR-P1-20260902-010` 在修复发布前，Antigravity 近24小时 invalid 已由 9 条增至 11 条，并出现同一用户连续 3 题复发。服务端 fail-closed 判定正确；问题是客户端在 `Pier rc=0 + 官方 terminal=ERROR` 时可能先显示 completed，同时上传证据缺少脱敏终态类别。

## 改动

- 在 Antigravity adapter 边界将官方错误原文压缩为固定 `terminal_error_category` 枚举，不保存账号、位置值、凭据、prompt、代码或请求正文。
- runloop 在 outcome 判定前结构校验 provider-usage sidecar；普通非 SUCCESS、缺失或坏 sidecar 均本地标记 interrupted / `agent-terminal-failure`。
- 仅完整账本及 exact recovery schema/reason/response hash 的窄候选可暂留 completed，最终仍由服务端绑定 trajectory、patch、result 与 usage。
- 保持 0.5.170–0.5.175 旧 sidecar 兼容；旧 ERROR 仍 fail-closed。
- 服务端 recovery 和 invalid 门槛未修改，诊断字段不得参与放宽。

## 验证

- 定向：119 passed
- CLI 全量：1393 passed, 2 skipped
- Server Antigravity 独立回归：29 passed；新增字段下 SUCCESS 仍 eligible、ERROR 仍 `agent_result_incomplete`
- `git diff --check`、compileall、Ruff fatal rules `E9/F63/F7/F82` 通过
- 隐私反例：注入 email/location/request/prompt 原文后，facts 仅保留 allowlist category；未知自由文本字段使 sidecar fail-closed

## 与 PR #274 的冲突矩阵

- PR #274：`src/dradar/runner.py`、`tests/test_runner_tools.py`，prebuild task-base 安全校验
- 本 PR：adapter、runloop 及三份对应测试，postrun terminal/outcome/upload 诊断
- 文件无重叠；共同基线 `04fdf28a6f7666129d9843994d3dffc9fffd3eda`
- `git merge-tree` 无冲突，合并树 `4e8a585aae1b1f6bcdc96d46736a5d951acab7f9`

## 发布门禁

**候选尚未生产验证。禁止合并，直到雷达调度器明确放行。**

本 PR 不包含部署、真实跑题、账号/OAuth、网络、runner、租约、并发或 Cloudflare 变更。共享发布仍由 #0008 第二轮 QA 与 #0001 ds0 单样本验证占用。

正式闭环仍需至少 3 个独立新鲜自然样本、至少 2 个环境或身份，覆盖普通 ERROR 安全分类且仍 invalid、SUCCESS 自然恢复不受历史污染，以及 strict recovery 仅在服务端全绑定后进入 grading；最后由哨兵只读复验。