### PR TITLE
[#0029] Add Gemini 3.8 Flash Antigravity CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,10 +393,11 @@ DRadar 服务端或轨迹。容器启动后 Key 会立即转入 ZCode 的内存�
 allowlist/denylist，保留完整编码和 `Agent` 子代理能力；网络仍只允许 ZCode 控制面与模型
 端点。任务中断不会恢复 ZCode session/rollout；运行完成后的精确产物只走待上传账本。
 
-### Google Antigravity Gemini 3.7 Flash 订阅 OAuth agent
+### Google Antigravity Gemini 3.8 / 3.7 Flash 订阅 OAuth agent
 
-Antigravity 只使用 DRadar 独立的 Google OAuth 状态和固定 Linux CLI `1.1.22`，模型固定为
-`gemini-3.7-flash` 的 `low`/`medium`/`high` 三档。每题在 Pier Docker 中使用
+Antigravity 只使用 DRadar 独立的 Google OAuth 状态和固定 Linux CLI `1.1.24`，支持
+`gemini-3.8-flash` 与原有 `gemini-3.7-flash` 的 `low`/`medium`/`high` 三档；每个领取格子
+都会绑定并核验精确的模型与档位，不会跨模型回退。每题在 Pier Docker 中使用
 `--dangerously-skip-permissions`，不再叠加 CLI terminal sandbox；文件、命令和原生子代理
 不会因 headless 审批被静默拒绝。容器只挂载独立 `.gemini` 树，网络只开放 Google OAuth、
 Antigravity 模型控制面和固定运行时下载的精确域名；日常 Gemini 配置、宿主 HOME 与其他

--- a/src/dradar/pier_antigravity.py
+++ b/src/dradar/pier_antigravity.py
@@ -26,22 +26,29 @@ from pier.models.trajectories import Agent, FinalMetrics, Step, Trajectory
 from pier.utils.trajectory_metrics import populate_context_from_final_metrics
 
 
-ANTIGRAVITY_CLI_VERSION = "1.1.22"
+ANTIGRAVITY_CLI_VERSION = "1.1.24"
 ANTIGRAVITY_MODEL = "gemini-3.7-flash"
+ANTIGRAVITY_FLASH_38_MODEL = "gemini-3.8-flash"
+ANTIGRAVITY_MODELS = frozenset({ANTIGRAVITY_MODEL, ANTIGRAVITY_FLASH_38_MODEL})
 ANTIGRAVITY_RUNTIME_MODELS = {
     "low": "gemini-3.7-flash-low",
     "medium": "gemini-3.7-flash-medium",
     "high": "gemini-3.7-flash-high",
 }
-ANTIGRAVITY_LINUX_RELEASE = "1.1.22-5711547746615296"
+ANTIGRAVITY_RUNTIME_MODELS_BY_MODEL = {
+    (model, effort): f"{model}-{effort}"
+    for model in ANTIGRAVITY_MODELS
+    for effort in ("low", "medium", "high")
+}
+ANTIGRAVITY_LINUX_RELEASE = "1.1.24-6130423206641664"
 ANTIGRAVITY_LINUX_SHA512 = {
     "x86_64": (
-        "40225d4b1f009412e905f0a234ba3d51487038d1ad1b8fa19331c84be55610a0"
-        "1f5b0ad9916fb871151cc45456c6bc30cc0b1ea5dab6c0616bc8fb262bcdd7a9"
+        "ed4df91ea7ced986aa14507a0ab8225d92985190f7d551010eba0c46c569587e6"
+        "02cb36af81c9cde7af0d6b380e8dd3a82131361806cd96012d44a3e47fb369a"
     ),
     "aarch64": (
-        "b37a718330eb5e270e1ca70135bf964a407ba626fbff7537ac58e094ea31bc623"
-        "e6d216ef197188fe8b5c46e6f57aee64a3b7c9e23fc855cefee43fe434179d3"
+        "316ca00d50389a08b162c66066b4e2db201e4ffb85acea05029e3c4532c69d5b"
+        "8f7c741cf027325889f898ea8f747af8cd15c802e15fcf5d73b7137b6e2420a1"
     ),
 }
 ANTIGRAVITY_STREAM_INTERRUPTED_MESSAGE = (
@@ -200,7 +207,7 @@ def _antigravity_usage_facts(
     facts: dict[str, object] = {
         "schema": "dradar-subscription-provider-usage-v1",
         "provider": "antigravity",
-        "model": ANTIGRAVITY_MODEL,
+        "model": expected_runtime_model.rsplit("-", 1)[0],
         "provider_runtime_model": expected_runtime_model,
         "complete": reconciled,
         "request_count": len(token_usage_events) if observed else 0,
@@ -282,7 +289,7 @@ def _install_command() -> str:
 
 
 class Antigravity(BaseInstalledAgent):
-    """Run Gemini 3.7 Flash through a DRadar-owned AGY subscription."""
+    """Run an approved Gemini Flash model through isolated AGY OAuth."""
 
     SUPPORTS_ATIF = True
     _REMOTE_USER_HOME = PurePosixPath("/tmp/dradar-antigravity-user")
@@ -301,22 +308,31 @@ class Antigravity(BaseInstalledAgent):
         *args: Any,
         auth_home_dir: str,
         reasoning_effort: str,
+        model_name: str | None = None,
+        version: str | None = ANTIGRAVITY_CLI_VERSION,
         shared_oauth: bool = False,
         **kwargs: Any,
     ):
         auth_home = Path(auth_home_dir)
         if not auth_home.is_dir():
             raise ValueError("Antigravity OAuth home is missing")
-        if reasoning_effort not in ANTIGRAVITY_RUNTIME_MODELS:
+        resolved_model = model_name or ANTIGRAVITY_MODEL
+        if resolved_model not in ANTIGRAVITY_MODELS:
+            raise ValueError("Antigravity model is unsupported")
+        if reasoning_effort not in {"low", "medium", "high"}:
             raise ValueError("Antigravity reasoning_effort must be low, medium, or high")
+        if version != ANTIGRAVITY_CLI_VERSION:
+            raise ValueError(f"Antigravity adapter requires CLI {ANTIGRAVITY_CLI_VERSION}")
         if not isinstance(shared_oauth, bool):
             raise ValueError("Antigravity shared_oauth must be a boolean")
         self._auth_home_dir = auth_home
         self._reasoning_effort = reasoning_effort
-        self._runtime_model = ANTIGRAVITY_RUNTIME_MODELS[reasoning_effort]
+        self._runtime_model = ANTIGRAVITY_RUNTIME_MODELS_BY_MODEL[
+            (resolved_model, reasoning_effort)
+        ]
         self._shared_oauth = shared_oauth
         self._instruction = ""
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, model_name=resolved_model, version=version, **kwargs)
 
     def get_version_command(self) -> str:
         return f"{self._REMOTE_CLI.as_posix()} --version"
@@ -380,7 +396,7 @@ class Antigravity(BaseInstalledAgent):
                 f"grep -Eq {shlex.quote(_model_line_pattern(slug))} "
                 f"{shlex.quote(models_file)}"
             )
-            for slug in ANTIGRAVITY_RUNTIME_MODELS.values()
+            for slug in ANTIGRAVITY_RUNTIME_MODELS_BY_MODEL.values()
         )
         await self.exec_as_agent(
             environment,

--- a/src/dradar/provider_config.py
+++ b/src/dradar/provider_config.py
@@ -37,8 +37,7 @@ from .codebuddy_provider import (
 from .providers import (
     ANTIGRAVITY_CLI_VERSION,
     ANTIGRAVITY_LINUX_ARTIFACTS,
-    ANTIGRAVITY_MODEL,
-    ANTIGRAVITY_RUNTIME_MODELS,
+    ANTIGRAVITY_RUNTIME_MODELS_BY_MODEL,
     CLAUDE_API_KEY_ENVS,
     CLAUDE_CLI_VERSION,
     CLAUDE_MODELS,
@@ -558,7 +557,7 @@ def _antigravity_models_live(docker: str, executable: Path) -> str | None:
         for line in proc.stdout.splitlines()
         if line.strip()
     }
-    missing = set(ANTIGRAVITY_RUNTIME_MODELS.values()) - available
+    missing = set(ANTIGRAVITY_RUNTIME_MODELS_BY_MODEL.values()) - available
     if missing:
         return "the account cannot access " + ", ".join(sorted(missing))
     return None
@@ -577,7 +576,7 @@ def _setup_antigravity_subscription() -> int:
         if issue is None:
             print(
                 f"Antigravity subscription provider is already ready (CLI "
-                f"{ANTIGRAVITY_CLI_VERSION}, {ANTIGRAVITY_MODEL} low/medium/high verified)."
+                f"{ANTIGRAVITY_CLI_VERSION}, Gemini 3.7/3.8 Flash low/medium/high verified)."
             )
             return 0
     if not sys.stdin.isatty():
@@ -641,8 +640,8 @@ def _setup_antigravity_subscription() -> int:
         return 1
     print(
         f"Antigravity subscription OAuth is ready at {antigravity_auth_path()} "
-        f"(tokens hidden, CLI {ANTIGRAVITY_CLI_VERSION}, three Gemini 3.7 Flash "
-        "effort levels verified)."
+        f"(tokens hidden, CLI {ANTIGRAVITY_CLI_VERSION}, Gemini 3.7/3.8 Flash "
+        "low/medium/high verified)."
     )
     return 0
 
@@ -667,7 +666,7 @@ def _status_antigravity_subscription(*, live: bool) -> int:
     print(
         f"Antigravity subscription provider ready via {antigravity_auth_path()} "
         f"(OAuth tokens hidden, CLI {ANTIGRAVITY_CLI_VERSION}, "
-        f"{ANTIGRAVITY_MODEL} low/medium/high, API keys disabled)."
+        "Gemini 3.7/3.8 Flash low/medium/high, API keys disabled)."
     )
     return 0
 

--- a/src/dradar/providers.py
+++ b/src/dradar/providers.py
@@ -210,46 +210,52 @@ _KIMI_VERSION_RE = re.compile(r"(?:^|\s)(\d+\.\d+\.\d+)(?:\s|$)")
 ANTIGRAVITY_PROVIDER = "google-antigravity-subscription"
 ANTIGRAVITY_AGENT = "antigravity"
 ANTIGRAVITY_MODEL = "gemini-3.7-flash"
-ANTIGRAVITY_CLI_VERSION = "1.1.22"
-ANTIGRAVITY_LINUX_RELEASE = "1.1.22-5711547746615296"
+ANTIGRAVITY_FLASH_38_MODEL = "gemini-3.8-flash"
+ANTIGRAVITY_MODELS = frozenset({ANTIGRAVITY_MODEL, ANTIGRAVITY_FLASH_38_MODEL})
+ANTIGRAVITY_CLI_VERSION = "1.1.24"
+ANTIGRAVITY_LINUX_RELEASE = "1.1.24-6130423206641664"
 ANTIGRAVITY_LINUX_ARTIFACTS = {
     "x86_64": {
         "url": (
             "https://storage.googleapis.com/antigravity-public/"
-            "antigravity-cli/1.1.22-5711547746615296/linux-x64/"
+            "antigravity-cli/1.1.24-6130423206641664/linux-x64/"
             "cli_linux_x64.tar.gz"
         ),
         "sha512": (
-            "40225d4b1f009412e905f0a234ba3d51487038d1ad1b8fa19331c84be55610a0"
-            "1f5b0ad9916fb871151cc45456c6bc30cc0b1ea5dab6c0616bc8fb262bcdd7a9"
+            "ed4df91ea7ced986aa14507a0ab8225d92985190f7d551010eba0c46c569587e6"
+            "02cb36af81c9cde7af0d6b380e8dd3a82131361806cd96012d44a3e47fb369a"
         ),
     },
     "aarch64": {
         "url": (
             "https://storage.googleapis.com/antigravity-public/"
-            "antigravity-cli/1.1.22-5711547746615296/linux-arm/"
+            "antigravity-cli/1.1.24-6130423206641664/linux-arm/"
             "cli_linux_arm64.tar.gz"
         ),
         "sha512": (
-            "b37a718330eb5e270e1ca70135bf964a407ba626fbff7537ac58e094ea31bc623"
-            "e6d216ef197188fe8b5c46e6f57aee64a3b7c9e23fc855cefee43fe434179d3"
+            "316ca00d50389a08b162c66066b4e2db201e4ffb85acea05029e3c4532c69d5b"
+            "8f7c741cf027325889f898ea8f747af8cd15c802e15fcf5d73b7137b6e2420a1"
         ),
     },
 }
 ANTIGRAVITY_SUPPORTED_EFFORTS = frozenset({"low", "medium", "high"})
 ANTIGRAVITY_RUNTIME_MODELS = {
-    "low": "gemini-3.7-flash-low",
-    "medium": "gemini-3.7-flash-medium",
-    "high": "gemini-3.7-flash-high",
+    effort: f"{ANTIGRAVITY_MODEL}-{effort}"
+    for effort in ANTIGRAVITY_SUPPORTED_EFFORTS
+}
+ANTIGRAVITY_RUNTIME_MODELS_BY_MODEL = {
+    (model, effort): f"{model}-{effort}"
+    for model in ANTIGRAVITY_MODELS
+    for effort in ANTIGRAVITY_SUPPORTED_EFFORTS
 }
 ANTIGRAVITY_CAPABILITY = (
-    "antigravity-gemini-3.7-flash-subscription-oauth-sandbox-v1"
+    "antigravity-gemini-3-flash-family-subscription-oauth-sandbox-v2"
 )
 ANTIGRAVITY_RUN_CONFIG_VERSION = (
-    "antigravity-gemini-3.7-flash-subscription-oauth-full-container-v2"
+    "antigravity-gemini-3-flash-family-subscription-oauth-full-container-v3"
 )
 ANTIGRAVITY_RUNTIME_PROFILE = (
-    "pier-antigravity-gemini-3.7-flash-shared-oauth-full-container-v2"
+    "pier-antigravity-gemini-3-flash-family-shared-oauth-full-container-v3"
 )
 ANTIGRAVITY_ARTIFACT_CAPTURE = "full-worktree-v1"
 ANTIGRAVITY_HOME_RELATIVE_PATH = Path("providers") / "antigravity"
@@ -327,7 +333,7 @@ REFILL_HARNESS_CONSTRAINTS = {
     KIMI_AGENT: (frozenset({KIMI_MODEL}), KIMI_SUPPORTED_EFFORTS),
     GROK_AGENT: (frozenset({GROK_MODEL}), GROK_SUPPORTED_EFFORTS),
     ANTIGRAVITY_AGENT: (
-        frozenset({ANTIGRAVITY_MODEL}), ANTIGRAVITY_SUPPORTED_EFFORTS,
+        ANTIGRAVITY_MODELS, ANTIGRAVITY_SUPPORTED_EFFORTS,
     ),
     CODEBUDDY_AGENT: (
         frozenset({CODEBUDDY_MODEL}), CODEBUDDY_SUPPORTED_EFFORTS,
@@ -1116,7 +1122,7 @@ def antigravity_auth_error(home: Path | None = None) -> str | None:
         ready_payload.get("schema") != "dradar-antigravity-ready-v1"
         or ready_payload.get("cli_version") != ANTIGRAVITY_CLI_VERSION
         or ready_payload.get("models")
-        != sorted(ANTIGRAVITY_RUNTIME_MODELS.values())
+        != sorted(ANTIGRAVITY_RUNTIME_MODELS_BY_MODEL.values())
     ):
         return "Antigravity readiness proof does not match this DRadar release"
     return None
@@ -1161,7 +1167,7 @@ def mark_antigravity_ready(home: Path | None = None) -> Path:
             json.dump({
                 "schema": "dradar-antigravity-ready-v1",
                 "cli_version": ANTIGRAVITY_CLI_VERSION,
-                "models": sorted(ANTIGRAVITY_RUNTIME_MODELS.values()),
+                "models": sorted(ANTIGRAVITY_RUNTIME_MODELS_BY_MODEL.values()),
             }, handle, separators=(",", ":"))
             handle.flush()
             os.fsync(handle.fileno())

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -46,8 +46,9 @@ from .providers import (
     ANTIGRAVITY_AGENT,
     ANTIGRAVITY_CLI_VERSION,
     ANTIGRAVITY_MODEL,
+    ANTIGRAVITY_MODELS,
     ANTIGRAVITY_PROVIDER,
-    ANTIGRAVITY_RUNTIME_MODELS,
+    ANTIGRAVITY_RUNTIME_MODELS_BY_MODEL,
     ANTIGRAVITY_SUPPORTED_EFFORTS,
     CLAUDE_AGENT,
     CLAUDE_API_KEY_ENVS,
@@ -980,10 +981,11 @@ def _validate_antigravity_assignment(assignment: dict) -> None:
             "Antigravity assignments must explicitly use provider "
             f"{ANTIGRAVITY_PROVIDER!r}"
         )
-    if assignment.get("model") != ANTIGRAVITY_MODEL:
+    model = assignment.get("model")
+    if model not in ANTIGRAVITY_MODELS:
         raise RunnerError(
             f"unsupported Antigravity model {assignment.get('model')!r}; "
-            f"only {ANTIGRAVITY_MODEL!r} is enabled"
+            f"enabled models are {', '.join(sorted(ANTIGRAVITY_MODELS))}"
         )
     effort = assignment.get("effort")
     if effort not in ANTIGRAVITY_SUPPORTED_EFFORTS:
@@ -991,7 +993,7 @@ def _validate_antigravity_assignment(assignment: dict) -> None:
             "Antigravity effort must be low, medium, or high; "
             f"got {effort!r}"
         )
-    if ANTIGRAVITY_RUNTIME_MODELS.get(effort) != f"{ANTIGRAVITY_MODEL}-{effort}":
+    if ANTIGRAVITY_RUNTIME_MODELS_BY_MODEL.get((model, effort)) != f"{model}-{effort}":
         raise RunnerError("Antigravity runtime model mapping is inconsistent")
 
 

--- a/tests/test_antigravity_subscription.py
+++ b/tests/test_antigravity_subscription.py
@@ -20,9 +20,11 @@ from dradar.providers import (
     ANTIGRAVITY_AGENT,
     ANTIGRAVITY_CAPABILITY,
     ANTIGRAVITY_CLI_VERSION,
+    ANTIGRAVITY_FLASH_38_MODEL,
     ANTIGRAVITY_MODEL,
     ANTIGRAVITY_PROVIDER,
     ANTIGRAVITY_RUNTIME_MODELS,
+    ANTIGRAVITY_RUNTIME_MODELS_BY_MODEL,
     antigravity_auth_error,
     antigravity_auth_path,
     antigravity_settings_payload,
@@ -821,8 +823,24 @@ def test_provider_failure_is_additive_and_does_not_strip_other_credentials(
 
 
 def test_capability_name_is_additive_and_refill_alias_is_canonical() -> None:
-    assert ANTIGRAVITY_CAPABILITY.startswith("antigravity-gemini-3.7-flash-")
+    assert ANTIGRAVITY_CAPABILITY.startswith("antigravity-gemini-3-flash-family-")
     assert providers.normalize_refill_harness("agy") == ANTIGRAVITY_AGENT
     assert providers.validate_refill_scope(
         "antigravity", ANTIGRAVITY_MODEL, "high",
     ) == (ANTIGRAVITY_AGENT, ANTIGRAVITY_MODEL, "high")
+
+
+@pytest.mark.parametrize("effort", ["low", "medium", "high"])
+def test_gemini_38_assignment_uses_exact_official_runtime_slug(
+    effort: str,
+) -> None:
+    assignment = _assignment(model=ANTIGRAVITY_FLASH_38_MODEL, effort=effort)
+    runner._validate_antigravity_assignment(assignment)
+    assert ANTIGRAVITY_RUNTIME_MODELS_BY_MODEL[
+        (ANTIGRAVITY_FLASH_38_MODEL, effort)
+    ] == f"gemini-3.8-flash-{effort}"
+
+
+def test_unknown_antigravity_model_fails_closed() -> None:
+    with pytest.raises(RunnerError, match="unsupported Antigravity model"):
+        runner._validate_antigravity_assignment(_assignment(model="gemini-3.9-flash"))

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -445,7 +445,7 @@ def test_antigravity_live_check_restores_the_fail_closed_settings(
         return SimpleNamespace(
             returncode=0,
             stdout="\n".join(
-                provider_config.ANTIGRAVITY_RUNTIME_MODELS.values()
+                    provider_config.ANTIGRAVITY_RUNTIME_MODELS_BY_MODEL.values()
             ),
             stderr="",
         )


### PR DESCRIPTION
## Scope

- Adds exact Gemini 3.8 Flash low, medium, and high runtime mappings while preserving Gemini 3.7 Flash.
- Pins official Antigravity CLI 1.1.24 Linux x64 and ARM artifacts by immutable release URL and SHA-512.
- Fails closed on unknown model or effort and binds the selected model through Pier, trajectory, and usage metadata.
- Preserves the public runner compatibility export used by existing integrations.

## Verification

- Directed CLI suite: 82 passed.
- Full CLI suite on main version 0.5.182: 1622 passed, 2 skipped.
- Git diff check passed.

## Release boundary

Preparation only. This PR does not publish the required six-platform immutable OTA and must not be merged or released until the scheduler coordinates that later step.