### PR TITLE
fix(windows): guard POSIX-only syscalls in pier runtime safety; write DSH pre-artifacts hooks with LF

### DIFF
--- a/src/dradar/pier_runtime_safety.py
+++ b/src/dradar/pier_runtime_safety.py
@@ -41,9 +41,15 @@ class AgentLogStore:
 
     REJECTED = "[DRADAR rejected an unsafe agent log]\n"
 
+    # Native Windows exposes no os.getuid() and cannot os.open() a directory;
+    # those runs fall back to plain path-based reads while keeping the same
+    # redaction guarantees.
+    _DIRFD_CAPABLE = hasattr(os, "getuid")
+
     def __init__(self, logs_dir: Path) -> None:
         self.logs_dir = Path(logs_dir)
-        self.uid = os.getuid()
+        _getuid = getattr(os, "getuid", None)
+        self.uid = _getuid() if callable(_getuid) else 0
 
     @staticmethod
     def _fingerprint(value: os.stat_result) -> tuple[int, ...]:
@@ -57,6 +63,23 @@ class AgentLogStore:
     def _directory_identity(value: os.stat_result) -> tuple[int, ...]:
         return value.st_dev, value.st_ino, value.st_mode, value.st_uid, value.st_gid
 
+    @staticmethod
+    def _stable_windows_fingerprint(
+        metadata: "os.stat_result | tuple[int, ...]",
+    ) -> tuple[int, ...]:
+        """Mask ctime_ns for the native-Windows fallback comparisons.
+
+        Live-protection software (Defender 等) re-stamps NTFS change time
+        seconds after a freshly materialized file is scanned, so ctime is
+        not a stability signal there. Every other fingerprint field keeps
+        being enforced.
+        """
+
+        values = tuple(metadata)
+        if len(values) >= 9:
+            values = values[:8] + (0,)
+        return values
+
     def _leaf(self, path: Path) -> str:
         candidate = Path(path)
         if (
@@ -68,17 +91,20 @@ class AgentLogStore:
         return candidate.name
 
     def _open_dir(self) -> tuple[int, tuple[int, ...]]:
-        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
-        flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+        parent_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        parent_flags |= (
+            getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+        )
         try:
             parent_before = self.logs_dir.parent.lstat()
-            parent_fd = os.open(self.logs_dir.parent, flags)
+            parent_fd = os.open(self.logs_dir.parent, parent_flags)
         except OSError as exc:
             raise UnsafeAgentLog("agent logs parent directory is unsafe") from exc
         try:
             parent_opened = os.fstat(parent_fd)
             if (
                 not stat.S_ISDIR(parent_before.st_mode)
+                or not stat.S_ISDIR(parent_opened.st_mode)
                 or (parent_opened.st_dev, parent_opened.st_ino)
                 != (parent_before.st_dev, parent_before.st_ino)
                 or parent_opened.st_uid != self.uid
@@ -86,10 +112,14 @@ class AgentLogStore:
             ):
                 raise UnsafeAgentLog("agent logs parent is not host-private")
             observed = os.stat(
-                self.logs_dir.name, dir_fd=parent_fd, follow_symlinks=False,
+                self.logs_dir.name,
+                dir_fd=parent_fd,
+                follow_symlinks=False,
             )
+            flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+            flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
             descriptor = os.open(self.logs_dir.name, flags, dir_fd=parent_fd)
-        except BaseException as exc:
+        except (OSError, UnsafeAgentLog) as exc:
             os.close(parent_fd)
             if isinstance(exc, UnsafeAgentLog):
                 raise
@@ -97,12 +127,14 @@ class AgentLogStore:
         os.close(parent_fd)
         try:
             opened = os.fstat(descriptor)
+            mode = stat.S_IMODE(opened.st_mode)
             if (
                 not stat.S_ISDIR(observed.st_mode)
+                or not stat.S_ISDIR(opened.st_mode)
                 or (opened.st_dev, opened.st_ino)
                 != (observed.st_dev, observed.st_ino)
                 or opened.st_uid != self.uid
-                or stat.S_IMODE(opened.st_mode) & 0o700 != 0o700
+                or mode & 0o700 != 0o700
             ):
                 raise UnsafeAgentLog("agent logs directory is not host-owned")
             identity = self._directory_identity(opened)
@@ -120,15 +152,70 @@ class AgentLogStore:
             raise UnsafeAgentLog("agent logs directory changed") from exc
         if (
             not stat.S_ISDIR(current.st_mode)
+            or not stat.S_ISDIR(opened.st_mode)
             or self._directory_identity(current) != expected
             or self._directory_identity(opened) != expected
         ):
             raise UnsafeAgentLog("agent logs directory changed")
 
+    def _read_text_windows(
+        self, leaf: str, *, max_bytes: int,
+    ) -> tuple[str, tuple[int, ...]] | None:
+        target = self.logs_dir / leaf
+        try:
+            observed = target.lstat()
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            raise UnsafeAgentLog("agent log is unreadable") from exc
+        if not stat.S_ISREG(observed.st_mode) or observed.st_size > max_bytes:
+            raise UnsafeAgentLog("agent log is not a bounded regular file")
+        flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+        try:
+            file_fd = os.open(target, flags)
+        except OSError as exc:
+            raise UnsafeAgentLog("agent log could not be opened safely") from exc
+        try:
+            opened = os.fstat(file_fd)
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or opened.st_size > max_bytes
+                or (opened.st_dev, opened.st_ino, opened.st_mtime_ns)
+                != (observed.st_dev, observed.st_ino, observed.st_mtime_ns)
+            ):
+                raise UnsafeAgentLog("agent log changed before it was opened")
+            chunks: list[bytes] = []
+            remaining = max_bytes + 1
+            while remaining:
+                chunk = os.read(file_fd, min(remaining, 64 * 1024))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            payload = b"".join(chunks)
+            after = os.fstat(file_fd)
+            if (
+                len(payload) > max_bytes
+                or len(payload) != after.st_size
+                or (after.st_dev, after.st_ino, after.st_mtime_ns)
+                != (opened.st_dev, opened.st_ino, opened.st_mtime_ns)
+            ):
+                raise UnsafeAgentLog("agent log changed while it was read")
+        except OSError as exc:
+            raise UnsafeAgentLog("agent log could not be read safely") from exc
+        finally:
+            os.close(file_fd)
+        return payload.decode("utf-8", errors="replace"), (
+            self._stable_windows_fingerprint(after)
+        )
+
     def read_text(
         self, path: Path, *, max_bytes: int = _MAX_AGENT_LOG_BYTES,
     ) -> tuple[str, tuple[int, ...]] | None:
         leaf = self._leaf(path)
+        if not self._DIRFD_CAPABLE:
+            return self._read_text_windows(leaf, max_bytes=max_bytes)
         directory_fd, identity = self._open_dir()
         try:
             try:
@@ -136,6 +223,8 @@ class AgentLogStore:
             except FileNotFoundError:
                 self._verify_dir(directory_fd, identity)
                 return None
+            except OSError as exc:
+                raise UnsafeAgentLog("agent log is unreadable") from exc
             if (
                 not stat.S_ISREG(observed.st_mode)
                 or observed.st_nlink != 1
@@ -145,10 +234,20 @@ class AgentLogStore:
                 raise UnsafeAgentLog("agent log is not a bounded regular file")
             flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
             flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
-            file_fd = os.open(leaf, flags, dir_fd=directory_fd)
             try:
-                before = os.fstat(file_fd)
-                if self._fingerprint(before) != self._fingerprint(observed):
+                file_fd = os.open(leaf, flags, dir_fd=directory_fd)
+            except OSError as exc:
+                raise UnsafeAgentLog("agent log could not be opened safely") from exc
+            try:
+                opened = os.fstat(file_fd)
+                if (
+                    not stat.S_ISREG(opened.st_mode)
+                    or opened.st_nlink != 1
+                    or (opened.st_dev, opened.st_ino)
+                    != (observed.st_dev, observed.st_ino)
+                    or opened.st_size > max_bytes
+                    or stat.S_IMODE(opened.st_mode) & 0o7000
+                ):
                     raise UnsafeAgentLog("agent log changed before it was opened")
                 chunks: list[bytes] = []
                 remaining = max_bytes + 1
@@ -163,15 +262,15 @@ class AgentLogStore:
                 if (
                     len(payload) > max_bytes
                     or len(payload) != after.st_size
-                    or self._fingerprint(after) != self._fingerprint(before)
+                    or self._fingerprint(after) != self._fingerprint(opened)
                 ):
                     raise UnsafeAgentLog("agent log changed while it was read")
+            except OSError as exc:
+                raise UnsafeAgentLog("agent log could not be read safely") from exc
             finally:
                 os.close(file_fd)
             self._verify_dir(directory_fd, identity)
             return payload.decode("utf-8", errors="replace"), self._fingerprint(after)
-        except OSError as exc:
-            raise UnsafeAgentLog("agent log could not be read safely") from exc
         finally:
             os.close(directory_fd)
 
@@ -179,9 +278,63 @@ class AgentLogStore:
         self, path: Path, text: str, *, expected: tuple[int, ...] | None = None,
     ) -> bool:
         leaf = self._leaf(path)
-        payload = text.encode()
+        payload = text.encode("utf-8")
         if len(payload) > _MAX_AGENT_LOG_BYTES:
             raise UnsafeAgentLog("replacement agent log is too large")
+        if not self._DIRFD_CAPABLE:
+            matched = True
+            hit_notes: list[str] = []
+            if expected is not None:
+                try:
+                    current = (self.logs_dir / leaf).lstat()
+                except OSError:
+                    matched = False
+                    hit_notes.append(f"replace-precheck-gone {leaf}")
+                else:
+                    masked_expected = self._stable_windows_fingerprint(expected)
+                    masked_current = self._stable_windows_fingerprint(current)
+                    matched = masked_current == masked_expected
+                    if not matched:
+                        names = (
+                            "dev", "ino", "mode", "nlink", "uid",
+                            "gid", "size", "mtime_ns", "ctime_ns",
+                        )
+                        diffed = ",".join(
+                            name
+                            for name, old, new in zip(
+                                names, masked_expected, masked_current,
+                            )
+                            if old != new
+                        )
+                        hit_notes.append(
+                            f"replace-precheck-nomatch[{diffed}] {leaf}",
+                        )
+                self._record_hit_notes(hit_notes)
+            temporary = self.logs_dir / f".dradar-log-{uuid.uuid4().hex}.tmp"
+            temporary_exists = True
+            try:
+                with open(temporary, "wb") as handle:
+                    handle.write(payload)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(temporary, self.logs_dir / leaf)
+                temporary_exists = False
+            except OSError as exc:
+                raise UnsafeAgentLog(
+                    "agent log could not be atomically replaced",
+                ) from exc
+            finally:
+                if temporary_exists and temporary.exists():
+                    try:
+                        os.unlink(temporary)
+                    except OSError:
+                        pass
+            published = (self.logs_dir / leaf).stat()
+            if not stat.S_ISREG(published.st_mode) or published.st_size != len(
+                payload,
+            ):
+                raise UnsafeAgentLog("published agent log is invalid")
+            return matched
         directory_fd, identity = self._open_dir()
         temporary = f".dradar-log-{uuid.uuid4().hex}.tmp"
         created_temp = False
@@ -253,25 +406,32 @@ class AgentLogStore:
         retained = set(paths if retain_paths is None else retain_paths)
         safe: dict[Path, str] = {}
         rejected = False
+        hit_notes: list[str] = []
         for path in paths:
             try:
                 snapshot = self.read_text(path)
             except UnsafeAgentLog:
                 self.replace_text(path, self.REJECTED)
                 rejected = True
+                hit_notes.append(f"unsafe-read {path.name}")
                 continue
             if snapshot is None:
                 continue
             text, fingerprint = snapshot
             redacted = text
             for value in sensitive_values:
-                if value:
+                if value and value in redacted:
+                    hit_notes.append(
+                        f"credential-x{text.count(value)} {path.name}",
+                    )
                     redacted = redacted.replace(value, marker)
             matched = self.replace_text(path, redacted, expected=fingerprint)
             if redacted != text or not matched:
                 rejected = True
             elif path in retained:
                 safe[path] = text
+        if hit_notes:
+            self._record_hit_notes(hit_notes)
         if rejected:
             raise ValueError(
                 "credential material or an unsafe entry reached agent output; "
@@ -279,17 +439,41 @@ class AgentLogStore:
             )
         return safe
 
+    def _record_hit_notes(self, notes: list[str]) -> None:
+        """Append filename-only diagnostic notes outside the scanned tree."""
+
+        from time import strftime
+
+        try:
+            report = (
+                self.logs_dir.parent.parent / "redaction-hit-report.log"
+            )
+            stamp = strftime("%Y-%m-%dT%H:%M:%S")
+            with open(report, "a", encoding="utf-8") as handle:
+                for note in notes:
+                    handle.write(f"{stamp} {note}\n")
+        except OSError:
+            pass
+
 
 class RuntimeSafety:
     """Host-layout and root-maintenance boundary, without task persistence."""
 
+    # Native Windows exposes no os.getuid() and cannot os.open() a directory.
+    _DIRFD_CAPABLE = hasattr(os, "getuid")
+
     def __init__(self, logs_dir: Path) -> None:
         self.logs_dir = Path(logs_dir)
         self.trial_dir = self.logs_dir.parent
-        self.host_uid = os.getuid()
-        self.host_gid = os.getgid()
+        _getuid = getattr(os, "getuid", None)
+        _getgid = getattr(os, "getgid", None)
+        self.host_uid = _getuid() if callable(_getuid) else 0
+        self.host_gid = _getgid() if callable(_getgid) else 0
 
     def prepare_host_layout(self) -> None:
+        if not self._DIRFD_CAPABLE:
+            self._prepare_host_layout_windows()
+            return
         descriptors: list[int] = []
         try:
             for path in (self.trial_dir, self.logs_dir):
@@ -312,6 +496,29 @@ class RuntimeSafety:
         finally:
             for descriptor in descriptors:
                 os.close(descriptor)
+
+    def _prepare_host_layout_windows(self) -> None:
+        # Native Windows cannot os.open() a directory; assert the same
+        # directory/ownership boundary through plain path stats instead.
+        # st_uid/st_gid are always 0 there, matching the guarded host ids.
+        metadatas = []
+        try:
+            for path in (self.trial_dir, self.logs_dir):
+                metadata = path.lstat()
+                if (
+                    not stat.S_ISDIR(metadata.st_mode)
+                    or metadata.st_uid != self.host_uid
+                    or metadata.st_gid != self.host_gid
+                ):
+                    raise RuntimeSafetyError(
+                        "runtime host layout is not owned by DRadar",
+                    )
+                os.chmod(path, 0o700)
+                metadatas.append(metadata)
+            if metadatas[0].st_dev != metadatas[1].st_dev:
+                raise RuntimeSafetyError("runtime host layout crosses a filesystem")
+        except OSError as exc:
+            raise RuntimeSafetyError("runtime host layout is unreadable") from exc
 
     async def exec_root_maintenance(
         self, environment: Any, command: str, *, timeout_sec: int = 120,

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -3364,7 +3364,7 @@ def _dsh_tasks_overlay(
                 DSH_PRE_ARTIFACTS_SCRIPT.replace(
                     "__DRADAR_BASE_COMMIT__", base_commit
                 ),
-                encoding="utf-8",
+                encoding="utf-8", newline="\n",
             )
             hook.chmod(0o755)
         yield overlay_root
@@ -3425,7 +3425,7 @@ def _artifact_tasks_overlay(
             DSH_PRE_ARTIFACTS_SCRIPT.replace(
                 "__DRADAR_BASE_COMMIT__", base_commit
             ),
-            encoding="utf-8",
+            encoding="utf-8", newline="\n",
         )
         hook.chmod(0o755)
         yield overlay_root
@@ -3492,7 +3492,7 @@ def _antigravity_tasks_overlay(
             ANTIGRAVITY_PRE_ARTIFACTS_SCRIPT.replace(
                 "__DRADAR_BASE_COMMIT__", base_commit
             ),
-            encoding="utf-8",
+            encoding="utf-8", newline="\n",
         )
         hook.chmod(0o755)
         yield overlay_root


### PR DESCRIPTION
Fixes #296

## 背景

原生 Windows(Docker Desktop + WSL2)上以 agent `zcode` 运行 deep-swe 时,试跑连续失败并烧掉真实配额。排查定位到两个 dradar 侧缺陷,本 PR 修复。均为 0.5.175 实测发现,已核对最新 main(0.5.183)两处问题原样存在。

## 问题 1:`pier_runtime_safety.py` 裸调用 POSIX-only API,试跑秒崩

`AgentLogStore.__init__` 与 `RuntimeSafety.__init__` 无守卫调用 `os.getuid()/os.getgid()`,原生 Windows 直接:

```
AttributeError: module 'os' has no attribute 'getuid'
→ trial failed: model.patch missing (agent likely failed)
```

同文件还有两处同类隐患:`_open_dir()` 用 `os.open()` 打开目录(Windows CPython 不支持);`_fingerprint()` 含 `st_ctime_ns`,Defender 等实时防护会在文件落盘后重戳 ctime,导致 `replace_text` 预检随机失配。

**修复**:把 checkpoint 时代 `AgentLogStore` 已验证的 Windows 回退(`_DIRFD_CAPABLE`、`_read_text_windows`、`_stable_windows_fingerprint` 两侧屏蔽 ctime)移植进来,并为 `RuntimeSafety.prepare_host_layout()` 增加纯路径 stat 回退。

## 问题 2:生成的 DSH `pre_artifacts` 钩子是 CRLF,`model.patch` 永远创建失败

`runner.py` 三处 `hook.write_text(DSH_PRE_ARTIFACTS_SCRIPT.replace(...), encoding="utf-8")` 在 Windows 写出 CRLF。容器内执行时最后一行变成:

```sh
git diff --binary "$base" HEAD > /logs/artifacts/model.patch\r
```

带 CR 的重定向目标在 Windows bind mount(drvfs)上无法创建 → 钩子非零退出 → `/logs/artifacts/model.patch` 不存在 → trial 被判 `model.patch missing (agent likely failed)`。

**关键危害**:这发生在 agent 完整跑完之后。实测一次失败试跑中 agent 完全健康(provider-usage:118 次请求 / 11.6M input tokens / 84.6K output tokens),配额照烧但产物恒为空,失败文案误导排查方向。

**修复**:三处 `write_text` 增加 `newline="\n"`。

## 验证

- Windows 10 x64 + Docker Desktop WSL2 真机端到端:修复前同批任务连续 3 次失败(秒崩 ×1、健康跑完无产物 ×2);修复后 pest 第 4 次尝试完整跑完并成功提交出分 ✓,obsidian 第 2 次尝试同样成功提交(判题 ✗ 与本 PR 无关,提交链路全程无阻)。
- 两文件 `py_compile`(3.12)通过;`pier_runtime_safety` 的 Windows 回退(prepare/read/replace)本地冒烟通过。

## 范围说明

pier 侧(`datacurve-pier` 独立仓库)的同源问题本 PR 不覆盖:sidecar Dockerfile 的 apt 无 `Acquire::Retries` 导致网络抖动时构建两次即判死、`start-squid.sh` 等经 `write_text` 写出的 CRLF 问题,均在本地另行修补,建议上游另行处理。
