### PR TITLE
#0040 P0: isolate run-plan flight recorder evidence

### DIFF
--- a/src/dradar/api_client.py
+++ b/src/dradar/api_client.py
@@ -647,6 +647,13 @@ class ApiClient:
         excluded = sorted(set(exclude_assignment_ids or ()))
         data = {"exclude_assignment_ids": ",".join(excluded),
                 "session_id": session_id or ""}
+        if session_id:
+            # Current servers can reserve a free-pick cell for this exact
+            # runner while its environment is still building.  Older servers
+            # ignore the extra form field and keep their historical
+            # checkout-starts-runtime behaviour, so this is rolling-upgrade
+            # compatible.
+            data["prepare_only"] = "true"
         if self.benchmark_id:
             data["benchmark_id"] = self.benchmark_id
         if self.batch_id:

--- a/src/dradar/flight_recorder.py
+++ b/src/dradar/flight_recorder.py
@@ -507,10 +507,22 @@ class FlightRecorder:
                 return 0
             sent_ids = {event["event_id"] for event in batch}
             try:
-                raw_acknowledged = response.get("acknowledged_event_ids") or ()
+                raw_acknowledged = response.get("acknowledged_event_ids")
+                # The server contract is a JSON array.  Treat every other
+                # shape (including a dict whose keys happen to be event IDs,
+                # a string, or a custom iterable) as malformed evidence; a
+                # malformed response must never delete durable pending data or
+                # satisfy the strict worker-registration handshake.
+                if not isinstance(raw_acknowledged, list):
+                    return 0
+                if any(
+                    not self._valid_event_id(event_id)
+                    for event_id in raw_acknowledged
+                ):
+                    return 0
                 acknowledged = {
                     event_id for event_id in raw_acknowledged
-                    if self._valid_event_id(event_id) and event_id in sent_ids
+                    if event_id in sent_ids
                 }
             except (AttributeError, TypeError):
                 # A malformed response is not evidence of acceptance.  Keep

--- a/src/dradar/flight_recorder.py
+++ b/src/dradar/flight_recorder.py
@@ -427,8 +427,40 @@ class FlightRecorder:
         except (OSError, ValueError):
             return None
 
-    def flush(self) -> int:
+    def flush(
+        self,
+        *,
+        batch_id: str | None = None,
+        session_id: str | None = None,
+        required_event_id: str | None = None,
+    ) -> int:
+        """Upload pending events, optionally restricted to one lifecycle scope.
+
+        ``pending.jsonl`` is intentionally shared by the CLI's lightweight
+        recorder instances.  A run-plan token can therefore leave events from
+        another plan, account, or device session in the same file.  The
+        server's flight-event endpoint validates the whole request atomically;
+        sending that mixed prefix would make an otherwise valid
+        ``worker_registered`` event unacknowledgeable.  Callers that know the
+        active scope should provide its batch and session IDs.  ``None`` keeps
+        the historical unscoped replay behavior for diagnostics and legacy
+        integrations.
+
+        ``required_event_id`` is used by the synchronous worker-registration
+        handshake.  When present, the matching event is moved to the front of
+        the selected scope so an unrelated backlog cannot hide the receipt
+        behind the 100-event upload limit.  It is never selected when it falls
+        outside the requested scope.
+        """
         if self.client is None or self._remote_disabled:
+            return 0
+        # A session-only (or required-event-only) scope cannot prove the plan
+        # or account boundary.  In particular, never replay a legacy
+        # ``batch_id=null`` event under a newly authenticated session; retain
+        # it for explicit diagnostics or a future, manually selected replay.
+        if batch_id is None and (
+            session_id is not None or required_event_id is not None
+        ):
             return 0
         with self._lock:
             try:
@@ -436,7 +468,32 @@ class FlightRecorder:
                     pending = self._load(self.pending_path)
                     if not pending:
                         return 0
-                    batch = [validate_event(event) for event in pending[:UPLOAD_BATCH_SIZE]]
+                    scoped = [
+                        event for event in pending
+                        if (batch_id is None or event.get("batch_id") == batch_id)
+                        and (session_id is None or event.get("session_id") == session_id)
+                    ]
+                    if not scoped:
+                        return 0
+                    if required_event_id is not None:
+                        required = next(
+                            (
+                                event for event in scoped
+                                if event.get("event_id") == required_event_id
+                            ),
+                            None,
+                        )
+                        if required is not None:
+                            scoped = [
+                                required,
+                                *(
+                                    event for event in scoped
+                                    if event.get("event_id") != required_event_id
+                                ),
+                            ]
+                    batch = [
+                        validate_event(event) for event in scoped[:UPLOAD_BATCH_SIZE]
+                    ]
             except OSError:
                 # Flight evidence is best effort.  A locked/read-only home
                 # must never turn a heartbeat into a worker crash; strict

--- a/src/dradar/flight_recorder.py
+++ b/src/dradar/flight_recorder.py
@@ -14,9 +14,10 @@ import threading
 import time
 import uuid
 import zipfile
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 
 SCHEMA_VERSION = "dradar.flight_event.v1"
@@ -24,6 +25,62 @@ MAX_EVENT_BYTES = 4096
 MAX_LOG_BYTES = 4 * 1024 * 1024
 MAX_LOG_EVENTS = 5000
 UPLOAD_BATCH_SIZE = 100
+_LOCK_FILENAME = "recorder.lock"
+_ACKNOWLEDGED_FILENAME = "acknowledged.jsonl"
+
+# ``FlightRecorder`` is instantiated once by the fleet supervisor and once by
+# every worker child.  A Python lock only coordinates threads in one process;
+# keep a small in-process guard as well so Windows' byte-range locking does not
+# trip over two handles opened by sibling objects in the same process.
+_PROCESS_LOCK = threading.Lock()
+
+
+@contextmanager
+def _exclusive_file_lock(path: Path) -> Iterator[None]:
+    """Serialize recorder read/modify/write cycles across processes.
+
+    The lock is deliberately a separate, never-replaced file.  The JSONL files
+    themselves are atomically replaced by :meth:`FlightRecorder._write`, so a
+    reader from an older CLI still sees a complete old or new snapshot.  Both
+    POSIX ``flock`` and Windows ``msvcrt`` are used without adding a runtime
+    dependency; a crashed process releases either kernel lock automatically.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+    locked = False
+    windows_lock = False
+    with _PROCESS_LOCK:
+        try:
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"\0")
+            os.lseek(fd, 0, os.SEEK_SET)
+            try:
+                import fcntl
+
+                fcntl.flock(fd, fcntl.LOCK_EX)
+            except ImportError:  # pragma: no cover - Windows CI
+                import msvcrt
+
+                msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+                windows_lock = True
+            locked = True
+            yield
+        finally:
+            if locked:
+                try:
+                    if windows_lock:  # pragma: no cover - Windows CI
+                        import msvcrt
+
+                        os.lseek(fd, 0, os.SEEK_SET)
+                        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+                    else:
+                        import fcntl
+
+                        fcntl.flock(fd, fcntl.LOCK_UN)
+                except (ImportError, OSError):
+                    pass
+            os.close(fd)
+
 
 EVENT_TYPES = frozenset({
     "session_started", "session_closed", "phase_changed",
@@ -201,6 +258,8 @@ class FlightRecorder:
         self.events_path = self.root / "events.jsonl"
         self.pending_path = self.root / "pending.jsonl"
         self.client_id_path = self.root / "client_id"
+        self.lock_path = self.root / _LOCK_FILENAME
+        self.acknowledged_path = self.root / _ACKNOWLEDGED_FILENAME
         self._lock = threading.Lock()
         self._seq = 0
         self._remote_disabled = False
@@ -208,6 +267,21 @@ class FlightRecorder:
         self.client_id = self._load_client_id()
 
     def _load_client_id(self) -> str:
+        # Re-read after taking the inter-process lock.  Without this, two
+        # freshly-started fleet children can each mint a client ID and the last
+        # atomic replace wins on disk while the other process keeps a different
+        # in-memory identity.
+        try:
+            with _exclusive_file_lock(self.lock_path):
+                return self._load_or_create_client_id()
+        except OSError:
+            # Diagnostics and best-effort telemetry must still work on a
+            # read-only/misconfigured home.  There is no durable cross-process
+            # guarantee in this fallback, but callers already treat the local
+            # recorder as optional in that environment.
+            return self._load_or_create_client_id()
+
+    def _load_or_create_client_id(self) -> str:
         try:
             value = self.client_id_path.read_text(encoding="ascii").strip()
             if len(value) == 32 and all(c in "0123456789abcdef" for c in value):
@@ -262,6 +336,46 @@ class FlightRecorder:
         os.chmod(temporary, 0o600)
         os.replace(temporary, path)
 
+    @staticmethod
+    def _valid_event_id(value: Any) -> bool:
+        return (
+            isinstance(value, str)
+            and len(value) == 32
+            and all(char in "0123456789abcdef" for char in value)
+        )
+
+    def _load_acknowledged_ids_unlocked(self) -> list[str]:
+        try:
+            lines = self.acknowledged_path.read_text(encoding="ascii").splitlines()
+        except OSError:
+            return []
+        values: list[str] = []
+        seen: set[str] = set()
+        for value in lines[-MAX_LOG_EVENTS:]:
+            if self._valid_event_id(value) and value not in seen:
+                values.append(value)
+                seen.add(value)
+        return values
+
+    def _write_acknowledged_ids_unlocked(self, event_ids: set[str]) -> None:
+        """Persist a bounded shared receipt set under the recorder lock."""
+        if not event_ids:
+            return
+        values = self._load_acknowledged_ids_unlocked()
+        seen = set(values)
+        for event_id in event_ids:
+            if self._valid_event_id(event_id) and event_id not in seen:
+                values.append(event_id)
+                seen.add(event_id)
+        values = values[-MAX_LOG_EVENTS:]
+        self.acknowledged_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        temporary = self.acknowledged_path.with_name(
+            f".{self.acknowledged_path.name}.{os.getpid()}.{time.time_ns()}"
+        )
+        temporary.write_text("".join(value + "\n" for value in values), encoding="ascii")
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, self.acknowledged_path)
+
     def record(
         self,
         event_type: str,
@@ -275,29 +389,30 @@ class FlightRecorder:
         attributes: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         with self._lock:
-            self._seq += 1
-            event = {
-                "schema_version": SCHEMA_VERSION,
-                "event_id": uuid.uuid4().hex,
-                "client_id": self.client_id,
-                "occurred_at": datetime.now(timezone.utc).isoformat(),
-                "seq": self._seq,
-                "event_type": event_type,
-                "component": component,
-                "actor": "cli",
-                "batch_id": batch_id,
-                "session_id": session_id,
-                "assignment_id": assignment_id,
-                "request_id": request_id,
-                "reason_code": reason_code,
-                "attributes": attributes or {},
-            }
-            event = validate_event(event)
-            history = self._load(self.events_path)
-            pending = self._load(self.pending_path)
-            self._write(self.events_path, [*history, event])
-            self._write(self.pending_path, [*pending, event])
-            return event
+            with _exclusive_file_lock(self.lock_path):
+                self._seq += 1
+                event = {
+                    "schema_version": SCHEMA_VERSION,
+                    "event_id": uuid.uuid4().hex,
+                    "client_id": self.client_id,
+                    "occurred_at": datetime.now(timezone.utc).isoformat(),
+                    "seq": self._seq,
+                    "event_type": event_type,
+                    "component": component,
+                    "actor": "cli",
+                    "batch_id": batch_id,
+                    "session_id": session_id,
+                    "assignment_id": assignment_id,
+                    "request_id": request_id,
+                    "reason_code": reason_code,
+                    "attributes": attributes or {},
+                }
+                event = validate_event(event)
+                history = self._load(self.events_path)
+                pending = self._load(self.pending_path)
+                self._write(self.events_path, [*history, event])
+                self._write(self.pending_path, [*pending, event])
+                return event
 
     def try_record(self, event_type: str, **kwargs) -> dict[str, Any] | None:
         """Record best-effort evidence without affecting the primary workflow.
@@ -316,43 +431,82 @@ class FlightRecorder:
         if self.client is None or self._remote_disabled:
             return 0
         with self._lock:
-            pending = self._load(self.pending_path)
-            if not pending:
+            try:
+                with _exclusive_file_lock(self.lock_path):
+                    pending = self._load(self.pending_path)
+                    if not pending:
+                        return 0
+                    batch = [validate_event(event) for event in pending[:UPLOAD_BATCH_SIZE]]
+            except OSError:
+                # Flight evidence is best effort.  A locked/read-only home
+                # must never turn a heartbeat into a worker crash; strict
+                # worker registration will fail closed when no receipt exists.
                 return 0
-            batch = pending[:UPLOAD_BATCH_SIZE]
-            batch = [validate_event(event) for event in batch]
             try:
                 response = self.client.flight_events(batch)
             except Exception as exc:
                 if getattr(exc, "status_code", None) == 404:
                     self._remote_disabled = True
                 return 0
-            acknowledged = set(response.get("acknowledged_event_ids") or ())
-            # A concurrent heartbeat may flush another batch immediately
-            # after this one. Keep the worker event receipt for the lifetime
-            # of this recorder instead of replacing it with the newest batch.
-            self._last_acknowledged_event_ids.update(acknowledged)
+            sent_ids = {event["event_id"] for event in batch}
+            try:
+                raw_acknowledged = response.get("acknowledged_event_ids") or ()
+                acknowledged = {
+                    event_id for event_id in raw_acknowledged
+                    if self._valid_event_id(event_id) and event_id in sent_ids
+                }
+            except (AttributeError, TypeError):
+                # A malformed response is not evidence of acceptance.  Keep
+                # the durable pending event and let a later retry reconcile it.
+                return 0
             if not acknowledged:
                 return 0
-            self._write(
-                self.pending_path,
-                [event for event in pending if event.get("event_id") not in acknowledged],
-            )
+            try:
+                with _exclusive_file_lock(self.lock_path):
+                    # Another process may have recorded or flushed events while
+                    # the request was in flight.  Re-read before removing only
+                    # the IDs this response actually acknowledged.
+                    current_pending = self._load(self.pending_path)
+                    self._write_acknowledged_ids_unlocked(acknowledged)
+                    self._write(
+                        self.pending_path,
+                        [
+                            event for event in current_pending
+                            if event.get("event_id") not in acknowledged
+                        ],
+                    )
+            except OSError:
+                return 0
+            # Keep the local cache for callers that inspect this recorder, and
+            # also persist receipts so a sibling process can prove that its
+            # exact worker_registered event was accepted.
+            self._last_acknowledged_event_ids.update(acknowledged)
             return len(acknowledged)
 
     @property
     def last_acknowledged_event_ids(self) -> frozenset[str]:
-        return frozenset(self._last_acknowledged_event_ids)
+        with self._lock:
+            try:
+                with _exclusive_file_lock(self.lock_path):
+                    shared = self._load_acknowledged_ids_unlocked()
+            except OSError:
+                shared = []
+            return frozenset((*self._last_acknowledged_event_ids, *shared))
 
     def export_diagnostic_bundle(self, destination: Path) -> Path:
         """Create a local-only ZIP containing allowlisted events and a manifest."""
         destination = Path(destination).expanduser().resolve()
         destination.parent.mkdir(parents=True, exist_ok=True)
         with self._lock:
-            events = self._load(self.events_path)
-            pending = self._load(self.pending_path)
-            events = [validate_event(event) for event in events]
-            pending = [validate_event(event) for event in pending]
+            try:
+                with _exclusive_file_lock(self.lock_path):
+                    events = self._load(self.events_path)
+                    pending = self._load(self.pending_path)
+                    events = [validate_event(event) for event in events]
+                    pending = [validate_event(event) for event in pending]
+            except OSError:
+                events = []
+                pending = []
         manifest = {
             "schema_version": "dradar.flight_diagnostics.v1",
             "created_at": datetime.now(timezone.utc).isoformat(),

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -4821,7 +4821,10 @@ def _run_worker_pool(args) -> int:
             batch_id=args.batch_id,
             attributes={"elapsed_ms": elapsed_ms, "phase": "preparing"},
         )
-        flight.flush()
+        # The supervisor has no runner session ID, but its preparation events
+        # are still bound to this exact batch.  Keep stale plans/accounts out
+        # of the server's atomic flight-event upload.
+        flight.flush(batch_id=args.batch_id)
 
     if fleet_pool:
         args.allow_new_claims = bool(getattr(args, "refill", False))
@@ -4989,7 +4992,9 @@ def _run_worker_pool(args) -> int:
             reason_code=reason_code,
             attributes=attributes,
         )
-        flight.flush()
+        # Supervisor events are batch-scoped (there is no child session to
+        # match); never replay a global pending prefix under this token.
+        flight.flush(batch_id=args.batch_id)
 
     def acknowledge_child_ready(slot: int, activity_state: str | None) -> None:
         nonlocal startup_ready

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -6081,6 +6081,18 @@ def _run_checkout_loop(args, client: ApiClient, tasks_root: Path,
         if outcome == "failed" or outcome in _TERMINAL_LOCAL_OUTCOMES:
             failed_ids.add(assignment["assignment_id"])
         results.append(outcome)
+        # The checkout response reports the authoritative number of remaining
+        # unstarted assignments.  Once the last held task has settled, a
+        # single-task/non-refill run must finish here; otherwise the next loop
+        # iteration emits claim_requested even though no claim can succeed.
+        if (
+            not getattr(args, "refill", False)
+            and outcome in {"submitted", "interrupted", "empty-submission"}
+            and isinstance(extra, int)
+            and not isinstance(extra, bool)
+            and extra == 0
+        ):
+            break
     if "environment-build-failed" in results:
         return _ENVIRONMENT_BUILD_FAILED_EXIT_CODE
     ok = all(o in _NON_FAULT_RUNNER_OUTCOMES for o in results)

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -4391,7 +4391,7 @@ def _assignment_is_ready_for_checkout(
         and assignment.get("runner_phase") is None
     )
     if (assignment.get("started_at")
-            or assignment.get("execution_state") == "paused"
+            or assignment.get("execution_state") not in (None, "waiting")
             or assignment.get("checkpoint_id")):
         return False
     if claimed_after is not None:

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -3795,8 +3795,24 @@ def _wait_for_worker_registration(
     environment_build_timeout_multiplier: float,
     worker_event_source: Callable[[], object | None] | None = None,
     expected_session_id: str | None = None,
+    log_path: Path | None = None,
 ) -> dict:
-    """Wait for a bounded, structured Pier lifecycle record (never logs)."""
+    """Wait for a bounded, structured Pier lifecycle record.
+
+    The sidecar remains the lifecycle source of truth; a bounded log tail is
+    included only when the caller supplies ``log_path`` so a pre-registration
+    build failure remains actionable.
+    """
+
+    def registration_error(message: str) -> RunnerError:
+        if log_path is None:
+            return RunnerError(message)
+        tail = _tail(log_path)
+        detail = f"{message} (see {log_path})"
+        if tail:
+            detail += f"\nlast lines of the log:\n{tail}"
+        return RunnerError(detail)
+
     event_offset = 0
     # #0034 contract: preparation/sidecar waiting is exactly 30 minutes;
     # this clock is separate from the post-registration runtime watchdog.
@@ -3820,12 +3836,12 @@ def _wait_for_worker_registration(
                 "occurred_at_ms": parsed.occurred_at_ms,
             }
         if proc.poll() is not None:
-            raise RunnerError(
+            raise registration_error(
                 "Pier exited before the structured worker_registered signal; "
                 "runtime lease was not started"
             )
         if time.monotonic() >= deadline:
-            raise RunnerError(
+            raise registration_error(
                 "environment preparation exceeded its grace window without "
                 "worker_registered; runtime lease was not started"
             )
@@ -4249,6 +4265,7 @@ def run_trial(
                         ),
                         worker_event_source=worker_event_source,
                         expected_session_id=assignment.get("_runner_session_id"),
+                        log_path=log_path,
                     )
                     if on_worker_registered is not None:
                         on_worker_registered(event)
@@ -4370,6 +4387,8 @@ def run_trial(
         # Defensive guard for future launch-path changes: artifact harvesting
         # must never report a runtime duration when no launch boundary was
         # reached.
+        if terminal_error is not None:
+            raise terminal_error
         raise RunnerError("worker launch boundary was not reached")
     duration = time.time() - started
     if isinstance(terminal_error, LiveAccountTerminalError):

--- a/src/dradar/telemetry.py
+++ b/src/dradar/telemetry.py
@@ -178,6 +178,29 @@ class RunnerTelemetry:
         kwargs.setdefault("session_id", self.session_id)
         return self.flight_recorder.try_record(event_type, component=component, **kwargs)
 
+    def _flush_flight_events(self, *, required_event_id: str | None = None) -> int:
+        """Flush only this runner's bound batch/session evidence.
+
+        The recorder queue is shared across plans and processes.  Do not let a
+        stale event from another token or device session enter this heartbeat's
+        atomic upload.  A runner without a server-assigned batch has no safe
+        flight-event scope yet, so its pending evidence remains local until a
+        later bind.
+        """
+        recorder = self.flight_recorder
+        if recorder is None:
+            return 0
+        with self._lock:
+            batch_id = self._batch_id
+            session_id = self.session_id
+        if not batch_id:
+            return 0
+        return recorder.flush(
+            batch_id=batch_id,
+            session_id=session_id,
+            required_event_id=required_event_id,
+        )
+
     def set_phase(
         self,
         phase: str,
@@ -226,7 +249,12 @@ class RunnerTelemetry:
                 "target_workers": self.target_workers,
             }
 
-    def _send_once(self, *, propagate_errors: bool = False) -> int:
+    def _send_once(
+        self,
+        *,
+        propagate_errors: bool = False,
+        required_event_id: str | None = None,
+    ) -> int:
         """Send once and return the server-selected next interval."""
         with self._send_lock:
             if self._disabled:
@@ -281,8 +309,8 @@ class RunnerTelemetry:
                 # server assigns a batch. Bind before flushing pending events.
                 self.bind_batch(response["batch_id"])
             self.record_event("heartbeat_acknowledged", component="heartbeat")
-            self._last_flight_events_acked = (
-                self.flight_recorder.flush() if self.flight_recorder is not None else 0
+            self._last_flight_events_acked = self._flush_flight_events(
+                required_event_id=required_event_id,
             )
             self._show_notices(response)
             if response.get("stop_requested") is True:
@@ -333,7 +361,10 @@ class RunnerTelemetry:
         """
         if self._disabled:
             return False
-        self._send_once(propagate_errors=True)
+        self._send_once(
+            propagate_errors=True,
+            required_event_id=required_event_id,
+        )
         with self._lock:
             if not self._last_heartbeat_accepted:
                 return False
@@ -378,5 +409,4 @@ class RunnerTelemetry:
             "session_closed", component="cli", reason_code=reason,
             assignment_id=self._active_assignment_id,
         )
-        if self.flight_recorder is not None:
-            self.flight_recorder.flush()
+        self._flush_flight_events()

--- a/src/dradar/telemetry.py
+++ b/src/dradar/telemetry.py
@@ -84,12 +84,8 @@ class RunnerTelemetry:
         self._jitter = jitter
         self._shown_notice_ids: set[str] = set()
         self._stop_requested = False
+        self._session_started_recorded = False
         self.flight_recorder = FlightRecorder(home, client) if home is not None else None
-        if self.flight_recorder is not None:
-            self.flight_recorder.try_record(
-                "session_started", component="cli", session_id=self.session_id,
-                attributes={"target_workers": target_workers},
-            )
 
     @property
     def stop_requested(self) -> bool:
@@ -150,15 +146,35 @@ class RunnerTelemetry:
         with self._lock:
             changed = self._batch_id != batch_id
             self._batch_id = batch_id
+            record_session_started = changed and not self._session_started_recorded
+            if record_session_started:
+                # Set the guard while holding the state lock so concurrent
+                # heartbeat responses cannot enqueue this lifecycle event twice.
+                self._session_started_recorded = True
             if changed:
                 self._progress_counter += 1
+        if record_session_started:
+            # Every server flight event must carry a batch identity. Defer
+            # session_started until this first bind so legacy heartbeats that
+            # receive the batch from the server cannot enqueue batch_id=null.
+            self.record_event(
+                "session_started", component="cli",
+                attributes={"target_workers": self.target_workers},
+            )
         if changed:
             self._wake.set()
 
     def record_event(self, event_type: str, *, component: str, **kwargs) -> dict | None:
         if self.flight_recorder is None:
             return None
-        kwargs.setdefault("batch_id", self._batch_id)
+        with self._lock:
+            batch_id = self._batch_id
+        # ``session_started`` is accepted by the server only after a batch is
+        # known. Drop accidental pre-bind calls instead of persisting a null
+        # identity that can never be uploaded or reconciled.
+        if event_type == "session_started" and not batch_id:
+            return None
+        kwargs.setdefault("batch_id", batch_id)
         kwargs.setdefault("session_id", self.session_id)
         return self.flight_recorder.try_record(event_type, component=component, **kwargs)
 
@@ -260,6 +276,10 @@ class RunnerTelemetry:
             self._warned = False
             with self._lock:
                 self._last_heartbeat_accepted = response.get("accepted") is True
+            if response.get("batch_id"):
+                # Legacy/super-account heartbeat may be the first place the
+                # server assigns a batch. Bind before flushing pending events.
+                self.bind_batch(response["batch_id"])
             self.record_event("heartbeat_acknowledged", component="heartbeat")
             self._last_flight_events_acked = (
                 self.flight_recorder.flush() if self.flight_recorder is not None else 0
@@ -268,9 +288,6 @@ class RunnerTelemetry:
             if response.get("stop_requested") is True:
                 self._stop_requested = True
                 self._publish_stop_marker()
-            if response.get("batch_id"):
-                with self._lock:
-                    self._batch_id = response["batch_id"]
             requested = response.get("next_heartbeat_sec", self._interval)
             try:
                 requested_interval = min(600, max(30, int(requested)))

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -624,6 +624,7 @@ def test_checkout_sends_failed_cell_exclusions():
         exclude_assignment_ids={"a2", "a1"}, session_id="session-123")
     assert b"exclude_assignment_ids=a1%2Ca2" in seen["body"]
     assert b"session_id=session-123" in seen["body"]
+    assert b"prepare_only=true" in seen["body"]
 
 
 def test_mark_started_sends_runner_session_id():

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -67,6 +67,15 @@ class StubTelemetry:
         self.phases.append((phase, assignment_id, resume_generation))
 
 
+class RecordingTelemetry(StubTelemetry):
+    def __init__(self, checkout_error=None):
+        super().__init__(checkout_error=checkout_error)
+        self.events = []
+
+    def record_event(self, event_type, *, component, **kwargs):
+        self.events.append((event_type, component, kwargs))
+
+
 def test_persisted_empty_submission_blocks_new_batch_before_checkout(
         monkeypatch, capsys, tmp_path):
     monkeypatch.setattr(runloop, "HOME", tmp_path)
@@ -320,9 +329,50 @@ def test_checkout_flushes_and_passes_session_id_before_server_stamps_cell(
     )
     assert runloop._go_menu(
         _args(), {}, client, tmp_path, telemetry=telemetry) == 0
-    assert client.checkout_sessions == ["session-test", "session-test"]
-    assert telemetry.flushes >= 2
+    assert client.checkout_sessions == ["session-test"]
+    assert telemetry.flushes >= 1
     assert ("preparing", "a1", None) in telemetry.phases
+
+
+def test_single_task_without_refill_does_not_request_after_upload(
+        monkeypatch, tmp_path):
+    """A final checkout response with no unstarted work is terminal.
+
+    The old loop made one more checkout after upload_completed, producing a
+    claim_requested event without a matching claim_accepted event.
+    """
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    monkeypatch.setattr(runloop, "_check_version_pin", lambda *a, **kw: None)
+    assignment = _cell("only")
+    telemetry = RecordingTelemetry()
+
+    def run(_client, _assignment, *_args, telemetry=None, **_kwargs):
+        runloop._record_flight_event(
+            telemetry, "upload_completed", component="upload",
+            assignment_id=assignment["assignment_id"],
+            reason_code="submitted", attributes={"outcome": "submitted"},
+        )
+        return "submitted"
+
+    monkeypatch.setattr(runloop, "_run_and_submit", run)
+    client = CheckoutClient(
+        {"active": [assignment], "free_pick": True},
+        [
+            {"assignment": assignment, "held": 1, "unstarted": 0},
+            # This response must remain unused: there is no refill and the
+            # first checkout already said no unstarted assignment remains.
+            {"assignment": None, "held": 0, "unstarted": 0},
+        ],
+    )
+
+    assert runloop._run_checkout_loop(
+        _args(), client, tmp_path, [assignment], telemetry=telemetry,
+    ) == 0
+    assert len(client.checkout_exclusions) == 1
+    assert [event[0] for event in telemetry.events] == [
+        "claim_requested", "claim_accepted", "assignment_checked_out",
+        "upload_completed",
+    ]
 
 
 def test_checkout_preserves_session_fence_before_provider_preparation(
@@ -405,7 +455,7 @@ def test_checkout_loop_never_retries_a_cell_that_failed_this_session(
          {"assignment": None, "held": 2, "unstarted": 0}])
     rc = runloop._go_menu(_args(), {}, client, tmp_path)
     assert attempts == ["bad", "ok"]
-    assert client.checkout_exclusions == [set(), {"bad"}, {"bad"}]
+    assert client.checkout_exclusions == [set(), {"bad"}]
     assert rc == 1                            # the failure still fails the run
 
 
@@ -461,7 +511,7 @@ def test_supervised_worker_continues_after_expired_old_batch_assignment(
 
     assert runloop._go_menu(args, {}, client, tmp_path) == 0
     assert attempts == ["old", "new"]
-    assert client.checkout_exclusions == [set(), set(), set()]
+    assert client.checkout_exclusions == [set(), set()]
     assert "stopping this automatic batch runner" not in capsys.readouterr().out
 
 
@@ -491,9 +541,7 @@ def test_supervised_worker_continues_after_assignment_local_rejection(
 
     assert runloop._go_menu(args, {}, client, tmp_path) == 0
     assert attempts == ["invalid-answer", "next"]
-    assert client.checkout_exclusions == [
-        set(), {"invalid-answer"}, {"invalid-answer"},
-    ]
+    assert client.checkout_exclusions == [set(), {"invalid-answer"}]
     assert "stopping this automatic batch runner" not in capsys.readouterr().out
 
 
@@ -523,9 +571,7 @@ def test_supervised_worker_continues_after_task_local_runtime_failure(
 
     assert runloop._go_menu(args, {}, client, tmp_path) == 0
     assert attempts == ["zcode-terminal-missing", "next"]
-    assert client.checkout_exclusions == [
-        set(), {"zcode-terminal-missing"}, {"zcode-terminal-missing"},
-    ]
+    assert client.checkout_exclusions == [set(), {"zcode-terminal-missing"}]
     assert "stopping this automatic batch runner" not in capsys.readouterr().out
 
 

--- a/tests/test_flight_recorder.py
+++ b/tests/test_flight_recorder.py
@@ -207,7 +207,16 @@ def test_acknowledged_event_ids_are_cumulative_across_interleaved_flushes(tmp_pa
     assert second["event_id"] in recorder.last_acknowledged_event_ids
 
 
-@pytest.mark.parametrize("response", [None, {"acknowledged_event_ids": 1}])
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,
+        {"acknowledged_event_ids": 1},
+        {"acknowledged_event_ids": {"a" * 32: True}},
+        {"acknowledged_event_ids": "a" * 32},
+        {"acknowledged_event_ids": ["not-an-event-id"]},
+    ],
+)
 def test_malformed_flight_response_keeps_pending_event(tmp_path, response):
     class MalformedClient(FlightClient):
         def flight_events(self, events):
@@ -215,6 +224,29 @@ def test_malformed_flight_response_keeps_pending_event(tmp_path, response):
             return response
 
     recorder = FlightRecorder(tmp_path, MalformedClient())
+    event = recorder.record(
+        "worker_registered", component="provider",
+        batch_id=BATCH_ID, session_id=SESSION_ID,
+        assignment_id=ASSIGNMENT_ID, attributes={"provider": "codex"},
+    )
+    assert recorder.flush() == 0
+    assert event["event_id"] in {
+        item["event_id"] for item in recorder._load(recorder.pending_path)
+    }
+    assert not recorder.last_acknowledged_event_ids
+
+
+def test_generator_ack_response_keeps_pending_event(tmp_path):
+    class GeneratorClient(FlightClient):
+        def flight_events(self, events):
+            self.batches.append(events)
+            return {
+                "acknowledged_event_ids": (
+                    event["event_id"] for event in events
+                ),
+            }
+
+    recorder = FlightRecorder(tmp_path, GeneratorClient())
     event = recorder.record(
         "worker_registered", component="provider",
         batch_id=BATCH_ID, session_id=SESSION_ID,

--- a/tests/test_flight_recorder.py
+++ b/tests/test_flight_recorder.py
@@ -1,4 +1,8 @@
 import json
+import multiprocessing as mp
+import queue
+import threading
+import time
 import zipfile
 from pathlib import Path
 
@@ -16,6 +20,52 @@ SENSITIVE_VECTORS = json.loads(
 )
 
 
+def _record_events_in_child(home: str, worker: int, barrier) -> None:
+    """Force overlapping read/modify/write cycles in separate processes."""
+    # Deliberately widen the race window.  The production lock must serialize
+    # this without relying on a scheduler-friendly filesystem timing.
+    original_write = FlightRecorder._write
+
+    def slow_write(path, events):
+        time.sleep(0.002)
+        original_write(path, events)
+
+    FlightRecorder._write = staticmethod(slow_write)
+    recorder = FlightRecorder(Path(home))
+    barrier.wait(timeout=30)
+    session_id = f"{worker + 4:032x}"
+    for _ in range(25):
+        recorder.record(
+            "phase_changed",
+            component="heartbeat",
+            batch_id=BATCH_ID,
+            session_id=session_id,
+            attributes={"previous_phase": "preparing", "phase": "building"},
+        )
+
+
+def _record_worker_event_and_wait(
+    home: str, ready, release, result,
+) -> None:
+    recorder = FlightRecorder(Path(home))
+    event = recorder.record(
+        "worker_registered",
+        component="provider",
+        batch_id=BATCH_ID,
+        session_id=SESSION_ID,
+        assignment_id=ASSIGNMENT_ID,
+        attributes={"provider": "codex"},
+    )
+    result.put(event["event_id"])
+    ready.set()
+    if not release.wait(timeout=10):
+        result.put(False)
+        return
+    # The parent/supervisor may have flushed this event.  The receipt must be
+    # visible through the shared recorder state, not only the child's cache.
+    result.put(event["event_id"] in recorder.last_acknowledged_event_ids)
+
+
 class FlightClient:
     def __init__(self):
         self.batches = []
@@ -23,6 +73,112 @@ class FlightClient:
     def flight_events(self, events):
         self.batches.append(events)
         return {"acknowledged_event_ids": [event["event_id"] for event in events]}
+
+
+def test_parent_and_children_serialize_recorder_read_modify_write(tmp_path):
+    ctx = mp.get_context("spawn")
+    barrier = ctx.Barrier(2)
+    workers = [
+        ctx.Process(target=_record_events_in_child, args=(str(tmp_path), index, barrier))
+        for index in range(2)
+    ]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=30)
+    try:
+        assert all(worker.exitcode == 0 for worker in workers)
+        recorder = FlightRecorder(tmp_path)
+        history = recorder._load(recorder.events_path)
+        pending = recorder._load(recorder.pending_path)
+        assert len(history) == 50
+        assert len(pending) == 50
+        assert {event["client_id"] for event in history} == {recorder.client_id}
+    finally:
+        for worker in workers:
+            if worker.is_alive():
+                worker.terminate()
+                worker.join()
+
+
+def test_worker_registration_ack_is_visible_to_child_after_parent_flush(tmp_path):
+    ctx = mp.get_context("spawn")
+    ready = ctx.Event()
+    release = ctx.Event()
+    result = ctx.Queue()
+    worker = ctx.Process(
+        target=_record_worker_event_and_wait,
+        args=(str(tmp_path), ready, release, result),
+    )
+    worker.start()
+    try:
+        assert ready.wait(timeout=30)
+        event_id = result.get(timeout=5)
+        client = FlightClient()
+        supervisor = FlightRecorder(tmp_path, client)
+        assert supervisor.flush() == 1
+        release.set()
+        assert result.get(timeout=10) is True
+        worker.join(timeout=30)
+        assert worker.exitcode == 0
+        assert event_id not in {
+            event["event_id"] for event in supervisor._load(supervisor.pending_path)
+        }
+    finally:
+        if worker.is_alive():
+            release.set()
+            worker.terminate()
+            worker.join()
+        try:
+            while True:
+                result.get_nowait()
+        except queue.Empty:
+            pass
+
+
+def test_flush_commit_preserves_event_recorded_while_request_is_in_flight(tmp_path):
+    class BlockingClient(FlightClient):
+        def __init__(self):
+            super().__init__()
+            self.started = threading.Event()
+            self.release = threading.Event()
+
+        def flight_events(self, events):
+            self.started.set()
+            assert self.release.wait(timeout=10)
+            return super().flight_events(events)
+
+    client = BlockingClient()
+    first = FlightRecorder(tmp_path, client)
+    first_event = first.record(
+        "worker_registered",
+        component="provider",
+        batch_id=BATCH_ID,
+        session_id=SESSION_ID,
+        assignment_id=ASSIGNMENT_ID,
+        attributes={"provider": "codex"},
+    )
+    flush_thread = threading.Thread(target=first.flush)
+    flush_thread.start()
+    assert client.started.wait(timeout=10)
+
+    sibling = FlightRecorder(tmp_path)
+    sibling_event = sibling.record(
+        "heartbeat_sent",
+        component="heartbeat",
+        batch_id=BATCH_ID,
+        session_id=SESSION_ID,
+    )
+    client.release.set()
+    flush_thread.join(timeout=10)
+    assert not flush_thread.is_alive()
+
+    pending_ids = {
+        event["event_id"] for event in first._load(first.pending_path)
+    }
+    assert first_event["event_id"] not in pending_ids
+    assert sibling_event["event_id"] in pending_ids
+    assert first_event["event_id"] in first.last_acknowledged_event_ids
 
 
 def test_acknowledged_event_ids_are_cumulative_across_interleaved_flushes(tmp_path):
@@ -45,6 +201,26 @@ def test_acknowledged_event_ids_are_cumulative_across_interleaved_flushes(tmp_pa
     assert recorder.flush() == 1
     assert first["event_id"] in recorder.last_acknowledged_event_ids
     assert second["event_id"] in recorder.last_acknowledged_event_ids
+
+
+@pytest.mark.parametrize("response", [None, {"acknowledged_event_ids": 1}])
+def test_malformed_flight_response_keeps_pending_event(tmp_path, response):
+    class MalformedClient(FlightClient):
+        def flight_events(self, events):
+            self.batches.append(events)
+            return response
+
+    recorder = FlightRecorder(tmp_path, MalformedClient())
+    event = recorder.record(
+        "worker_registered", component="provider",
+        batch_id=BATCH_ID, session_id=SESSION_ID,
+        assignment_id=ASSIGNMENT_ID, attributes={"provider": "codex"},
+    )
+    assert recorder.flush() == 0
+    assert event["event_id"] in {
+        item["event_id"] for item in recorder._load(recorder.pending_path)
+    }
+    assert not recorder.last_acknowledged_event_ids
 
 
 def test_offline_jsonl_replays_idempotent_envelopes_and_keeps_history(tmp_path):

--- a/tests/test_flight_recorder.py
+++ b/tests/test_flight_recorder.py
@@ -8,12 +8,16 @@ from pathlib import Path
 
 import pytest
 
-from dradar.flight_recorder import FlightRecorder, validate_event
+from dradar.flight_recorder import FlightRecorder, UPLOAD_BATCH_SIZE, validate_event
 
 
 BATCH_ID = "1" * 32
 SESSION_ID = "2" * 32
 ASSIGNMENT_ID = "3" * 32
+OLD_BATCH_ID = "a" * 32
+NEW_BATCH_ID = "b" * 32
+OLD_SESSION_ID = "c" * 32
+NEW_SESSION_ID = "d" * 32
 SENSITIVE_VECTORS = json.loads(
     (Path(__file__).parent / "fixtures" / "flight_event_sensitive_vectors.json")
     .read_text(encoding="utf-8")
@@ -239,6 +243,102 @@ def test_offline_jsonl_replays_idempotent_envelopes_and_keeps_history(tmp_path):
     assert client.batches[0][0]["event_id"] == event["event_id"]
     assert replay.pending_path.read_text() == ""
     assert replay.events_path.read_text().count("\n") == 1
+
+
+def test_scoped_flush_keeps_other_plan_and_session_pending_across_restart(tmp_path):
+    """A new plan may upload only its own session without deleting old evidence."""
+    writer = FlightRecorder(tmp_path)
+    old_null_batch = writer.record(
+        "session_started",
+        component="cli",
+        session_id=OLD_SESSION_ID,
+    )
+    old_plan = writer.record(
+        "phase_changed",
+        component="heartbeat",
+        batch_id=OLD_BATCH_ID,
+        session_id=OLD_SESSION_ID,
+        attributes={"previous_phase": "preparing", "phase": "building"},
+    )
+    current_plan = writer.record(
+        "worker_registered",
+        component="provider",
+        batch_id=NEW_BATCH_ID,
+        session_id=NEW_SESSION_ID,
+        assignment_id=ASSIGNMENT_ID,
+        attributes={"provider": "codex"},
+    )
+
+    client = FlightClient()
+    replay = FlightRecorder(tmp_path, client)
+    assert replay.flush(batch_id=NEW_BATCH_ID, session_id=NEW_SESSION_ID) == 1
+    assert [event["event_id"] for event in client.batches[0]] == [
+        current_plan["event_id"]
+    ]
+
+    pending = replay._load(replay.pending_path)
+    assert {event["event_id"] for event in pending} == {
+        old_null_batch["event_id"], old_plan["event_id"],
+    }
+
+    # A later process can deliberately replay the old scope; it was retained,
+    # not silently discarded while the new plan was registering.
+    old_client = FlightClient()
+    old_replay = FlightRecorder(tmp_path, old_client)
+    assert old_replay.flush(batch_id=OLD_BATCH_ID, session_id=OLD_SESSION_ID) == 1
+    assert [event["event_id"] for event in old_client.batches[0]] == [
+        old_plan["event_id"]
+    ]
+    assert old_null_batch["event_id"] in {
+        event["event_id"] for event in old_replay._load(old_replay.pending_path)
+    }
+
+
+def test_session_scope_without_batch_stays_local(tmp_path):
+    """An unknown plan/account scope must not replay a null-batch event."""
+    recorder = FlightRecorder(tmp_path)
+    event = recorder.record(
+        "session_started", component="cli", session_id=OLD_SESSION_ID,
+    )
+    client = FlightClient()
+    replay = FlightRecorder(tmp_path, client)
+
+    assert replay.flush(session_id=OLD_SESSION_ID) == 0
+    assert client.batches == []
+    assert event["event_id"] in {
+        item["event_id"] for item in replay._load(replay.pending_path)
+    }
+
+
+def test_scoped_flush_prioritizes_required_worker_event_behind_backlog(tmp_path):
+    client = FlightClient()
+    recorder = FlightRecorder(tmp_path, client)
+    for _ in range(UPLOAD_BATCH_SIZE + 5):
+        recorder.record(
+            "phase_changed",
+            component="heartbeat",
+            batch_id=NEW_BATCH_ID,
+            session_id=NEW_SESSION_ID,
+            attributes={"previous_phase": "preparing", "phase": "building"},
+        )
+    required = recorder.record(
+        "worker_registered",
+        component="provider",
+        batch_id=NEW_BATCH_ID,
+        session_id=NEW_SESSION_ID,
+        assignment_id=ASSIGNMENT_ID,
+        attributes={"provider": "codex"},
+    )
+
+    assert recorder.flush(
+        batch_id=NEW_BATCH_ID,
+        session_id=NEW_SESSION_ID,
+        required_event_id=required["event_id"],
+    ) == UPLOAD_BATCH_SIZE
+    assert client.batches[0][0]["event_id"] == required["event_id"]
+    assert required["event_id"] not in {
+        event["event_id"] for event in recorder._load(recorder.pending_path)
+    }
 
 
 @pytest.mark.parametrize("forbidden", [

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -853,6 +853,31 @@ def test_run_trial_on_started_exception_terminates_launched_worker(tmp_path, mon
     assert captured["process_terminated"] is True
 
 
+def test_run_trial_preserves_pre_registration_build_error(tmp_path, monkeypatch):
+    """A build/registration timeout must not be replaced by a generic guard."""
+    _fake_pier(monkeypatch, tmp_path)
+
+    def wait_for_registration(*_args, **_kwargs):
+        raise RunnerError(
+            "environment preparation exceeded its grace window without "
+            "worker_registered; runtime lease was not started (see build.log)"
+        )
+
+    monkeypatch.setattr(
+        runner_mod, "_wait_for_worker_registration", wait_for_registration,
+    )
+    with pytest.raises(RunnerError, match="environment preparation exceeded") as exc:
+        run_trial(
+            _assignment("codex"),
+            tmp_path,
+            tmp_path,
+            on_started=lambda: None,
+            on_worker_registered=lambda _event: None,
+        )
+    assert "worker launch boundary was not reached" not in str(exc.value)
+    assert "build.log" in str(exc.value)
+
+
 def test_run_trial_uses_artifact_overlay_for_verifier_collect_pack(
     tmp_path, monkeypatch,
 ):

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -218,3 +218,50 @@ def test_close_carries_only_session_batch_seq_and_reason():
         "seq": 2,
         "reason": "paused",
     }]
+
+
+def test_session_started_is_deferred_until_batch_bind(tmp_path):
+    telemetry = RunnerTelemetry(FakeClient(), jitter=False, home=tmp_path)
+    assert telemetry.flight_recorder is not None
+    # Constructor must not enqueue an event with a null batch identity.
+    assert telemetry.flight_recorder._load(
+        telemetry.flight_recorder.pending_path,
+    ) == []
+    telemetry.bind_batch("b" * 32)
+    telemetry.bind_batch("c" * 32)
+    events = telemetry.flight_recorder._load(telemetry.flight_recorder.pending_path)
+    starts = [event for event in events if event["event_type"] == "session_started"]
+    assert len(starts) == 1
+    assert starts[0]["batch_id"] == "b" * 32
+
+
+def test_prebind_session_started_is_dropped_instead_of_persisted(tmp_path):
+    telemetry = RunnerTelemetry(FakeClient(), jitter=False, home=tmp_path)
+    assert telemetry.record_event("session_started", component="cli") is None
+    assert telemetry.flight_recorder._load(
+        telemetry.flight_recorder.pending_path,
+    ) == []
+    telemetry.bind_batch("b" * 32)
+    events = telemetry.flight_recorder._load(telemetry.flight_recorder.pending_path)
+    assert [event["event_type"] for event in events].count("session_started") == 1
+
+
+def test_legacy_heartbeat_backfills_batch_before_flight_upload(tmp_path):
+    client = FakeClient([{
+        "accepted": True,
+        "batch_id": "b" * 32,
+        "next_heartbeat_sec": 60,
+    }])
+    uploaded = []
+
+    def flight_events(events):
+        uploaded.extend(events)
+        return {"acknowledged_event_ids": [event["event_id"] for event in events]}
+
+    client.flight_events = flight_events
+    telemetry = RunnerTelemetry(client, jitter=False, home=tmp_path)
+    telemetry._send_once()
+    events = uploaded
+    starts = [event for event in events if event["event_type"] == "session_started"]
+    assert len(starts) == 1
+    assert starts[0]["batch_id"] == "b" * 32

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from dradar.api_client import ApiError
+from dradar.flight_recorder import FlightRecorder
 from dradar.telemetry import RunnerTelemetry
 
 
@@ -25,6 +26,26 @@ class FakeClient:
     def runner_close(self, payload):
         self.closes.append(payload)
         return {"ok": True}
+
+
+class AtomicScopeClient(FakeClient):
+    """Reject a mixed flight batch like the server's atomic endpoint."""
+
+    def __init__(self, responses=None):
+        super().__init__(responses)
+        self.flight_batches = []
+        self.allowed_batch = None
+        self.allowed_session = None
+
+    def flight_events(self, events):
+        self.flight_batches.append(events)
+        if any(
+            event.get("batch_id") != self.allowed_batch
+            or event.get("session_id") != self.allowed_session
+            for event in events
+        ):
+            return {"acknowledged_event_ids": []}
+        return {"acknowledged_event_ids": [event["event_id"] for event in events]}
 
 
 def test_payload_is_one_session_not_one_per_assignment_and_stays_small():
@@ -107,6 +128,58 @@ def test_recorder_present_without_exact_event_id_fails_closed(tmp_path):
     telemetry = RunnerTelemetry(FakeClient([{"accepted": True}]), jitter=False, home=tmp_path)
     telemetry.set_phase("building", "assignment-1")
     assert telemetry.flush_for_worker_registration() is False
+
+
+def test_worker_registration_isolated_from_persisted_plan_and_session_pending(tmp_path):
+    """A stale null/old-plan prefix cannot block the current worker receipt."""
+    old_batch = "a" * 32
+    new_batch = "b" * 32
+    old_session = "c" * 32
+    assignment_id = "d" * 32
+    recorder = FlightRecorder(tmp_path)
+    old_null = recorder.record(
+        "session_started", component="cli", session_id=old_session,
+    )
+    old_plan = recorder.record(
+        "phase_changed",
+        component="heartbeat",
+        batch_id=old_batch,
+        session_id=old_session,
+        attributes={"previous_phase": "preparing", "phase": "building"},
+    )
+
+    client = AtomicScopeClient([{
+        "accepted": True,
+        "action": "continue",
+        "batch_id": new_batch,
+        "next_heartbeat_sec": 30,
+    }])
+    telemetry = RunnerTelemetry(client, jitter=False, home=tmp_path)
+    telemetry.bind_batch(new_batch)
+    client.allowed_batch = new_batch
+    client.allowed_session = telemetry.session_id
+    worker = telemetry.record_event(
+        "worker_registered",
+        component="provider",
+        assignment_id=assignment_id,
+        attributes={"provider": "codex"},
+    )
+
+    assert worker is not None
+    assert telemetry.flush_for_worker_registration(worker["event_id"]) is True
+    assert len(client.flight_batches) == 1
+    uploaded = client.flight_batches[0]
+    assert uploaded[0]["event_id"] == worker["event_id"]
+    assert all(
+        event["batch_id"] == new_batch
+        and event["session_id"] == telemetry.session_id
+        for event in uploaded
+    )
+
+    pending = telemetry.flight_recorder._load(telemetry.flight_recorder.pending_path)
+    assert {event["event_id"] for event in pending} == {
+        old_null["event_id"], old_plan["event_id"],
+    }
 
 
 def test_server_notices_are_bounded_validated_and_printed_once(capsys):

--- a/tests/test_worker_events.py
+++ b/tests/test_worker_events.py
@@ -67,10 +67,15 @@ def test_registration_wait_uses_exact_thirty_minute_grace(monkeypatch, tmp_path)
     ticks = iter((0.0, 1799.0, 1800.1))
     monkeypatch.setattr(runner.time, "monotonic", lambda: next(ticks))
     monkeypatch.setattr(runner.time, "sleep", lambda _seconds: None)
-    with pytest.raises(runner.RunnerError, match="grace window"):
+    log_path = tmp_path / "build.log"
+    log_path.write_text("BuildKit stage package-install failed\n")
+    with pytest.raises(runner.RunnerError, match="grace window") as exc:
         runner._wait_for_worker_registration(
             LiveProcess(), tmp_path / "events.jsonl",
             environment_build_timeout_multiplier=8.0,
             worker_event_source=lambda: None,
+            log_path=log_path,
         )
+    assert str(log_path) in str(exc.value)
+    assert "BuildKit stage package-install failed" in str(exc.value)
     assert runner.WORKER_REGISTRATION_GRACE_SEC == 1800

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -1536,6 +1536,7 @@ def test_fleet_pool_fails_after_24_seconds_when_every_child_exits_precheckout(
         lambda seconds: clock.__setitem__("seconds", clock["seconds"] + seconds),
     )
     observed_events = []
+    observed_flushes = []
 
     class Recorder:
         def __init__(self, _home, _client):
@@ -1544,7 +1545,8 @@ def test_fleet_pool_fails_after_24_seconds_when_every_child_exits_precheckout(
         def try_record(self, event_type, **kwargs):
             observed_events.append((event_type, kwargs))
 
-        def flush(self):
+        def flush(self, **kwargs):
+            observed_flushes.append(kwargs)
             return 0
 
     monkeypatch.setattr(runloop, "FlightRecorder", Recorder)
@@ -1590,6 +1592,8 @@ def test_fleet_pool_fails_after_24_seconds_when_every_child_exits_precheckout(
         "precheckout_exit",
         "startup_failed",
     ]
+    assert observed_flushes
+    assert all(item == {"batch_id": batch_id} for item in observed_flushes)
 
 
 @pytest.mark.parametrize(
@@ -1636,6 +1640,7 @@ def test_fleet_precheckout_abort_is_never_completed(
         str(fleet._pool_startup_path(tmp_path, batch_id)),
     )
     monkeypatch.setattr(fleet, "controller_matches", lambda *_args: True)
+    observed_flushes = []
 
     class Recorder:
         def __init__(self, _home, _client):
@@ -1644,7 +1649,8 @@ def test_fleet_precheckout_abort_is_never_completed(
         def try_record(self, *_args, **_kwargs):
             return None
 
-        def flush(self):
+        def flush(self, **kwargs):
+            observed_flushes.append(kwargs)
             return 0
 
     monkeypatch.setattr(runloop, "FlightRecorder", Recorder)
@@ -1679,6 +1685,8 @@ def test_fleet_precheckout_abort_is_never_completed(
 
     startup = fleet._read_json(fleet._pool_startup_path(tmp_path, batch_id))
     assert result == 1
+    assert observed_flushes
+    assert all(item == {"batch_id": batch_id} for item in observed_flushes)
     assert startup["status"] == "failed"
     assert startup["error_code"] == error_code
     assert message_fragment in startup["user_message"]

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -2352,6 +2352,9 @@ def test_ready_assignment_filter_excludes_running_paused_and_bad_retry_time():
         {"started_at": None, "execution_state": "paused"}, now=now,
     )
     assert not runloop._assignment_is_ready_for_checkout(
+        {"started_at": None, "execution_state": "preparing"}, now=now,
+    )
+    assert not runloop._assignment_is_ready_for_checkout(
         {"started_at": None, "checkpoint_id": "checkpoint"}, now=now,
     )
     assert not runloop._assignment_is_ready_for_checkout(


### PR DESCRIPTION
Context: the real two-device run exposed misleading no_remaining/0-completed behavior and incomplete flight evidence. This PR combines the reviewed DFE, process-safe recorder, strict batch+session flush, required worker_registered receipt, fleet batch scoping, and malformed-ACK rejection. Scope: run-plan/Fleet lifecycle only; legacy leases.py unscoped replay remains a follow-up P1. Validation: focused 375 passed; full 1665 passed, 2 skipped, 1 deselected with the known external npm DNS test deselected; no production changes. Rollback: revert to cd6e1655.