### PR TITLE
Harden task pack extraction paths across platforms

### DIFF
--- a/src/dradar/taskpacks.py
+++ b/src/dradar/taskpacks.py
@@ -8,13 +8,19 @@ import os
 import shutil
 import tarfile
 import tempfile
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 from .api_client import ApiClient, ApiError
 
 MARKER = ".dradar-task-bundle.json"
 MAX_BUNDLE_BYTES = 2 * 1024 * 1024 * 1024
 MAX_ENTRIES = 100_000
+_WINDOWS_RESERVED_DEVICE_NAMES = frozenset({
+    "CON", "PRN", "AUX", "NUL", "CONIN$", "CONOUT$", "CLOCK$",
+    *(f"COM{suffix}" for suffix in (*range(1, 10), "¹", "²", "³")),
+    *(f"LPT{suffix}" for suffix in (*range(1, 10), "¹", "²", "³")),
+})
+_WINDOWS_FORBIDDEN_FILENAME_CHARS = frozenset('<>:"|?*')
 
 
 class TaskPackError(RuntimeError):
@@ -68,10 +74,36 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _unsafe_windows_component(component: str) -> bool:
+    """Reject names Windows rewrites or routes outside a normal file."""
+
+    if component.endswith((" ", ".")):
+        return True
+    if any(
+        ord(character) < 32
+        or ord(character) == 127
+        or character in _WINDOWS_FORBIDDEN_FILENAME_CHARS
+        for character in component
+    ):
+        return True
+    # Windows reserves device basenames case-insensitively, even when an
+    # extension is present or spaces precede it (for example ``NUL .txt``).
+    device_basename = component.split(".", 1)[0].rstrip(" ").upper()
+    return device_basename in _WINDOWS_RESERVED_DEVICE_NAMES
+
+
 def _safe_target(root: Path, member_name: str) -> Path:
     pure = PurePosixPath(member_name)
-    if pure.is_absolute() or not pure.parts or any(
-        part in {"", ".", ".."} for part in pure.parts
+    windows = PureWindowsPath(member_name)
+    if (
+        # Tar member names are POSIX paths. A backslash is ambiguous on
+        # Windows and can turn one apparently safe member into a traversal.
+        "\\" in member_name
+        or windows.anchor
+        or pure.is_absolute()
+        or not pure.parts
+        or any(part in {"", ".", ".."} for part in pure.parts)
+        or any(_unsafe_windows_component(part) for part in pure.parts)
     ):
         raise TaskPackError(f"unsafe path in task bundle: {member_name!r}")
     return root.joinpath(*pure.parts)

--- a/tests/test_taskpacks.py
+++ b/tests/test_taskpacks.py
@@ -2,10 +2,98 @@ import gzip
 import hashlib
 import io
 import tarfile
+from pathlib import PureWindowsPath
 
 import pytest
 
+from dradar import taskpacks
 from dradar.taskpacks import MARKER, TaskPackError, ensure_benchmark_task_pack
+
+
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        r"..\escape.txt",
+        r"sub\..\..\escape.txt",
+        r"C:\absolute.txt",
+        r"C:drive-relative.txt",
+        r"\rooted.txt",
+        r"\\server\share\escape.txt",
+        r"\\?\C:\device-absolute.txt",
+        r"\\.\PIPE\device-name",
+        "C:/drive-absolute.txt",
+    ],
+)
+def test_safe_target_rejects_windows_path_semantics(member_name):
+    # PureWindowsPath makes this test exercise Windows joining semantics on
+    # every CI host, including Linux/macOS runners.
+    windows_root = PureWindowsPath(r"C:\safe\tasks")
+
+    with pytest.raises(TaskPackError, match="unsafe path"):
+        taskpacks._safe_target(windows_root, member_name)
+
+
+_WINDOWS_RESERVED_NAMES = [
+    "CON", "con.ext", "PRN", "prn.log", "AUX", "aux.txt", "NUL", "nul.txt",
+    "CONIN$", "conin$.txt", "CONOUT$", "conout$.log", "CLOCK$", "clock$.txt",
+    *(f"COM{index}" for index in range(1, 10)),
+    *(f"com{index}.log" for index in range(1, 10)),
+    *(f"LPT{index}" for index in range(1, 10)),
+    *(f"lpt{index}.log" for index in range(1, 10)),
+    "COM¹", "COM².txt", "com³.log", "LPT¹", "LPT².txt", "lpt³.log",
+]
+
+
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        *_WINDOWS_RESERVED_NAMES,
+        *(f"task/{name}" for name in _WINDOWS_RESERVED_NAMES),
+        "task/NUL .txt",
+        "task/COM1...log",
+        "task/file.txt.",
+        "task/trailing-space ",
+        "task/file.txt:alternate-stream",
+        "task/file::$DATA",
+        "task/question?.txt",
+        "task/bad<name",
+        "task/bad>name",
+        'task/bad"name',
+        "task/bad|name",
+        "task/bad*name",
+        "task/control\x00.txt",
+        "task/control\x01.txt",
+        "task/control\x1f.txt",
+        "task/control\x7f.txt",
+    ],
+)
+def test_safe_target_rejects_windows_reserved_components(member_name, tmp_path):
+    with pytest.raises(TaskPackError, match="unsafe path"):
+        taskpacks._safe_target(tmp_path / "tasks", member_name)
+
+
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        "task/task.toml",
+        "nested/path/file-name_1.2.txt",
+        "unicode/任务说明.md",
+        "dotfile/.config",
+        "devices/COM0",
+        "devices/COM0.txt",
+        "devices/COM10",
+        "devices/LPT0.txt",
+        "devices/LPT10.txt",
+        "ordinary/CLOCK.txt",
+        "ordinary/dollar$.txt",
+    ],
+)
+def test_safe_target_keeps_portable_posix_members(member_name, tmp_path):
+    root = tmp_path / "tasks"
+
+    target = taskpacks._safe_target(root, member_name)
+
+    assert target == root.joinpath(*member_name.split("/"))
 
 
 def _archive(entries: dict[str, bytes]) -> bytes:
@@ -17,6 +105,18 @@ def _archive(entries: dict[str, bytes]) -> bytes:
                 info.size = len(content)
                 info.mode = 0o644
                 tar.addfile(info, io.BytesIO(content))
+    return output.getvalue()
+
+
+def _special_archive(entry_type: bytes) -> bytes:
+    output = io.BytesIO()
+    with gzip.GzipFile(filename="", mode="wb", fileobj=output, mtime=0) as compressed:
+        with tarfile.open(fileobj=compressed, mode="w") as tar:
+            info = tarfile.TarInfo("task/escape")
+            info.type = entry_type
+            if entry_type in {tarfile.LNKTYPE, tarfile.SYMTYPE}:
+                info.linkname = "../outside"
+            tar.addfile(info)
     return output.getvalue()
 
 
@@ -114,3 +214,53 @@ def test_task_pack_rejects_path_traversal(tmp_path):
         ensure_benchmark_task_pack(client, "pompeii-adjacency", root)
     assert not (tmp_path / "escape").exists()
     assert not root.exists()
+
+
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        r"..\escape.txt",
+        "C:/escape.txt",
+        "task/NUL.txt",
+        "task/file.txt:stream",
+        "task/trailing. ",
+        "task/control\x1f.txt",
+    ],
+)
+def test_task_pack_rejects_cross_platform_member_and_preserves_installed_pack(
+    member_name, tmp_path,
+):
+    old = FakeClient(_archive({"task/old.txt": b"old"}))
+    root = tmp_path / "tasks"
+    assert ensure_benchmark_task_pack(old, "pompeii-adjacency", root) is True
+
+    unsafe = FakeClient(_archive({member_name: b"unsafe"}))
+    with pytest.raises(TaskPackError, match="unsafe path"):
+        ensure_benchmark_task_pack(unsafe, "pompeii-adjacency", root)
+
+    assert (root / "task" / "old.txt").read_bytes() == b"old"
+
+
+@pytest.mark.parametrize(
+    "entry_type",
+    [
+        tarfile.SYMTYPE,
+        tarfile.LNKTYPE,
+        tarfile.FIFOTYPE,
+        tarfile.CHRTYPE,
+        tarfile.BLKTYPE,
+    ],
+)
+def test_task_pack_rejects_non_file_entries_and_preserves_installed_pack(
+    entry_type, tmp_path,
+):
+    old = FakeClient(_archive({"task/old.txt": b"old"}))
+    root = tmp_path / "tasks"
+    assert ensure_benchmark_task_pack(old, "pompeii-adjacency", root) is True
+
+    unsafe = FakeClient(_special_archive(entry_type))
+    with pytest.raises(TaskPackError, match="non-file entry"):
+        ensure_benchmark_task_pack(unsafe, "pompeii-adjacency", root)
+
+    assert (root / "task" / "old.txt").read_bytes() == b"old"
+    assert not (tmp_path / "escape").exists()


### PR DESCRIPTION
## Summary

- reject task-pack members with Windows traversal, drive, UNC, or device namespace semantics
- reject reserved device names, alternate data streams, control characters, and trailing dots/spaces
- preserve portable Unicode and valid names such as COM0, COM10, LPT0, and LPT10
- keep non-regular entry rejection and transactional preservation of an installed pack covered by tests

This PR is the low-coupling #0018-A path-safety slice only. It intentionally does not include #0018-B startup preparation reliability work.

## Tests

- `pytest -q tests/test_taskpacks.py` — 165 passed
- `pytest -q` — 1777 passed, 2 skipped
- independent QA — PASS, including 61 additional path-semantic cases and 4 archive integration cases

The validation and tests use `PurePosixPath` / `PureWindowsPath` rather than host-OS behavior, so they are runnable on Windows CI. The current repository workflow only exposes Ubuntu runners, so native Windows execution remains a low-risk evidence gap.

## Safety

- diff is limited to `src/dradar/taskpacks.py` and `tests/test_taskpacks.py`
- no API, schema, run protocol, Docker, production, or release changes
- no merge or deployment is requested by this PR creation
