### PR TITLE
feat: add privacy-safe CLI run flight recorder

### DIFF
--- a/src/dradar/api_client.py
+++ b/src/dradar/api_client.py
@@ -650,6 +650,7 @@ class ApiClient:
         *,
         release_all: bool = False,
         force: bool = False,
+        request_id: str | None = None,
     ) -> dict[str, Any]:
         """Immediately release held cells owned by this volunteer.
 
@@ -664,6 +665,7 @@ class ApiClient:
                 "assignment_ids": ",".join(ids),
                 "release_all": str(release_all).lower(),
                 "force": str(force).lower(),
+                "request_id": request_id or "",
             },
         )
 
@@ -679,6 +681,12 @@ class ApiClient:
     def runner_close(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Close a runner session without releasing any held lease."""
         return self._post("/api/v1/runner/close", json=payload, timeout=3.0)
+
+    def flight_events(self, events: list[dict[str, Any]]) -> dict[str, Any]:
+        """Idempotently upload privacy-allowlisted lifecycle events."""
+        return self._post(
+            "/api/v1/runner/flight-events", json={"events": events}, timeout=3.0,
+        )
 
     def mark_stopped(
         self,

--- a/src/dradar/cli.py
+++ b/src/dradar/cli.py
@@ -28,6 +28,7 @@ from .fleet import (
     cmd_fleet_add, cmd_fleet_serve, cmd_fleet_status, cmd_fleet_stop,
     cmd_fleet_watch,
 )
+from .flight_recorder import cmd_diagnostics
 from .identity import cmd_link_github, cmd_login, cmd_rename, cmd_status
 from .image_cache import cmd_config_set, cmd_config_show
 from .leases import cmd_leases, cmd_release
@@ -124,6 +125,14 @@ def main(argv: list[str] | None = None) -> int:
         help="check only the dependencies required by this agent",
     )
     p_doc.set_defaults(func=cmd_doctor)
+
+    p_diagnostics = sub.add_parser(
+        "diagnostics", help="export a privacy-minimized lifecycle diagnostic bundle")
+    p_diagnostics.add_argument(
+        "--output", required=True, metavar="ZIP",
+        help="destination ZIP path (the bundle is never uploaded automatically)",
+    )
+    p_diagnostics.set_defaults(func=cmd_diagnostics)
 
     p_capacity = sub.add_parser(
         "capacity", help="recommend a safe local worker count from Docker resources")

--- a/src/dradar/flight_recorder.py
+++ b/src/dradar/flight_recorder.py
@@ -1,0 +1,347 @@
+"""Privacy-minimized, offline-capable lifecycle flight recorder.
+
+The recorder intentionally accepts a small allowlist rather than trying to
+redact arbitrary dictionaries after the fact.  It never records request
+bodies, prompts, source code, commands, host/user names, credentials, proxy
+configuration, or model output.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import uuid
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "dradar.flight_event.v1"
+MAX_EVENT_BYTES = 4096
+MAX_LOG_BYTES = 4 * 1024 * 1024
+MAX_LOG_EVENTS = 5000
+UPLOAD_BATCH_SIZE = 100
+
+EVENT_TYPES = frozenset({
+    "session_started", "session_closed", "phase_changed",
+    "claim_requested", "claim_accepted", "claim_failed",
+    "assignment_checked_out", "assignment_stopped",
+    "build_started", "build_completed", "build_failed",
+    "provider_started", "provider_completed", "provider_failed",
+    "heartbeat_sent", "heartbeat_acknowledged", "heartbeat_failed",
+    "checkpoint_saved", "checkpoint_replayed", "checkpoint_failed",
+    "release_requested", "release_completed", "release_failed",
+    "upload_started", "upload_completed", "upload_failed",
+    "request_started", "request_completed", "request_failed",
+})
+COMPONENTS = frozenset({
+    "cli", "claim", "build", "provider", "heartbeat", "checkpoint",
+    "release", "upload", "api",
+})
+EVENT_KEYS = frozenset({
+    "schema_version", "event_id", "client_id", "occurred_at", "seq",
+    "event_type", "component", "actor", "batch_id", "session_id",
+    "assignment_id", "request_id", "reason_code", "attributes",
+})
+ATTRIBUTE_KEYS = frozenset({
+    "attempt", "elapsed_ms", "force", "http_status", "offline_replay",
+    "outcome", "phase", "previous_phase", "provider", "release_count",
+    "target_workers", "was_running", "worker_slot",
+})
+REASON_CODES = frozenset({
+    "api_error", "transport_error", "completed", "paused", "interrupted",
+    "error", "explicit_force", "explicit_safe", "user_force", "user",
+    "build_flake", "provider_failed", "submitted", "artifact-staging-failed",
+    "upload-blocked", "upload-failed", "pending_upload", "not-uploaded",
+    "assignment-reopened", "expired", "rejected",
+})
+OUTCOMES = frozenset({
+    "completed", "interrupted", "submitted", "artifact-staging-failed",
+    "upload-blocked", "upload-failed", "not-uploaded",
+    "assignment-reopened", "expired", "rejected",
+})
+PHASES = frozenset({"preparing", "queued", "running", "uploading", "paused"})
+PROVIDERS = frozenset({
+    "codex", "claude-code", "dsh-minimal", "grok-build", "kimi-code",
+    "zcode", "antigravity", "codebuddy",
+})
+ATTRIBUTE_RULES = {
+    "attempt": (int, 1, 100),
+    "elapsed_ms": (int, 0, 2_147_483_647),
+    "force": (bool, None, None),
+    "http_status": (int, 0, 599),
+    "offline_replay": (bool, None, None),
+    "outcome": (str, OUTCOMES, None),
+    "phase": (str, PHASES, None),
+    "previous_phase": (str, PHASES, None),
+    "provider": (str, PROVIDERS, None),
+    "release_count": (int, 0, 40),
+    "target_workers": (int, 1, 40),
+    "was_running": (bool, None, None),
+    "worker_slot": (int, 1, 40),
+}
+
+
+def _optional_id(value: Any, *, field: str) -> str | None:
+    if value is None:
+        return None
+    if (
+        not isinstance(value, str) or len(value) != 32
+        or any(char not in "0123456789abcdef" for char in value)
+    ):
+        raise ValueError(f"{field} must be 32 lowercase hex characters")
+    return value
+
+
+def _safe_attributes(attributes: dict[str, Any] | None) -> dict[str, Any]:
+    if attributes is None:
+        values = {}
+    elif isinstance(attributes, dict):
+        values = dict(attributes)
+    else:
+        raise ValueError("flight-event attributes must be an object")
+    unknown = set(values) - ATTRIBUTE_KEYS
+    if unknown:
+        raise ValueError(f"unsupported flight-event attributes: {sorted(unknown)}")
+    safe: dict[str, Any] = {}
+    for key, value in values.items():
+        expected, allowed_or_min, maximum = ATTRIBUTE_RULES[key]
+        if expected is bool:
+            if type(value) is not bool:
+                raise ValueError(f"flight-event attribute {key} must be boolean")
+        elif expected is int:
+            if type(value) is not int or not allowed_or_min <= value <= maximum:
+                raise ValueError(f"flight-event attribute {key} is out of range")
+        elif type(value) is not str or value not in allowed_or_min:
+            raise ValueError(f"flight-event attribute {key} is not an allowed value")
+        safe[key] = value
+    return safe
+
+
+def validate_event(value: Any) -> dict[str, Any]:
+    """Return one canonical event or reject it at every persistence boundary."""
+    if not isinstance(value, dict) or set(value) != EVENT_KEYS:
+        raise ValueError("flight event must contain exactly the versioned envelope")
+    if value.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("unsupported flight event schema")
+    for field in ("event_id", "client_id"):
+        candidate = value.get(field)
+        if (
+            not isinstance(candidate, str) or len(candidate) != 32
+            or any(char not in "0123456789abcdef" for char in candidate)
+        ):
+            raise ValueError(f"{field} must be 32 lowercase hex characters")
+    occurred_at = value.get("occurred_at")
+    if not isinstance(occurred_at, str):
+        raise ValueError("occurred_at must be a timezone-aware ISO timestamp")
+    try:
+        parsed_at = datetime.fromisoformat(occurred_at)
+    except ValueError as exc:
+        raise ValueError("occurred_at must be a timezone-aware ISO timestamp") from exc
+    if parsed_at.tzinfo is None:
+        raise ValueError("occurred_at must include a timezone")
+    seq = value.get("seq")
+    if isinstance(seq, bool) or not isinstance(seq, int) or not 1 <= seq <= 2_147_483_647:
+        raise ValueError("seq is out of range")
+    if value.get("event_type") not in EVENT_TYPES:
+        raise ValueError("unsupported flight event type")
+    if value.get("component") not in COMPONENTS:
+        raise ValueError("unsupported flight event component")
+    if value.get("actor") != "cli":
+        raise ValueError("client flight event actor must be cli")
+    for field in ("batch_id", "session_id", "assignment_id", "request_id"):
+        _optional_id(value.get(field), field=field)
+    reason_code = value.get("reason_code")
+    if reason_code is not None and reason_code not in REASON_CODES:
+        raise ValueError("flight event reason_code is not an allowed value")
+    attributes = _safe_attributes(value.get("attributes"))
+    canonical = dict(value)
+    canonical["attributes"] = attributes
+    if len(json.dumps(canonical, separators=(",", ":")).encode("utf-8")) > MAX_EVENT_BYTES:
+        raise ValueError("flight event exceeds the local size limit")
+    return canonical
+
+
+class FlightRecorder:
+    """Append a bounded local history and replay an independent pending queue."""
+
+    def __init__(self, home: Path, client=None):
+        self.home = Path(home)
+        self.client = client
+        self.root = self.home / "flight-recorder"
+        self.events_path = self.root / "events.jsonl"
+        self.pending_path = self.root / "pending.jsonl"
+        self.client_id_path = self.root / "client_id"
+        self._lock = threading.Lock()
+        self._seq = 0
+        self._remote_disabled = False
+        self.client_id = self._load_client_id()
+
+    def _load_client_id(self) -> str:
+        try:
+            value = self.client_id_path.read_text(encoding="ascii").strip()
+            if len(value) == 32 and all(c in "0123456789abcdef" for c in value):
+                return value
+        except OSError:
+            pass
+        value = uuid.uuid4().hex
+        try:
+            self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
+            temporary = self.client_id_path.with_name(
+                f".{self.client_id_path.name}.{os.getpid()}.{time.time_ns()}"
+            )
+            temporary.write_text(value, encoding="ascii")
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, self.client_id_path)
+        except OSError:
+            pass
+        return value
+
+    @staticmethod
+    def _load(path: Path) -> list[dict[str, Any]]:
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            return []
+        events = []
+        for line in lines[-MAX_LOG_EVENTS:]:
+            try:
+                value = json.loads(line)
+            except (TypeError, json.JSONDecodeError):
+                continue
+            try:
+                events.append(validate_event(value))
+            except ValueError:
+                continue
+        return events
+
+    @staticmethod
+    def _write(path: Path, events: list[dict[str, Any]]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        encoded = [
+            json.dumps(validate_event(event), sort_keys=True, separators=(",", ":"))
+            for event in events
+        ]
+        while encoded and (
+            len(encoded) > MAX_LOG_EVENTS
+            or sum(len(line.encode("utf-8")) + 1 for line in encoded) > MAX_LOG_BYTES
+        ):
+            del encoded[: max(1, len(encoded) // 4)]
+        temporary = path.with_name(f".{path.name}.{os.getpid()}.{time.time_ns()}")
+        temporary.write_text("".join(line + "\n" for line in encoded), encoding="utf-8")
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+
+    def record(
+        self,
+        event_type: str,
+        *,
+        component: str,
+        batch_id: str | None = None,
+        session_id: str | None = None,
+        assignment_id: str | None = None,
+        request_id: str | None = None,
+        reason_code: str | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        with self._lock:
+            self._seq += 1
+            event = {
+                "schema_version": SCHEMA_VERSION,
+                "event_id": uuid.uuid4().hex,
+                "client_id": self.client_id,
+                "occurred_at": datetime.now(timezone.utc).isoformat(),
+                "seq": self._seq,
+                "event_type": event_type,
+                "component": component,
+                "actor": "cli",
+                "batch_id": batch_id,
+                "session_id": session_id,
+                "assignment_id": assignment_id,
+                "request_id": request_id,
+                "reason_code": reason_code,
+                "attributes": attributes or {},
+            }
+            event = validate_event(event)
+            history = self._load(self.events_path)
+            pending = self._load(self.pending_path)
+            self._write(self.events_path, [*history, event])
+            self._write(self.pending_path, [*pending, event])
+            return event
+
+    def try_record(self, event_type: str, **kwargs) -> dict[str, Any] | None:
+        """Record best-effort evidence without affecting the primary workflow.
+
+        ``record`` remains the strict persistence boundary used by tests and
+        diagnostic tooling. Runtime integrations use this wrapper so a legacy
+        or malformed identifier, or an unavailable local disk, drops only the
+        diagnostic event instead of interrupting a claim, run, or release.
+        """
+        try:
+            return self.record(event_type, **kwargs)
+        except (OSError, ValueError):
+            return None
+
+    def flush(self) -> int:
+        if self.client is None or self._remote_disabled:
+            return 0
+        with self._lock:
+            pending = self._load(self.pending_path)
+            if not pending:
+                return 0
+            batch = pending[:UPLOAD_BATCH_SIZE]
+            batch = [validate_event(event) for event in batch]
+            try:
+                response = self.client.flight_events(batch)
+            except Exception as exc:
+                if getattr(exc, "status_code", None) == 404:
+                    self._remote_disabled = True
+                return 0
+            acknowledged = set(response.get("acknowledged_event_ids") or ())
+            if not acknowledged:
+                return 0
+            self._write(
+                self.pending_path,
+                [event for event in pending if event.get("event_id") not in acknowledged],
+            )
+            return len(acknowledged)
+
+    def export_diagnostic_bundle(self, destination: Path) -> Path:
+        """Create a local-only ZIP containing allowlisted events and a manifest."""
+        destination = Path(destination).expanduser().resolve()
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with self._lock:
+            events = self._load(self.events_path)
+            pending = self._load(self.pending_path)
+            events = [validate_event(event) for event in events]
+            pending = [validate_event(event) for event in pending]
+        manifest = {
+            "schema_version": "dradar.flight_diagnostics.v1",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "event_count": len(events),
+            "pending_count": len(pending),
+            "privacy_policy": "strict_allowlist_no_content_or_credentials",
+        }
+        with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
+            bundle.writestr(
+                "manifest.json", json.dumps(manifest, sort_keys=True, indent=2) + "\n"
+            )
+            bundle.writestr(
+                "events.jsonl",
+                "".join(
+                    json.dumps(event, sort_keys=True, separators=(",", ":")) + "\n"
+                    for event in events
+                ),
+            )
+        return destination
+
+
+def cmd_diagnostics(args) -> int:
+    from .local_config import HOME
+
+    output = FlightRecorder(HOME).export_diagnostic_bundle(Path(args.output))
+    print(f"diagnostic bundle written: {output}")
+    return 0

--- a/src/dradar/leases.py
+++ b/src/dradar/leases.py
@@ -8,12 +8,14 @@ hatch for a genuinely stuck local process.
 
 import json
 import sys
+import uuid
 from datetime import datetime
 
 from .api_client import ApiError
 from .assignment_state import assignment_state, state_summary
 from .identity import _client
-from .local_config import _load_config
+from .flight_recorder import FlightRecorder
+from .local_config import HOME, _load_config
 
 
 def _inventory(client) -> tuple[list[dict], list[dict]]:
@@ -220,6 +222,8 @@ def cmd_release(args) -> int:
     """Release explicit IDs, all safe-to-release cells, or an interactive pick."""
     cfg = _load_config()
     client = _client(cfg)
+    recorder = FlightRecorder(HOME, client)
+    request_id = uuid.uuid4().hex
     explicit = list(dict.fromkeys(args.assignment_ids or ()))
     active: list[dict] = []
 
@@ -247,10 +251,41 @@ def cmd_release(args) -> int:
             print("cancelled")
             return 1
 
+    for assignment_id in explicit:
+        recorder.try_record(
+            "release_requested", component="release",
+            assignment_id=assignment_id, request_id=request_id,
+            reason_code="explicit_force" if args.force else "explicit_safe",
+            attributes={
+                "force": bool(args.force), "release_count": len(explicit),
+            },
+        )
     try:
-        data = client.release_assignments(
-            explicit or None, release_all=args.all, force=args.force)
+        try:
+            data = client.release_assignments(
+                explicit or None, release_all=args.all, force=args.force,
+                request_id=request_id,
+            )
+        except TypeError as exc:
+            # Preserve developer/test adapters and rolling clients that expose
+            # the pre-flight-recorder call signature. No network request can
+            # have started when Python rejects an unexpected keyword.
+            if "request_id" not in str(exc):
+                raise
+            data = client.release_assignments(
+                explicit or None, release_all=args.all, force=args.force,
+            )
     except ApiError as exc:
+        for assignment_id in explicit:
+            recorder.try_record(
+                "release_failed", component="release",
+                assignment_id=assignment_id, request_id=request_id,
+                reason_code="api_error",
+                attributes={
+                    "force": bool(args.force), "http_status": exc.status_code or 0,
+                },
+            )
+        recorder.flush()
         if exc.status_code == 404:
             sys.exit("release failed: assignment not found, or this server/CLI "
                      "release API is not deployed yet")
@@ -259,6 +294,18 @@ def cmd_release(args) -> int:
     released = data.get("released") or []
     skipped = data.get("skipped") or []
     already = data.get("already_released") or []
+    for item in released:
+        recorder.try_record(
+            "release_completed", component="release",
+            request_id=data.get("request_id") or request_id,
+            assignment_id=item.get("assignment_id"),
+            reason_code="user_force" if args.force else "user",
+            attributes={
+                "force": bool(args.force),
+                "was_running": bool(item.get("was_running")),
+            },
+        )
+    recorder.flush()
     if released:
         print(f"released {len(released)} lease(s):")
         for item in released:

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -2488,6 +2488,15 @@ def _mark_stopped_quietly(
     return False
 
 
+def _record_flight_event(
+    telemetry: RunnerTelemetry | None, event_type: str, *, component: str, **kwargs,
+) -> None:
+    """Keep legacy/test telemetry adapters compatible during protocol rollout."""
+    recorder = getattr(telemetry, "record_event", None)
+    if recorder is not None:
+        recorder(event_type, component=component, **kwargs)
+
+
 def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
                     args, local_commit: str | None,
                     telemetry: RunnerTelemetry | None = None,
@@ -2547,6 +2556,11 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
         return "pending-upload"
     work_dir = HOME / "work"
     print("running trial (this can take a while)...")
+    if telemetry:
+        _record_flight_event(telemetry,
+            "build_started", component="build",
+            assignment_id=assignment["assignment_id"],
+        )
 
     ownership_state = "needs_bind"
 
@@ -2579,6 +2593,15 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
             telemetry.set_phase(
                 "running", assignment["assignment_id"],
                 assignment.get("owner_epoch"),
+            )
+            _record_flight_event(telemetry,
+                "build_completed", component="build",
+                assignment_id=assignment["assignment_id"],
+            )
+            _record_flight_event(telemetry,
+                "provider_started", component="provider",
+                assignment_id=assignment["assignment_id"],
+                attributes={"provider": assignment.get("agent") or "codex"},
             )
             telemetry.flush()
 
@@ -2627,6 +2650,13 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
                     )
             break
         except BuildFlakeError as exc:
+            if telemetry:
+                _record_flight_event(telemetry,
+                    "build_failed", component="build",
+                    assignment_id=assignment["assignment_id"],
+                    reason_code="build_flake",
+                    attributes={"attempt": attempt},
+                )
             # The image build died before the agent ran — a free failure
             # (zero quota), and mirror flakes usually pass on the second
             # attempt, so retry once automatically instead of bouncing the
@@ -2854,6 +2884,19 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
     terminal_outcome = _terminal_failure_outcome(failure_kind)
     outcome = "interrupted" if interrupted else "completed"
     if telemetry:
+        _record_flight_event(telemetry,
+            "provider_failed" if interrupted else "provider_completed",
+            component="provider", assignment_id=assignment["assignment_id"],
+            reason_code="provider_failed" if interrupted else "completed",
+            attributes={
+                "outcome": "interrupted" if interrupted else "completed",
+                "elapsed_ms": max(0, round(art.duration_sec * 1000)),
+            },
+        )
+        _record_flight_event(telemetry,
+            "upload_started", component="upload",
+            assignment_id=assignment["assignment_id"],
+        )
         telemetry.set_phase(
             "uploading", assignment["assignment_id"],
             assignment.get("owner_epoch"),
@@ -3070,6 +3113,23 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
         and not getattr(args, "yes", False)
         and not getattr(args, "parallel", False)
     ))
+    if telemetry:
+        upload_succeeded = upload_outcome in {"submitted", "interrupted"}
+        _record_flight_event(telemetry,
+            "upload_completed" if upload_succeeded else "upload_failed",
+            component="upload", assignment_id=assignment["assignment_id"],
+            reason_code=upload_outcome,
+            attributes={"outcome": upload_outcome},
+        )
+        if upload_outcome in {
+            "artifact-staging-failed", "upload-blocked", "upload-failed",
+        }:
+            _record_flight_event(telemetry,
+                "checkpoint_saved", component="checkpoint",
+                assignment_id=assignment["assignment_id"],
+                reason_code="pending_upload",
+                attributes={"outcome": upload_outcome},
+            )
     circuit_opened = _observe_repeat_failure(
         assignment,
         repeat_failure,
@@ -3898,7 +3958,7 @@ def cmd_go(args) -> int:
         target_workers = 1
     if not 1 <= target_workers <= 40:
         target_workers = 1
-    telemetry = RunnerTelemetry(client, target_workers=target_workers)
+    telemetry = RunnerTelemetry(client, target_workers=target_workers, home=HOME)
     telemetry.bind_batch(args.batch_id)
     telemetry.start()
     close_reason = "error"
@@ -5331,6 +5391,10 @@ def _run_checkout_loop(args, client: ApiClient, tasks_root: Path,
             # The server applies this exclusion before stamping started_at,
             # allowing the loop to keep draining other waiting cells.
             if telemetry:
+                _record_flight_event(telemetry,
+                    "claim_requested", component="claim",
+                    attributes={"attempt": 1},
+                )
                 if telemetry.flush_for_checkout():
                     print("this device was asked to stop before another checkout")
                     break
@@ -5379,6 +5443,10 @@ def _run_checkout_loop(args, client: ApiClient, tasks_root: Path,
             # process starts leaves pre-model failures unable to call the
             # owner-fenced stopped endpoint, stranding a phantom running cell.
             assignment["_runner_session_id"] = telemetry.session_id
+            _record_flight_event(telemetry,
+                "claim_accepted", component="claim",
+                assignment_id=assignment["assignment_id"],
+            )
         if assignment["assignment_id"] in checkout_exclusions:
             # Compatibility with an older server that ignores the exclusion
             # field: checkout just stamped this cell started again. Undo that
@@ -5426,6 +5494,10 @@ def _run_checkout_loop(args, client: ApiClient, tasks_root: Path,
             telemetry.set_phase(
                 "preparing", assignment["assignment_id"],
                 assignment.get("owner_epoch"),
+            )
+            _record_flight_event(telemetry,
+                "assignment_checked_out", component="claim",
+                assignment_id=assignment["assignment_id"],
             )
         print(f"\n=== checked out {assignment['task_id']} "
               f"{assignment['model']}@{assignment['effort']}"

--- a/src/dradar/telemetry.py
+++ b/src/dradar/telemetry.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from . import __version__
 from .api_client import ApiClient, ApiError
+from .flight_recorder import FlightRecorder
 
 
 def platform_family() -> str:
@@ -49,6 +50,7 @@ class RunnerTelemetry:
         *,
         jitter: bool = True,
         target_workers: int = 1,
+        home: Path | None = None,
     ):
         if not 1 <= target_workers <= 40:
             raise ValueError("target_workers must be between 1 and 40")
@@ -76,6 +78,12 @@ class RunnerTelemetry:
         self._jitter = jitter
         self._shown_notice_ids: set[str] = set()
         self._stop_requested = False
+        self.flight_recorder = FlightRecorder(home, client) if home is not None else None
+        if self.flight_recorder is not None:
+            self.flight_recorder.try_record(
+                "session_started", component="cli", session_id=self.session_id,
+                attributes={"target_workers": target_workers},
+            )
 
     @property
     def stop_requested(self) -> bool:
@@ -141,6 +149,13 @@ class RunnerTelemetry:
         if changed:
             self._wake.set()
 
+    def record_event(self, event_type: str, *, component: str, **kwargs) -> None:
+        if self.flight_recorder is None:
+            return
+        kwargs.setdefault("batch_id", self._batch_id)
+        kwargs.setdefault("session_id", self.session_id)
+        self.flight_recorder.try_record(event_type, component=component, **kwargs)
+
     def set_phase(
         self,
         phase: str,
@@ -154,6 +169,7 @@ class RunnerTelemetry:
         if assignment_id is None:
             owner_epoch = None
         with self._lock:
+            previous_phase = self._phase
             changed = (
                 self._phase, self._active_assignment_id, self._owner_epoch,
             ) != (phase, assignment_id, owner_epoch)
@@ -163,6 +179,11 @@ class RunnerTelemetry:
             if changed:
                 self._progress_counter += 1
         if changed:
+            self.record_event(
+                "phase_changed", component="heartbeat",
+                assignment_id=assignment_id,
+                attributes={"previous_phase": previous_phase, "phase": phase},
+            )
             self._wake.set()
 
     def _payload(self) -> dict:
@@ -189,6 +210,7 @@ class RunnerTelemetry:
             if self._disabled:
                 return self._interval
             try:
+                self.record_event("heartbeat_sent", component="heartbeat")
                 response = self.client.runner_heartbeat(self._payload())
             except ApiError as exc:
                 # Older servers have no endpoint. Silence and disable rather than
@@ -197,6 +219,11 @@ class RunnerTelemetry:
                     self._disabled = True
                     return self._interval
                 self._failures += 1
+                self.record_event(
+                    "heartbeat_failed", component="heartbeat",
+                    reason_code="api_error",
+                    attributes={"http_status": exc.status_code or 0},
+                )
                 if self._failures >= 3 and not self._warned:
                     print("warning: the server cannot see this runner's heartbeat; "
                           "work continues and your leases are not auto-released",
@@ -207,6 +234,10 @@ class RunnerTelemetry:
                 return self._interval
             except Exception:
                 self._failures += 1
+                self.record_event(
+                    "heartbeat_failed", component="heartbeat",
+                    reason_code="transport_error",
+                )
                 if self._failures >= 3 and not self._warned:
                     print("warning: runner heartbeat is unavailable; work continues and "
                           "your leases are not auto-released", file=sys.stderr)
@@ -219,6 +250,9 @@ class RunnerTelemetry:
                 print("runner heartbeat recovered", file=sys.stderr)
             self._failures = 0
             self._warned = False
+            self.record_event("heartbeat_acknowledged", component="heartbeat")
+            if self.flight_recorder is not None:
+                self.flight_recorder.flush()
             self._show_notices(response)
             if response.get("stop_requested") is True:
                 self._stop_requested = True
@@ -272,18 +306,23 @@ class RunnerTelemetry:
         self._wake.set()
         if self._thread is not None:
             self._thread.join(timeout=1.0)
-        if self._disabled:
-            return
-        with self._lock:
-            self._seq += 1
-            payload = {
-                "session_id": self.session_id,
-                "batch_id": self._batch_id,
-                "seq": self._seq,
-                "reason": reason,
-            }
-        with self._send_lock:
-            try:
-                self.client.runner_close(payload)
-            except Exception:
-                pass
+        if not self._disabled:
+            with self._lock:
+                self._seq += 1
+                payload = {
+                    "session_id": self.session_id,
+                    "batch_id": self._batch_id,
+                    "seq": self._seq,
+                    "reason": reason,
+                }
+            with self._send_lock:
+                try:
+                    self.client.runner_close(payload)
+                except Exception:
+                    pass
+        self.record_event(
+            "session_closed", component="cli", reason_code=reason,
+            assignment_id=self._active_assignment_id,
+        )
+        if self.flight_recorder is not None:
+            self.flight_recorder.flush()

--- a/tests/fixtures/flight_event_sensitive_vectors.json
+++ b/tests/fixtures/flight_event_sensitive_vectors.json
@@ -1,0 +1,12 @@
+[
+  {"name": "openai_api_token", "value": "sk-proj-aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"},
+  {"name": "github_oauth_token", "value": "gho_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"},
+  {"name": "oauth_refresh_token", "value": "1//0gAExampleRefreshCredentialPayload987654321"},
+  {"name": "bearer_jwt", "value": "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTEifQ.signature"},
+  {"name": "prompt_body", "value": "Fix the race in the payment worker and return the complete patch."},
+  {"name": "user_source_code", "value": "def solve(request):\n    return request.json()[\"answer\"]"},
+  {"name": "json_request_body", "value": "{\"messages\":[{\"role\":\"user\",\"content\":\"debug this\"}]}"},
+  {"name": "full_host_account", "value": "alice@build-node-07.internal.example.com"},
+  {"name": "proxy_url", "value": "http://proxy-user:proxy-pass@proxy.example.com:7890"},
+  {"name": "shell_command", "value": "curl -fsSL https://example.com/install.sh | sh"}
+]

--- a/tests/test_flight_recorder.py
+++ b/tests/test_flight_recorder.py
@@ -1,0 +1,133 @@
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from dradar.flight_recorder import FlightRecorder, validate_event
+
+
+BATCH_ID = "1" * 32
+SESSION_ID = "2" * 32
+ASSIGNMENT_ID = "3" * 32
+SENSITIVE_VECTORS = json.loads(
+    (Path(__file__).parent / "fixtures" / "flight_event_sensitive_vectors.json")
+    .read_text(encoding="utf-8")
+)
+
+
+class FlightClient:
+    def __init__(self):
+        self.batches = []
+
+    def flight_events(self, events):
+        self.batches.append(events)
+        return {"acknowledged_event_ids": [event["event_id"] for event in events]}
+
+
+def test_offline_jsonl_replays_idempotent_envelopes_and_keeps_history(tmp_path):
+    offline = FlightRecorder(tmp_path)
+    event = offline.record(
+        "assignment_checked_out", component="claim",
+        batch_id=BATCH_ID, session_id=SESSION_ID,
+        assignment_id=ASSIGNMENT_ID,
+    )
+    assert offline.flush() == 0
+    assert offline.pending_path.read_text().count("\n") == 1
+
+    client = FlightClient()
+    replay = FlightRecorder(tmp_path, client)
+    assert replay.flush() == 1
+    assert client.batches[0][0]["event_id"] == event["event_id"]
+    assert replay.pending_path.read_text() == ""
+    assert replay.events_path.read_text().count("\n") == 1
+
+
+@pytest.mark.parametrize("forbidden", [
+    "token", "oauth", "prompt", "source_code", "request_body",
+    "hostname", "proxy", "command",
+])
+def test_privacy_allowlist_rejects_sensitive_or_arbitrary_attributes(
+    tmp_path, forbidden,
+):
+    recorder = FlightRecorder(tmp_path)
+    with pytest.raises(ValueError, match="unsupported flight-event attributes"):
+        recorder.record(
+            "request_failed", component="api", attributes={forbidden: "secret"},
+        )
+    assert not recorder.events_path.exists()
+
+
+def test_diagnostic_bundle_contains_only_manifest_and_allowlisted_events(tmp_path):
+    recorder = FlightRecorder(tmp_path)
+    recorder.record(
+        "release_completed", component="release",
+        request_id="a" * 32, assignment_id=ASSIGNMENT_ID,
+        reason_code="user_force",
+        attributes={"force": True, "was_running": True},
+    )
+    output = recorder.export_diagnostic_bundle(tmp_path / "diagnostics.zip")
+    with zipfile.ZipFile(output) as bundle:
+        assert set(bundle.namelist()) == {"manifest.json", "events.jsonl"}
+        manifest = json.loads(bundle.read("manifest.json"))
+        events = bundle.read("events.jsonl").decode()
+    assert manifest["privacy_policy"] == "strict_allowlist_no_content_or_credentials"
+    assert "user_force" in events
+    for forbidden in ("token", "oauth", "prompt", "source_code", "hostname", "command"):
+        assert forbidden not in events.lower()
+
+
+def test_client_actor_is_fixed_and_tampered_actor_is_rejected(tmp_path):
+    recorder = FlightRecorder(tmp_path)
+    event = recorder.record("checkpoint_replayed", component="checkpoint")
+    assert event["actor"] == "cli"
+    tampered = dict(event, actor="legacy_unknown")
+    with pytest.raises(ValueError, match="actor must be cli"):
+        validate_event(tampered)
+
+
+@pytest.mark.parametrize(
+    "vector", SENSITIVE_VECTORS, ids=[item["name"] for item in SENSITIVE_VECTORS],
+)
+def test_real_sensitive_values_are_rejected_by_closed_field_enums(
+    tmp_path, vector,
+):
+    recorder = FlightRecorder(tmp_path)
+    with pytest.raises(ValueError, match="not an allowed value"):
+        recorder.record(
+            "request_failed", component="api",
+            attributes={"outcome": vector["value"]},
+        )
+
+
+def test_tampered_jsonl_cannot_enter_upload_or_diagnostic_bundle(tmp_path):
+    recorder = FlightRecorder(tmp_path)
+    safe = recorder.record(
+        "request_failed", component="api", attributes={"outcome": "upload-failed"},
+    )
+    tampered = dict(safe)
+    tampered["event_id"] = "b" * 32
+    tampered["attributes"] = {"outcome": SENSITIVE_VECTORS[0]["value"]}
+    poisoned = json.dumps(tampered, separators=(",", ":")) + "\n"
+    recorder.events_path.write_text(poisoned, encoding="utf-8")
+    recorder.pending_path.write_text(poisoned, encoding="utf-8")
+
+    client = FlightClient()
+    replay = FlightRecorder(tmp_path, client)
+    assert replay.flush() == 0
+    assert client.batches == []
+    output = replay.export_diagnostic_bundle(tmp_path / "tampered.zip")
+    with zipfile.ZipFile(output) as bundle:
+        assert bundle.read("events.jsonl") == b""
+        manifest = json.loads(bundle.read("manifest.json"))
+    assert manifest["event_count"] == 0
+    assert manifest["pending_count"] == 0
+
+
+def test_runtime_try_record_drops_invalid_diagnostic_without_writing(tmp_path):
+    recorder = FlightRecorder(tmp_path)
+    assert recorder.try_record(
+        "assignment_checked_out", component="claim", assignment_id="legacy-test-id",
+    ) is None
+    assert not recorder.events_path.exists()
+    assert not recorder.pending_path.exists()


### PR DESCRIPTION
## Scope

DR-P2-20260902-011 CLI half: add privacy-safe local flight events, lifecycle wiring, and sensitive-value regression vectors.

## Verification

- Archived third-round independent QA: CLI 1405 passed / 2 skipped; cross-repository checkout/upload/release scenarios passed
- Exact committed candidate: 23 flight-recorder tests passed
- Sensitive-pattern scan and `git diff --check origin/main...HEAD` passed
- Candidate is based directly on current `origin/main` (`04fdf28a6f7666129d9843994d3dffc9fffd3eda`)

## Release gate

Review only for now. Do not merge or release until DR-P0-20260902-018 startup-chain changes are finalized and the combined CLI behavior is revalidated.