### PR TITLE
chore(ota): register production signing key

### DIFF
--- a/release/ota/trusted-keys.json
+++ b/release/ota/trusted-keys.json
@@ -1,4 +1,11 @@
 {
   "schema_version": 1,
-  "keys": {}
+  "keys": {
+    "dradar-ota-prod-2026-09-03-01": {
+      "public_key_base64": "cNKyezPQwWVFv7rQua/e4mmQKho0OmgQvrLyR/R2otI=",
+      "status": "active",
+      "not_before": "2026-09-03T00:00:00Z",
+      "not_after": "2027-09-03T00:00:00Z"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- register the reviewed Ed25519 production public key for the stable OTA channel
- keep the private seed only in the protected `ota-production` Environment secret

## Verification
- `tests/test_ota_release_tool.py`: 34 passed
- `git diff --check`: clean
- single-file diff: `release/ota/trusted-keys.json`

## Safety
- no CLI artifacts, manifest, stable pointer, or workflow dispatch in this PR
- rollback before first publication is a normal reviewed revert; after use, rotate by adding a new key rather than deleting the old key