### PR TITLE
fix: stop refill after verified empty submissions (#0013)

### DIFF
--- a/src/dradar/api_client.py
+++ b/src/dradar/api_client.py
@@ -1,5 +1,6 @@
 """HTTP client for the dradar dispatch server."""
 
+import hashlib
 import json
 import os
 import random
@@ -91,6 +92,14 @@ class ApiClient:
                  benchmark_id: str | None = None,
                  batch_id: str | None = None):
         self.server = server.rstrip("/")
+        # Stable, non-secret account boundary for local safety latches. Never
+        # persist or expose the bearer token itself.
+        self.account_scope = (
+            hashlib.sha256(
+                f"{self.server}\0{token}".encode("utf-8"),
+            ).hexdigest()
+            if token else None
+        )
         self.plan_scoped = token.startswith("drp_")
         self.benchmark_id = benchmark_id
         self.batch_id = normalize_batch_id(batch_id)

--- a/src/dradar/empty_submission_circuit.py
+++ b/src/dradar/empty_submission_circuit.py
@@ -1,0 +1,171 @@
+"""Persistent local latch for server-verified completed empty patches."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+SCHEMA_VERSION = 1
+STATE_FILE = "empty-submission-circuits.json"
+LOCK_FILE = "empty-submission-circuits.lock"
+_PROCESS_LOCK = threading.Lock()
+
+
+def _scope(
+    assignment: dict, client_version: str, account_scope: str | None = None,
+) -> dict:
+    return {
+        "account_scope": account_scope,
+        "benchmark_id": assignment.get("benchmark_id") or "deep-swe",
+        "harness": assignment.get("agent") or "codex",
+        "provider": assignment.get("provider"),
+        "model": assignment.get("model"),
+        "effort": assignment.get("effort"),
+        "client_version": client_version,
+        "agent_version": assignment.get("agent_version"),
+    }
+
+
+def _key(scope: dict) -> str:
+    return json.dumps(scope, sort_keys=True, separators=(",", ":"))
+
+
+@contextmanager
+def _locked(home: Path) -> Iterator[None]:
+    home.mkdir(parents=True, exist_ok=True)
+    with _PROCESS_LOCK:
+        fd = os.open(home / LOCK_FILE, os.O_RDWR | os.O_CREAT, 0o600)
+        if os.fstat(fd).st_size == 0:
+            os.write(fd, b"\0")
+        os.lseek(fd, 0, os.SEEK_SET)
+        windows_lock = False
+        try:
+            try:
+                import fcntl
+                fcntl.flock(fd, fcntl.LOCK_EX)
+            except ImportError:  # pragma: no cover - Windows CI
+                import msvcrt
+                msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+                windows_lock = True
+            yield
+        finally:
+            if windows_lock:  # pragma: no cover - Windows CI
+                import msvcrt
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            else:
+                try:
+                    import fcntl
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                except (ImportError, OSError):
+                    pass
+            os.close(fd)
+
+
+def _load(home: Path) -> dict:
+    try:
+        value = json.loads((home / STATE_FILE).read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return {"schema_version": SCHEMA_VERSION, "circuits": {}}
+    if not isinstance(value, dict) or value.get("schema_version") != SCHEMA_VERSION:
+        return {"schema_version": SCHEMA_VERSION, "circuits": {}}
+    circuits = value.get("circuits")
+    if not isinstance(circuits, dict):
+        value["circuits"] = {}
+    return value
+
+
+def _save(home: Path, state: dict) -> None:
+    fd, raw_tmp = tempfile.mkstemp(
+        dir=home, prefix=f".{STATE_FILE}.", suffix=".tmp",
+    )
+    tmp = Path(raw_tmp)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(state, handle, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, home / STATE_FILE)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def open_for(
+    home: Path, assignment: dict, client_version: str, *,
+    account_scope: str | None = None,
+) -> bool:
+    """Read without creating state, for pre-claim/pre-checkout checks."""
+    state = _load(home)
+    return _key(_scope(
+        assignment, client_version, account_scope,
+    )) in state["circuits"]
+
+
+def open_for_claim(
+    home: Path, cell: dict, client_version: str, *,
+    account_scope: str | None = None,
+    conservative_missing_runtime: bool = False,
+) -> bool:
+    """Match a not-yet-claimed menu cell without inventing missing metadata."""
+    candidate = _scope(cell, client_version, account_scope)
+    for saved in _load(home)["circuits"].values():
+        scope = saved.get("scope") if isinstance(saved, dict) else None
+        if not isinstance(scope, dict):
+            continue
+        if any(
+            scope.get(key) != candidate.get(key)
+            for key in (
+                "account_scope", "benchmark_id", "model", "effort",
+                "client_version",
+            )
+        ):
+            continue
+        optional = ("harness", "provider", "agent_version")
+        if any(
+            scope.get(key) != candidate.get(key)
+            and not (
+                conservative_missing_runtime and candidate.get(key) is None
+            )
+            for key in optional
+        ):
+            continue
+        return True
+    return False
+
+
+def record_empty(
+    home: Path, assignment: dict, client_version: str, *,
+    account_scope: str | None = None,
+) -> None:
+    with _locked(home):
+        state = _load(home)
+        scope = _scope(assignment, client_version, account_scope)
+        state["circuits"][_key(scope)] = {
+            "scope": scope,
+            "assignment_id": assignment.get("assignment_id"),
+            "task_id": assignment.get("task_id"),
+        }
+        _save(home, state)
+
+
+def record_success(
+    home: Path, assignment: dict, client_version: str, *,
+    account_scope: str | None = None,
+) -> None:
+    """A normal non-empty accepted submission explicitly rearms its scope."""
+    with _locked(home):
+        state = _load(home)
+        state["circuits"].pop(_key(_scope(
+            assignment, client_version, account_scope,
+        )), None)
+        if state["circuits"]:
+            _save(home, state)
+        else:
+            (home / STATE_FILE).unlink(missing_ok=True)

--- a/src/dradar/refill.py
+++ b/src/dradar/refill.py
@@ -32,6 +32,7 @@ RUNNING_STATES = {"active", "draining"}
 FAULTED_STATE = "faulted"
 REFILL_FAULT_FAMILIES = frozenset({
     "checkpoint_invalid", "checkpoint_incompatible", "provider_not_ready",
+    "empty_submission",
 })
 TIERS = ("plus", "pro-5x", "pro-20x")
 REFILL_ORDERS = ("cost", "least-run")
@@ -923,6 +924,10 @@ def refill_once(home: Path, client) -> dict:
                         cell["task_id"], cell["model"], cell["effort"],
                     )
             except ApiError as exc:
+                if exc.code == "empty_submission_circuit_open":
+                    plan["status"] = FAULTED_STATE
+                    plan["stop_reason"] = str(exc)
+                    break
                 if exc.code in {
                     "refill_limit_reached", "refill_campaign_not_active",
                     "refill_campaign_faulted",

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -27,7 +27,8 @@ import uuid
 
 from . import (
     __version__, artifact_staging, assignment_boundary, assignment_lock, egress,
-    failure_circuit, image_cache, local_jobs, pending, refill as refill_plan,
+    empty_submission_circuit, failure_circuit, image_cache, local_jobs, pending,
+    refill as refill_plan,
 )
 from .api_client import ApiClient, ApiError, normalize_batch_id
 from .codebuddy_provider import (
@@ -156,6 +157,7 @@ _ACCOUNT_TERMINAL_OUTCOMES = {
     "auth-failure", "insufficient-balance", "quota-exhausted",
     "runtime-incompatible", "provider-preflight-failed",
     "repeat-agent-failure",
+    "empty-submission",
 }
 _POOL_ABORT_ENV = "DRADAR_POOL_ABORT_FILE"
 _POOL_TARGET_FILE_ENV = "DRADAR_POOL_TARGET_FILE"
@@ -561,6 +563,9 @@ def _announce_account_stop(outcome: str) -> None:
         "repeat-agent-failure": (
             "the same zero-progress agent command failure repeated"
         ),
+        "empty-submission": (
+            "the server verified a completed run produced an empty model patch"
+        ),
     }
     reason = messages.get(outcome, "an account-wide stop condition was detected")
     print(
@@ -570,6 +575,70 @@ def _announce_account_stop(outcome: str) -> None:
         "Unstarted leases remain untouched; fix or wait for "
         "the condition, then explicitly start `dradar resume` again."
     )
+
+
+def _empty_submission_blocked_ids(
+    active: list[dict], client: ApiClient | None = None,
+) -> set[str]:
+    return {
+        assignment["assignment_id"]
+        for assignment in active
+        if assignment.get("assignment_id")
+        and empty_submission_circuit.open_for(
+            HOME, assignment, __version__,
+            account_scope=getattr(client, "account_scope", None),
+        )
+    }
+
+
+def _allow_explicit_empty_submission_retry(
+    args, active: list[dict], client: ApiClient | None = None,
+) -> bool:
+    """Gate persisted blank-patch scopes before any new model/checkout work.
+
+    Automated, refill and multi-cell invocations fail closed. A human may
+    explicitly re-run exactly one held assignment after seeing the diagnosis;
+    a normal non-empty acknowledgement clears the durable latch.
+    """
+    blocked_ids = _empty_submission_blocked_ids(active, client)
+    blocked = [
+        assignment for assignment in active
+        if assignment.get("assignment_id") in blocked_ids
+    ]
+    if not blocked:
+        return True
+    if len(blocked) < len(active):
+        print(
+            f"leaving {len(blocked)} empty-patch-circuit assignment(s) "
+            "untouched while continuing unrelated runtime scopes"
+        )
+        return True
+    automatic = bool(
+        getattr(args, "worker_child", False)
+        or getattr(args, "refill", False)
+        or getattr(args, "auto", None) is not None
+        or getattr(args, "yes", False)
+        or len(active) != 1
+    )
+    if automatic:
+        print(
+            "server-verified empty-patch circuit is still open for this "
+            "runtime; no new checkout or refill was attempted. Existing "
+            "in-flight siblings are untouched. Run an interactive single-task "
+            "`dradar resume` when you are ready to diagnose and retry."
+        )
+        return False
+    assignment = blocked[0]
+    answer = input(
+        f"the previous completed {assignment.get('model')}@"
+        f"{assignment.get('effort')} run produced an empty model patch. "
+        "Explicitly retry this one held task now? [y/N] "
+    ).strip().lower()
+    if answer not in {"y", "yes"}:
+        print("retry cancelled; the assignment and circuit remain untouched")
+        return False
+    args._empty_submission_retry_confirmed = True
+    return True
 
 
 def _repeat_failure_state_path() -> Path | None:
@@ -819,6 +888,31 @@ def _choose_menu_entry(menu: list[dict], yes: bool) -> dict:
     return menu[0]
 
 
+def _allow_claim_after_empty_submission(
+    client: ApiClient, cell: dict, *, automatic: bool,
+    conservative_missing_runtime: bool = False,
+) -> bool:
+    if not empty_submission_circuit.open_for_claim(
+        HOME, cell, __version__,
+        account_scope=getattr(client, "account_scope", None),
+        conservative_missing_runtime=conservative_missing_runtime,
+    ):
+        return True
+    label = f"{cell.get('task_id')}/{cell.get('model')}@{cell.get('effort')}"
+    if automatic:
+        print(
+            f"  {label}: not claimed — a persisted server-verified empty-patch "
+            "circuit blocks automatic claims for this runtime"
+        )
+        return False
+    answer = input(
+        f"the previous completed {cell.get('model')}@{cell.get('effort')} "
+        "run produced an empty patch. Explicitly claim this one task for a "
+        "diagnostic retry? [y/N] "
+    ).strip().lower()
+    return answer in {"y", "yes"}
+
+
 def _claim_from_menu(client: ApiClient, menu: list[dict], yes: bool) -> dict | None:
     """Claim a menu entry, retrying once with a fresh menu if it went stale.
     Returns the claimed assignment (or an already-held one, when a 409 meant
@@ -826,6 +920,10 @@ def _claim_from_menu(client: ApiClient, menu: list[dict], yes: bool) -> dict | N
     None when no work is available."""
     for attempt in range(2):
         choice = _choose_menu_entry(menu, yes)
+        if not _allow_claim_after_empty_submission(
+            client, choice, automatic=yes,
+        ):
+            return None
         try:
             data = client.claim_assignment(choice["task_id"], choice["model"], choice["effort"])
             return data.get("assignment")
@@ -857,7 +955,10 @@ class _ConcurrentCapHit(Exception):
     line N times."""
 
 
-def _claim_cell(client: ApiClient, task_id: str, model: str, effort: str) -> dict | None:
+def _claim_cell(
+    client: ApiClient, task_id: str, model: str, effort: str, *,
+    automatic: bool = True, cell_metadata: dict | None = None,
+) -> dict | None:
     """Claim one cell, printing a clear per-cell success/failure line (the
     acceptance bar from volunteer issue #1: an Agent driving this headlessly
     needs to know exactly what landed, not just an aggregate count). A stale/
@@ -865,6 +966,17 @@ def _claim_cell(client: ApiClient, task_id: str, model: str, effort: str) -> dic
     rest of the batch. Everything else (401, the concurrent-hold cap, a
     validation error) propagates: _ConcurrentCapHit to the batch loop,
     anything else to _exit_for."""
+    if not _allow_claim_after_empty_submission(
+        client, cell_metadata or {
+            "task_id": task_id, "model": model, "effort": effort,
+        },
+        automatic=automatic,
+        # --pick carries no provider/runtime metadata. Automated exact picks
+        # must fail closed on a matching core scope; an interactive pick can
+        # still proceed only after the explicit diagnostic confirmation.
+        conservative_missing_runtime=cell_metadata is None,
+    ):
+        return None
     try:
         data = client.claim_assignment(task_id, model, effort)
     except ApiError as exc:
@@ -881,13 +993,17 @@ def _claim_cell(client: ApiClient, task_id: str, model: str, effort: str) -> dic
     return a
 
 
-def _claim_picks(client: ApiClient, specs: list[str]) -> list[dict]:
+def _claim_picks(
+    client: ApiClient, specs: list[str], *, automatic: bool = True,
+) -> list[dict]:
     """`dradar go --pick task:model:effort` (repeatable): claim exact cells by
     ID instead of picking from the web or auto-suggesting."""
     claimed = []
     try:
         for task_id, model, effort in (_parse_pick(s) for s in specs):
-            a = _claim_cell(client, task_id, model, effort)
+            a = _claim_cell(
+                client, task_id, model, effort, automatic=automatic,
+            )
             if a is not None:
                 claimed.append(a)
     except _ConcurrentCapHit as exc:
@@ -896,7 +1012,8 @@ def _claim_picks(client: ApiClient, specs: list[str]) -> list[dict]:
 
 
 def _top_up_picks(
-    client: ApiClient, active: list[dict], specs: list[str],
+    client: ApiClient, active: list[dict], specs: list[str], *,
+    automatic: bool = True,
 ) -> list[dict]:
     """Claim exact requested cells that are not already held.
 
@@ -917,7 +1034,7 @@ def _top_up_picks(
             continue
         seen.add(cell)
         missing.append(spec)
-    return active + _claim_picks(client, missing)
+    return active + _claim_picks(client, missing, automatic=automatic)
 
 
 def _claim_auto(client: ApiClient, n: int) -> list[dict]:
@@ -934,7 +1051,10 @@ def _claim_auto(client: ApiClient, n: int) -> list[dict]:
     claimed = []
     try:
         for c in cells:
-            a = _claim_cell(client, c["task_id"], c["model"], c["effort"])
+            a = _claim_cell(
+                client, c["task_id"], c["model"], c["effort"],
+                cell_metadata=c,
+            )
             if a is not None:
                 claimed.append(a)
     except _ConcurrentCapHit as exc:
@@ -2364,7 +2484,19 @@ def _upload_trial(
         archive_after_submit(HOME, entry)
     pending.remove(HOME, assignment_id)
     cleanup_settled()
-    if ack.get("grade_status") == "invalid":
+    exact_empty_submission = (
+        ack.get("terminal_outcome") == "empty-submission"
+        and ack.get("failure_kind") == "empty-submission"
+        and ack.get("failure_layer") == "artifact"
+        and ack.get("failure_code") == "empty-model-patch"
+    )
+    if exact_empty_submission:
+        print(
+            f"recorded completed empty patch: {ack['submission_id']} — the "
+            "server kept the audit artifacts but no new automatic work will "
+            "start for this runtime until an explicit single-task retry"
+        )
+    elif ack.get("grade_status") == "invalid":
         # Neutral by design: the cause (printed by _run_and_submit's
         # diagnosis) may be anything from a stale agent image to a real rate
         # limit — claiming "wait for your quota to reset" here misled a real
@@ -2401,6 +2533,8 @@ def _upload_trial(
                       "(`dradar cleanup --include-kept` removes them later)")
         else:
             shutil.rmtree(job_dir, ignore_errors=True)
+    if exact_empty_submission:
+        return "empty-submission"
     return "interrupted" if outcome == "interrupted" else "submitted"
 
 
@@ -3142,8 +3276,26 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
         and not getattr(args, "yes", False)
         and not getattr(args, "parallel", False)
     ))
+    if upload_outcome == "empty-submission":
+        empty_submission_circuit.record_empty(
+            HOME, assignment, __version__,
+            account_scope=getattr(client, "account_scope", None),
+        )
+        if getattr(args, "refill", False):
+            refill_plan.open_circuit(HOME, assignment, "empty_submission")
+        _signal_pool_abort(
+            "server-verified completed empty model patch",
+            interrupt_siblings=False,
+        )
+    elif upload_outcome == "submitted":
+        empty_submission_circuit.record_success(
+            HOME, assignment, __version__,
+            account_scope=getattr(client, "account_scope", None),
+        )
     if telemetry:
-        upload_succeeded = upload_outcome in {"submitted", "interrupted"}
+        upload_succeeded = upload_outcome in {
+            "submitted", "interrupted", "empty-submission",
+        }
         _record_flight_event(telemetry,
             "upload_completed" if upload_succeeded else "upload_failed",
             component="upload", assignment_id=assignment["assignment_id"],
@@ -5470,6 +5622,14 @@ def _run_batch(args, client: ApiClient, tasks_root: Path, active: list[dict],
     if not active:
         print("all held assignments already have durable pending results; refusing to rerun")
         return 1
+    empty_blocked_ids = _empty_submission_blocked_ids(active, client)
+    if empty_blocked_ids and len(empty_blocked_ids) < len(active):
+        active = [
+            assignment for assignment in active
+            if assignment.get("assignment_id") not in empty_blocked_ids
+        ]
+    if not _allow_explicit_empty_submission_retry(args, active, client):
+        return 1
     tasks_root, local_commit = _version_pinned_tasks_root(
         active[0].get("deep_swe_commit"), tasks_root, args.allow_task_drift,
     )
@@ -5488,7 +5648,9 @@ def _run_batch(args, client: ApiClient, tasks_root: Path, active: list[dict],
             print("  it's your call whether you have room for this — dradar doesn't track "
                   "your subscription usage. If you don't finish before the lease expires, "
                   "the cell just reopens for someone else and nothing is counted.")
-        if not args.yes:
+        if not args.yes and not getattr(
+            args, "_empty_submission_retry_confirmed", False,
+        ):
             prompt = "run it now? [y/N]" + (" (or 's' to skip this one)" if n > 1 else "") + " "
             answer = input(prompt).strip().lower()
             if n > 1 and answer == "s":
@@ -5571,10 +5733,13 @@ def _run_checkout_loop(args, client: ApiClient, tasks_root: Path,
     batch instead of racing over a shared snapshot. Returns None when the
     server predates the checkout endpoint — the caller falls back to the
     legacy whole-batch flow."""
+    if not _allow_explicit_empty_submission_retry(args, active, client):
+        return 1
     tasks_root, local_commit = _version_pinned_tasks_root(
         active[0].get("deep_swe_commit"), tasks_root, args.allow_task_drift,
     )
     results, failed_ids = [], set()
+    local_empty_blocked_ids = _empty_submission_blocked_ids(active, client)
     batch_assignment_ids = {
         item["assignment_id"] for item in active if item.get("assignment_id")
     }
@@ -5595,6 +5760,7 @@ def _run_checkout_loop(args, client: ApiClient, tasks_root: Path,
             break
         checkout_exclusions = (
             failed_ids | degraded_exclusions
+            | local_empty_blocked_ids
             | (pending.assignment_ids(HOME) & batch_assignment_ids)
         )
         try:
@@ -6246,7 +6412,9 @@ def _prepare_batch(args, client: ApiClient) -> tuple[list[dict], bool]:
               "unchanged; use `dradar cleanup --docker --dry-run` to inspect cleanup.")
     elif free_pick and wants_pick:
         try:
-            active = _top_up_picks(client, active, wants_pick)
+            active = _top_up_picks(
+                client, active, wants_pick, automatic=args.yes,
+            )
         except ApiError as exc:
             _exit_for(exc)
     elif free_pick and auto_target is not None and not wants_refill:

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -6,6 +6,7 @@ import threading
 from types import SimpleNamespace
 
 import dradar.runloop as runloop
+from dradar import empty_submission_circuit
 import pytest
 from dradar.api_client import ApiError
 from dradar.runner import diagnose_exception
@@ -64,6 +65,233 @@ class StubTelemetry:
 
     def set_phase(self, phase, assignment_id=None, resume_generation=None):
         self.phases.append((phase, assignment_id, resume_generation))
+
+
+def test_persisted_empty_submission_blocks_new_batch_before_checkout(
+        monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    failed = _cell("prior-empty")
+    empty_submission_circuit.record_empty(
+        tmp_path, failed, runloop.__version__,
+    )
+    restarted = {**_cell("new-batch"), "batch_id": "batch-2"}
+    client = CheckoutClient(
+        {"active": [restarted], "free_pick": True},
+        [{"assignment": restarted, "held": 1, "unstarted": 0}],
+    )
+    args = _args()
+    args.yes = True
+
+    assert runloop._run_checkout_loop(args, client, tmp_path, [restarted]) == 1
+    assert client.checkout_exclusions == []
+    assert "no new checkout or refill" in capsys.readouterr().out
+
+
+def test_first_exact_empty_submission_stops_before_next_checkout(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(runloop, "_check_version_pin", lambda *a, **kw: None)
+    attempts = []
+
+    def run(_client, assignment, *_args, **_kwargs):
+        attempts.append(assignment["assignment_id"])
+        return "empty-submission"
+
+    monkeypatch.setattr(runloop, "_run_and_submit", run)
+    cells = [_cell("empty"), _cell("must-not-start")]
+    client = CheckoutClient(
+        {"active": cells, "free_pick": True},
+        [
+            {"assignment": cells[0], "held": 2, "unstarted": 1},
+            {"assignment": cells[1], "held": 2, "unstarted": 0},
+        ],
+    )
+
+    assert runloop._run_checkout_loop(_args(), client, tmp_path, cells) == 1
+    assert attempts == ["empty"]
+    assert len(client.checkout_exclusions) == 1
+
+
+def test_interactive_single_task_can_explicitly_retry_and_success_rearms(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    assignment = _cell("retry")
+    empty_submission_circuit.record_empty(
+        tmp_path, assignment, runloop.__version__,
+    )
+    args = _args()
+    args.yes = False
+    monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+
+    assert runloop._allow_explicit_empty_submission_retry(args, [assignment])
+    empty_submission_circuit.record_success(
+        tmp_path, assignment, runloop.__version__,
+    )
+    assert not empty_submission_circuit.open_for(
+        tmp_path, assignment, runloop.__version__,
+    )
+
+
+def test_persisted_empty_submission_blocks_auto_claim_before_request(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    assignment = _cell("prior")
+    empty_submission_circuit.record_empty(
+        tmp_path, assignment, runloop.__version__,
+    )
+
+    class Client:
+        def claim_assignment(self, *_args):
+            raise AssertionError("automatic claim must be blocked locally")
+
+    assert runloop._claim_cell(
+        Client(), assignment["task_id"], assignment["model"],
+        assignment["effort"], cell_metadata=assignment,
+    ) is None
+
+
+def test_persisted_empty_submission_does_not_block_new_runtime_claim(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    failed = {**_cell("prior"), "agent_version": "0.144.1"}
+    empty_submission_circuit.record_empty(
+        tmp_path, failed, runloop.__version__,
+    )
+    new_runtime = {**failed, "agent_version": "0.145.0"}
+
+    class Client:
+        def claim_assignment(self, *_args):
+            return {"assignment": new_runtime}
+
+    assert runloop._claim_cell(
+        Client(), new_runtime["task_id"], new_runtime["model"],
+        new_runtime["effort"], cell_metadata=new_runtime,
+    ) == new_runtime
+
+
+def test_persisted_empty_submission_does_not_block_other_provider_claim(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    failed = {**_cell("prior"), "provider": "openai"}
+    empty_submission_circuit.record_empty(
+        tmp_path, failed, runloop.__version__,
+    )
+    other_provider = {**failed, "provider": "azure-openai"}
+
+    class Client:
+        def claim_assignment(self, *_args):
+            return {"assignment": other_provider}
+
+    assert runloop._claim_cell(
+        Client(), other_provider["task_id"], other_provider["model"],
+        other_provider["effort"], cell_metadata=other_provider,
+    ) == other_provider
+
+
+def test_automatic_exact_pick_without_runtime_metadata_fails_closed(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    failed = {
+        **_cell("prior"), "provider": "openai", "agent_version": "0.144.1",
+    }
+    empty_submission_circuit.record_empty(
+        tmp_path, failed, runloop.__version__,
+    )
+
+    class Client:
+        def claim_assignment(self, *_args):
+            raise AssertionError("automatic exact pick must be blocked locally")
+
+    assert runloop._claim_cell(
+        Client(), failed["task_id"], failed["model"], failed["effort"],
+    ) is None
+
+
+def test_interactive_exact_pick_without_runtime_metadata_requires_confirmation(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    failed = {
+        **_cell("prior"), "provider": "openai", "agent_version": "0.144.1",
+    }
+    empty_submission_circuit.record_empty(
+        tmp_path, failed, runloop.__version__,
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+
+    class Client:
+        def claim_assignment(self, *_args):
+            return {"assignment": failed}
+
+    assert runloop._claim_cell(
+        Client(), failed["task_id"], failed["model"], failed["effort"],
+        automatic=False,
+    ) == failed
+
+
+def test_checkout_mixed_scopes_excludes_only_empty_submission_scope(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    monkeypatch.setattr(runloop, "_check_version_pin", lambda *a, **kw: None)
+    blocked = {**_cell("blocked"), "agent_version": "0.144.1"}
+    safe = {**_cell("safe"), "agent_version": "0.145.0"}
+    empty_submission_circuit.record_empty(
+        tmp_path, blocked, runloop.__version__,
+    )
+    ran = []
+
+    def run(_client, assignment, *_args, **_kwargs):
+        ran.append(assignment["assignment_id"])
+        return "submitted"
+
+    monkeypatch.setattr(runloop, "_run_and_submit", run)
+    client = CheckoutClient(
+        {"active": [blocked, safe], "free_pick": True},
+        [{"assignment": safe, "held": 2, "unstarted": 0},
+         {"assignment": None, "held": 2, "unstarted": 0}],
+    )
+
+    assert runloop._run_checkout_loop(_args(), client, tmp_path, [blocked, safe]) == 0
+    assert ran == ["safe"]
+    assert client.checkout_exclusions[0] == {"blocked"}
+
+
+def test_legacy_batch_mixed_scopes_runs_only_safe_assignments(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    monkeypatch.setattr(
+        runloop, "_version_pinned_tasks_root",
+        lambda *_args, **_kwargs: (tmp_path, None),
+    )
+    blocked = {**_cell("blocked"), "agent_version": "0.144.1"}
+    safe = {**_cell("safe"), "agent_version": "0.145.0"}
+    empty_submission_circuit.record_empty(
+        tmp_path, blocked, runloop.__version__,
+    )
+    ran = []
+
+    def run(_client, assignment, *_args, **_kwargs):
+        ran.append(assignment["assignment_id"])
+        return "submitted"
+
+    monkeypatch.setattr(runloop, "_run_and_submit", run)
+    args = _args()
+    args.yes = True
+
+    assert runloop._run_batch(args, object(), tmp_path, [blocked, safe]) == 0
+    assert ran == ["safe"]
+
+
+def test_local_empty_submission_scope_does_not_cross_accounts(tmp_path):
+    assignment = _cell("prior")
+    empty_submission_circuit.record_empty(
+        tmp_path, assignment, runloop.__version__, account_scope="account-a",
+    )
+
+    assert empty_submission_circuit.open_for(
+        tmp_path, assignment, runloop.__version__, account_scope="account-a",
+    )
+    assert not empty_submission_circuit.open_for(
+        tmp_path, assignment, runloop.__version__, account_scope="account-b",
+    )
 
 
 def test_checkout_loop_runs_dispensed_cells_until_drained(monkeypatch, capsys, tmp_path):

--- a/tests/test_pending_upload.py
+++ b/tests/test_pending_upload.py
@@ -131,6 +131,38 @@ def test_upload_success_clears_ledger(tmp_path: Path, monkeypatch):
     assert pending.load(tmp_path) == []
 
 
+def test_exact_empty_submission_ack_is_not_collapsed_to_submitted(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    pending.record(tmp_path, {"assignment_id": "a1", "task_id": "t1"})
+    client = FakeClient(lambda _aid: {
+        "submission_id": "s-empty",
+        "grade_status": "invalid",
+        "terminal_outcome": "empty-submission",
+        "failure_kind": "empty-submission",
+        "failure_layer": "artifact",
+        "failure_code": "empty-model-patch",
+    })
+
+    assert runloop._upload_trial(client, _entry(trial_dir)) == "empty-submission"
+    assert pending.load(tmp_path) == []
+
+
+def test_generic_progress_bearing_invalid_remains_non_circuit_submission(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    client = FakeClient(lambda _aid: {
+        "submission_id": "s-invalid", "grade_status": "invalid",
+        "failure_kind": "rate-limit",
+    })
+
+    assert runloop._upload_trial(client, _entry(trial_dir)) == "submitted"
+
+
 def test_session_bound_upload_registers_intent_before_submit(
     tmp_path: Path, monkeypatch,
 ):


### PR DESCRIPTION
## Scope

P0 mitigation for #0013. This preserves the completed upload/audit path but treats the server-owned `empty-submission / artifact / empty-model-patch` acknowledgement as a dedicated terminal outcome.

- persist a private account/runtime-scoped local latch across runner, batch, and process restarts
- stop new automatic claim, checkout, and refill after the first exact acknowledgement
- gracefully drain already-running sibling workers without interrupting them
- allow only an explicit interactive single-task diagnostic retry
- keep all other progress-bearing invalid results on their existing path
- clear the exact latch after a normal non-empty accepted submission

This is a containment change only. It does **not** fix or claim to identify the 8 GB code-mode/unified_exec SIGKILL/OOM root cause.

## Safety and non-regression

- server acknowledgement must match all four structured fields; generic invalids do not trip this latch
- scope includes non-secret account hash, benchmark, harness/provider, model/effort, CLI version, and agent runtime
- mixed-scope batches exclude only the blocked assignment
- reward=0 graded submissions, timeout, rate limit, agent-command-failed, patch-bearing invalids, and other accounts are unaffected
- no lease recovery/release semantics changed
- no real assignment was claimed and no production state was changed

## Validation

- full CLI suite: **1658 passed**
- targeted checkout/upload suite: **126 passed**
- independent QA: P0 empty-submission refill containment **PASS**
- external regressions cover runtime/provider isolation, mixed-scope draining, and automatic exact-pick fail-closed behavior
- `git diff --check` and sensitive-data scan passed

Independent QA explicitly does not mark #0013 fully closed: the 8 GB unified_exec SIGKILL root-cause track remains open.

## Integration note

PR #291 (#0021) also edits refill/runloop/API-client files for bounded paid-API refill. The goals are orthogonal, but final integration must be serial: whichever lands second must rebase onto current `main`, preserve both safeguards, and rerun the full suite. No code from #291 or legacy PR #277 is merged here.

## Rollback

Revert commit `a1e3a3b`. This removes only the local latch/terminal handling and its tests; it does not alter server data or lease state.
