### PR TITLE
#0040 P0：隔离 pending 上传与批次恢复作用域

### DIFF
--- a/src/dradar/fleet.py
+++ b/src/dradar/fleet.py
@@ -1484,7 +1484,12 @@ def cmd_fleet_serve(args) -> int:
             # is simply unavailable until the unrelated config is repaired.
             cfg = {}
         if cfg.get("server") and cfg.get("token"):
-            _retry_pending_uploads(_client(cfg))
+            client = _client(cfg)
+            # Fleet startup has no authoritative batch yet; only replay
+            # entries fingerprinted for this exact account/server context.
+            from .runloop import _mark_pending_scope_required
+            _mark_pending_scope_required(client)
+            _retry_pending_uploads(client)
         return _controller_loop(HOME, state)
 
 

--- a/src/dradar/image_cache.py
+++ b/src/dradar/image_cache.py
@@ -1273,7 +1273,12 @@ def _protected_projects(home: Path, protected_assignment_ids: set[str],
     from . import local_jobs, pending
 
     projects: set[str] = set()
-    pending_entries = pending.load(home)
+    # A hand-edited or partially migrated pending ledger may contain a
+    # non-object row.  Keep that raw evidence on disk, but never let cleanup
+    # crash while inspecting it or infer an assignment from it.
+    pending_entries = [
+        item for item in pending.load(home) if isinstance(item, dict)
+    ]
     pending_ids = {str(item.get("assignment_id")) for item in pending_entries
                    if item.get("assignment_id")}
     for entry in pending_entries:
@@ -1338,6 +1343,8 @@ def plan_cleanup(
     pending_ids = set()
     from . import pending
     for entry in pending.load(home):
+        if not isinstance(entry, dict):
+            continue
         if entry.get("assignment_id"):
             pending_ids.add(str(entry["assignment_id"]))
     protected_ids = protected_assignment_ids | pending_ids

--- a/src/dradar/pending.py
+++ b/src/dradar/pending.py
@@ -16,6 +16,7 @@ the entry. A 409 recovery-generation conflict is not success and stays queued.
 Anything else keeps it for the next retry.
 """
 
+import hashlib
 import json
 import os
 import tempfile
@@ -27,6 +28,35 @@ from typing import Iterator
 _FILENAME = "pending_uploads.json"
 _LOCK_FILENAME = "pending_uploads.lock"
 _PROCESS_LOCK = threading.Lock()
+
+
+def scope_fingerprint(
+    *,
+    server: str | None,
+    account_scope: str | None,
+    benchmark_id: str | None = None,
+    batch_id: str | None = None,
+) -> str | None:
+    """Return a non-secret identity for a pending-upload queue.
+
+    The bearer token is already reduced to ``account_scope`` by ``ApiClient``;
+    neither it nor any other credential is persisted here.  Including the
+    server, account and plan/batch makes a ledger entry from one login or
+    private run plan ineligible for an unrelated context sharing the same
+    ``DRADAR_HOME``.  ``None`` means the caller cannot prove a safe scope and
+    must keep the entry for explicit review rather than guessing.
+    """
+    if not server or not account_scope:
+        return None
+    payload = {
+        "schema": "dradar-pending-scope-v1",
+        "server": str(server).rstrip("/"),
+        "account_scope": str(account_scope),
+        "benchmark_id": str(benchmark_id or ""),
+        "batch_id": str(batch_id or ""),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
 def _path(home: Path) -> Path:
@@ -102,7 +132,7 @@ def assignment_ids(home: Path) -> set[str]:
     return {
         str(entry["assignment_id"])
         for entry in load(home)
-        if entry.get("assignment_id")
+        if isinstance(entry, dict) and entry.get("assignment_id")
     }
 
 
@@ -143,20 +173,51 @@ def _save_unlocked(home: Path, entries: list[dict]) -> None:
 
 
 def record(home: Path, entry: dict) -> None:
-    """Add or replace (by assignment_id) a pending-upload entry."""
+    """Add or replace a pending-upload entry.
+
+    Assignment IDs are normally globally unique, but old ledgers have no
+    scope metadata.  A scoped entry must not replace an old/foreign entry with
+    the same ID: preserving that evidence is safer than silently discarding
+    it during a login or plan switch.
+    """
     with _locked(home):
         entries = [
             e for e in _load_unlocked(home)
-            if e.get("assignment_id") != entry.get("assignment_id")
+            if (
+                not isinstance(e, dict)
+                or e.get("assignment_id") != entry.get("assignment_id")
+                or (
+                    e.get("scope_fingerprint") != entry.get("scope_fingerprint")
+                    and (
+                        e.get("scope_fingerprint") is not None
+                        or entry.get("scope_fingerprint") is not None
+                    )
+                )
+            )
         ]
         entries.append(entry)
         _save_unlocked(home, entries)
 
 
-def remove(home: Path, assignment_id: str) -> None:
+def remove(
+    home: Path,
+    assignment_id: str,
+    *,
+    scope_fingerprint: str | None = None,
+) -> None:
+    """Remove one assignment, optionally limited to its queue scope.
+
+    An omitted scope removes only legacy (unscoped) rows.  Scoped callers must
+    identify their exact row so settling one context cannot delete preserved
+    evidence from another context sharing the same assignment ID.
+    """
     with _locked(home):
         entries = [
             e for e in _load_unlocked(home)
-            if e.get("assignment_id") != assignment_id
+            if not (
+                isinstance(e, dict)
+                and e.get("assignment_id") == assignment_id
+                and e.get("scope_fingerprint") == scope_fingerprint
+            )
         ]
         _save_unlocked(home, entries)

--- a/src/dradar/run_plans.py
+++ b/src/dradar/run_plans.py
@@ -1048,7 +1048,9 @@ def _local_preparing_response(
     return result
 
 
-def _exact_pending_uploads(batch_id: str) -> list[dict[str, Any]]:
+def _exact_pending_uploads(
+    batch_id: str, client: ApiClient | None = None,
+) -> list[dict[str, Any]]:
     """Read only durable completed results belonging to one exact plan batch."""
 
     from . import pending
@@ -1057,13 +1059,30 @@ def _exact_pending_uploads(batch_id: str) -> list[dict[str, Any]]:
         expected = normalize_batch_id(batch_id)
     except ValueError:
         return []
+    expected_scope = None
+    if (
+        client is not None
+        and getattr(client, "server", None)
+        and getattr(client, "account_scope", None)
+    ):
+        expected_scope = pending.scope_fingerprint(
+            server=client.server,
+            account_scope=client.account_scope,
+            benchmark_id=getattr(client, "benchmark_id", None),
+            batch_id=expected,
+        )
     matches = []
     for entry in pending.load(HOME):
+        if not isinstance(entry, dict):
+            continue
         try:
             actual = normalize_batch_id(entry.get("batch_id"))
         except ValueError:
             continue
-        if actual == expected:
+        if actual == expected and (
+            expected_scope is None
+            or entry.get("scope_fingerprint") == expected_scope
+        ):
             matches.append(entry)
     return matches
 
@@ -1212,7 +1231,7 @@ def _recover_plan_uploads(
     """Replay this plan's completed local uploads without starting a runner."""
 
     batch_id = state["batch_id"]
-    before = _exact_pending_uploads(batch_id)
+    before = _exact_pending_uploads(batch_id, client)
     if not before:
         return {
             "schema_version": SCHEMA_VERSION,
@@ -1227,8 +1246,9 @@ def _recover_plan_uploads(
         }
     from . import runloop
 
+    runloop._mark_pending_scope_required(client)
     runloop._retry_pending_uploads(client, batch_id=batch_id)
-    remaining = _exact_pending_uploads(batch_id)
+    remaining = _exact_pending_uploads(batch_id, client)
     if not remaining:
         return {
             "schema_version": SCHEMA_VERSION,
@@ -2315,7 +2335,7 @@ def cmd_progress_plan(args) -> int:
         from . import fleet
 
         local_item = fleet.batch_status(state["batch_id"])
-        pending_uploads = _exact_pending_uploads(state["batch_id"])
+        pending_uploads = _exact_pending_uploads(state["batch_id"], client)
         same_local_plan = bool(
             isinstance(local_item, dict)
             and local_item.get("plan_id") == state["plan_id"]

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -1848,7 +1848,10 @@ def _upload_trial(
             print(f"patch contains secret-shaped content ({', '.join(labels)}) "
                   "outside safely redactable added lines, or redaction made the diff "
                   f"invalid; not uploaded. Raw evidence kept at {patch}")
-            pending.remove(HOME, assignment_id)
+            pending.remove(
+                HOME, assignment_id,
+                scope_fingerprint=entry.get("scope_fingerprint"),
+            )
             settle_terminal_local_failure()
             return "not-uploaded"
         print(f"patch contained secret-shaped content "
@@ -1877,7 +1880,10 @@ def _upload_trial(
                 "    assignment reopened for an independent ZCode re-solve; "
                 "no prior model answer is reused"
             )
-            pending.remove(HOME, assignment_id)
+            pending.remove(
+                HOME, assignment_id,
+                scope_fingerprint=entry.get("scope_fingerprint"),
+            )
             settle_terminal_local_failure()
             # This guard is assignment-local: the model completed normally,
             # but did not produce the one allowed deliverable.  The server has
@@ -2279,7 +2285,10 @@ def _upload_trial(
                                     f"  {task_id}: lease expired before its saved "
                                     "upload could be reconciled; local evidence kept"
                                 )
-                                pending.remove(HOME, assignment_id)
+                                pending.remove(
+                                    HOME, assignment_id,
+                                    scope_fingerprint=entry.get("scope_fingerprint"),
+                                )
                                 cleanup_settled()
                                 return "expired"
                             print(
@@ -2359,7 +2368,10 @@ def _upload_trial(
                             "upload recovery could be registered — the cell "
                             "reopened, dropping it"
                         )
-                        pending.remove(HOME, assignment_id)
+                        pending.remove(
+                            HOME, assignment_id,
+                            scope_fingerprint=entry.get("scope_fingerprint"),
+                        )
                         cleanup_settled()
                         return "expired"
                     if exc.status_code == 409 and exc.code == "upload_owner_superseded":
@@ -2436,7 +2448,10 @@ def _upload_trial(
                         "releasing the incompatible assignment instead of "
                         "retrying forever"
                     )
-                    pending.remove(HOME, assignment_id)
+                    pending.remove(
+                        HOME, assignment_id,
+                        scope_fingerprint=entry.get("scope_fingerprint"),
+                    )
                     settle_terminal_local_failure()
                     print(
                         "  rejected artifacts kept for diagnosis: "
@@ -2450,13 +2465,19 @@ def _upload_trial(
                     print(f"  {task_id}: already submitted (an earlier attempt landed) — clearing it")
                     if not ask_cleanup:
                         archive_after_submit(HOME, entry)
-                    pending.remove(HOME, assignment_id)
+                    pending.remove(
+                        HOME, assignment_id,
+                        scope_fingerprint=entry.get("scope_fingerprint"),
+                    )
                     cleanup_settled()
                     return "submitted"
                 if exc.status_code == 410:
                     print(f"  {task_id}: lease expired, unsalvageable — the cell reopened "
                           "for someone else, dropping it")
-                    pending.remove(HOME, assignment_id)
+                    pending.remove(
+                        HOME, assignment_id,
+                        scope_fingerprint=entry.get("scope_fingerprint"),
+                    )
                     cleanup_settled()
                     return "expired"
                 if (exc.status_code in (404, 413)
@@ -2469,7 +2490,10 @@ def _upload_trial(
                     print(f"  {task_id}: the server rejected this upload for good ({exc}) — "
                           "retrying can't fix it, dropping it from the retry queue "
                           f"(local artifact path: {patch.parent.parent})")
-                    pending.remove(HOME, assignment_id)
+                    pending.remove(
+                        HOME, assignment_id,
+                        scope_fingerprint=entry.get("scope_fingerprint"),
+                    )
                     settle_terminal_local_failure()
                     print(f"  rejected artifacts kept for diagnosis: {patch.parent.parent}")
                     return "rejected"
@@ -2482,7 +2506,10 @@ def _upload_trial(
 
     if not ask_cleanup:
         archive_after_submit(HOME, entry)
-    pending.remove(HOME, assignment_id)
+    pending.remove(
+        HOME, assignment_id,
+        scope_fingerprint=entry.get("scope_fingerprint"),
+    )
     cleanup_settled()
     exact_empty_submission = (
         ack.get("terminal_outcome") == "empty-submission"
@@ -2712,7 +2739,9 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
             ),
         )
         return "task-content-mismatch"
-    if assignment["assignment_id"] in pending.assignment_ids(HOME):
+    if assignment["assignment_id"] in _pending_assignment_ids_for_client(
+        client, batch_id=assignment.get("batch_id"),
+    ):
         print(
             "refusing to start: this assignment already has a durable completed "
             "result pending upload; run `dradar retry-upload`"
@@ -3309,6 +3338,12 @@ def _run_and_submit(client: ApiClient, assignment: dict, tasks_root: Path,
         # machine can retry the upload without re-running the model or touching
         # another concurrently active Honeypot.
         "batch_id": assignment.get("batch_id"),
+        "scope_fingerprint": pending.scope_fingerprint(
+            server=getattr(client, "server", None),
+            account_scope=getattr(client, "account_scope", None),
+            benchmark_id=getattr(client, "benchmark_id", None),
+            batch_id=assignment.get("batch_id"),
+        ),
         "meta": meta, "outcome": outcome,
         "job_dir": str(art.job_dir) if art.job_dir else None, "keep": args.keep,
         "archive_session": getattr(args, "archive_session", False),
@@ -3387,7 +3422,202 @@ def _pending_uploads_for_batch(batch_id: str) -> list[dict]:
         except ValueError:
             return False
 
-    return [entry for entry in pending.load(HOME) if belongs(entry)]
+    return [
+        entry for entry in pending.load(HOME)
+        if isinstance(entry, dict) and belongs(entry)
+    ]
+
+
+def _pending_uploads_for_client_batch(
+    client: ApiClient, batch_id: str,
+) -> list[dict]:
+    """Filter a batch ledger by the client's account/server identity too."""
+    entries = _pending_uploads_for_batch(batch_id)
+    if not _pending_scope_is_required(client):
+        return entries
+    expected = _pending_scope_fingerprint(client, batch_id=batch_id)
+    if expected is None:
+        return []
+    return [
+        entry for entry in entries
+        if entry.get("scope_fingerprint") == expected
+    ]
+
+
+def _pending_scope_fingerprint(
+    client: ApiClient, *, batch_id: str | None = None,
+) -> str | None:
+    """Build the non-secret queue identity for this client/plan context."""
+    effective_batch = (
+        batch_id if batch_id is not None else getattr(client, "batch_id", None)
+    )
+    if effective_batch is not None:
+        try:
+            # Persist and compare one canonical representation even when an
+            # assignment envelope used the UUID's hyphenated spelling.  An
+            # invalid batch is unknown, so callers must fail closed instead
+            # of hashing an unverifiable value into a replayable scope.
+            effective_batch = normalize_batch_id(effective_batch)
+        except (TypeError, ValueError):
+            return None
+    return pending.scope_fingerprint(
+        server=getattr(client, "server", None),
+        account_scope=getattr(client, "account_scope", None),
+        benchmark_id=getattr(client, "benchmark_id", None),
+        batch_id=effective_batch,
+    )
+
+
+def _mark_pending_scope_required(client: ApiClient) -> None:
+    """Opt a production retry scan into fail-closed scope filtering.
+
+    Keeping this as a client marker preserves compatibility with tiny test and
+    third-party adapters that monkeypatch ``_retry_pending_uploads`` with the
+    historical one-argument callable.  Real ``ApiClient`` instances always
+    carry ``server`` and ``account_scope`` and therefore opt in.
+    """
+    if getattr(client, "server", None) and getattr(client, "account_scope", None):
+        try:
+            setattr(client, "_pending_scope_required", True)
+        except Exception:  # pragma: no cover - unusual immutable adapter
+            pass
+
+
+def _pending_scope_is_required(client: ApiClient) -> bool:
+    """Whether this retry adapter can and must prove an account scope."""
+    return bool(
+        getattr(client, "_pending_scope_required", False)
+        or (
+            getattr(client, "server", None)
+            and getattr(client, "account_scope", None)
+        )
+    )
+
+
+def _pending_entry_matches_scope(
+    client: ApiClient,
+    entry: dict,
+    *,
+    batch_id: str | None = None,
+) -> bool:
+    """Whether a durable entry belongs to this exact client/plan context."""
+    if not isinstance(entry, dict):
+        return False
+    effective_batch = (
+        batch_id if batch_id is not None else getattr(client, "batch_id", None)
+    )
+    raw_entry_batch = entry.get("batch_id")
+    if effective_batch is None:
+        if raw_entry_batch is not None:
+            return False
+    else:
+        try:
+            if normalize_batch_id(raw_entry_batch) != normalize_batch_id(
+                effective_batch,
+            ):
+                return False
+        except (TypeError, ValueError):
+            return False
+    expected = _pending_scope_fingerprint(client, batch_id=effective_batch)
+    if expected is None or entry.get("scope_fingerprint") != expected:
+        return False
+    # ``runner_session_id`` remains in the entry and is sent through the
+    # server's owner-intent fence.  A standalone retry may therefore replay a
+    # durable session safely once its server/account/plan scope matches; the
+    # server, not a newly-created local process, decides whether that exact
+    # owner session is still valid.
+    return True
+
+
+def _pending_uploads_for_scope(
+    client: ApiClient, *, batch_id: str | None = None,
+) -> list[dict]:
+    """Load only entries proven to belong to this client/plan scope."""
+    effective_batch = (
+        batch_id if batch_id is not None else getattr(client, "batch_id", None)
+    )
+    if effective_batch is None:
+        candidates, ambiguous_ids = _personal_scope_candidates(client)
+        return [
+            entry for entry in candidates
+            if entry.get("assignment_id") not in ambiguous_ids
+        ]
+    return [
+        entry for entry in pending.load(HOME)
+        if _pending_entry_matches_scope(client, entry, batch_id=effective_batch)
+    ]
+
+
+def _pending_assignment_ids_for_client(
+    client: ApiClient, *, batch_id: str | None = None,
+) -> set[str]:
+    """Return durable assignments only from this account/plan queue.
+
+    Assignment fencing must still include session-bound rows: even when a
+    standalone command cannot immediately replay such a row, it must not rerun
+    the paid model work.  Unlike upload replay, this helper intentionally does
+    not require a live session ID.
+    """
+    if not _pending_scope_is_required(client):
+        return pending.assignment_ids(HOME)
+    effective_batch = (
+        batch_id if batch_id is not None else getattr(client, "batch_id", None)
+    )
+    if effective_batch is None:
+        entries, _ambiguous_ids = _personal_scope_candidates(client)
+    else:
+        entries = [
+            entry for entry in pending.load(HOME)
+            if _pending_entry_matches_scope(
+                client, entry, batch_id=effective_batch,
+            )
+        ]
+    return {
+        str(entry["assignment_id"])
+        for entry in entries
+        if entry.get("assignment_id")
+    }
+
+
+def _personal_scope_candidates(
+    client: ApiClient,
+) -> tuple[list[dict], set[str]]:
+    """Find all own personal-batch rows and flag assignment collisions.
+
+    A normal client can legitimately have more than one active personal
+    batch.  Each row is matched against its own normalized ``batch_id``;
+    only an invalid/unknown row or the same assignment appearing in multiple
+    batches is ambiguous and therefore withheld from automatic replay.
+    """
+    candidates: list[dict] = []
+    assignment_batches: dict[str, set[str | None]] = {}
+    for entry in pending.load(HOME):
+        if not isinstance(entry, dict):
+            continue
+        raw_batch = entry.get("batch_id")
+        if raw_batch is None:
+            normalized_batch = None
+        else:
+            try:
+                normalized_batch = normalize_batch_id(raw_batch)
+            except ValueError:
+                continue
+        expected = _pending_scope_fingerprint(
+            client, batch_id=normalized_batch,
+        )
+        if expected is None or entry.get("scope_fingerprint") != expected:
+            continue
+        candidates.append(entry)
+        assignment_id = entry.get("assignment_id")
+        if assignment_id:
+            assignment_batches.setdefault(str(assignment_id), set()).add(
+                normalized_batch,
+            )
+    ambiguous_ids = {
+        assignment_id for assignment_id, batches in assignment_batches.items()
+        if len(batches) > 1
+    }
+    return candidates, ambiguous_ids
 
 
 def _retry_pending_uploads(
@@ -3397,9 +3627,21 @@ def _retry_pending_uploads(
     previous run couldn't upload before doing anything else. Silent no-op
     when the ledger is empty — this must never surprise a volunteer who has
     nothing pending."""
-    entries = pending.load(HOME)
-    if batch_id is not None:
-        entries = _pending_uploads_for_batch(batch_id)
+    malformed_count = sum(
+        not isinstance(entry, dict) for entry in pending.load(HOME)
+    )
+    if malformed_count:
+        print(
+            f"warning: kept {malformed_count} malformed pending ledger row(s) "
+            "for manual recovery; no upload was attempted for those rows"
+        )
+    if _pending_scope_is_required(client):
+        entries = _pending_uploads_for_scope(client, batch_id=batch_id)
+    else:
+        entries = pending.load(HOME)
+        if batch_id is not None:
+            entries = _pending_uploads_for_batch(batch_id)
+        entries = [entry for entry in entries if isinstance(entry, dict)]
     if not entries:
         return []
     print(f"checking {len(entries)} pending upload(s) left over from a previous run...")
@@ -3425,7 +3667,8 @@ def cmd_retry_upload(args) -> int:
     if salvage_assignment_id:
         matches = [
             entry for entry in entries
-            if entry.get("assignment_id") == salvage_assignment_id
+            if isinstance(entry, dict)
+            and entry.get("assignment_id") == salvage_assignment_id
         ]
         if not matches:
             print(
@@ -3448,13 +3691,46 @@ def cmd_retry_upload(args) -> int:
             if answer not in {"y", "yes"}:
                 print("cancelled — no server or local state was changed")
                 return 1
+        if (
+            getattr(client, "server", None)
+            and getattr(client, "account_scope", None)
+            and not _pending_entry_matches_scope(
+                client, entry, batch_id=entry.get("batch_id")
+            )
+        ):
+            print(
+                "saved result belongs to a different or unknown server/account/plan "
+                "scope; local evidence was kept and no upload was attempted"
+            )
+            return 1
         outcome = _upload_trial(client, entry, request_salvage=True)
         return 0 if outcome in {"submitted", "interrupted"} else 1
+    _mark_pending_scope_required(client)
     _retry_pending_uploads(client)
     remaining = pending.load(HOME)
     if remaining:
-        blocked = [entry for entry in remaining if entry.get("upload_blocked")]
-        retryable = [entry for entry in remaining if not entry.get("upload_blocked")]
+        if _pending_scope_is_required(client):
+            eligible = _pending_uploads_for_scope(client)
+            eligible_ids = {
+                (entry.get("assignment_id"), entry.get("scope_fingerprint"))
+                for entry in eligible
+            }
+            skipped = [
+                entry for entry in remaining
+                if not isinstance(entry, dict)
+            ]
+            skipped.extend(
+                entry for entry in remaining
+                if isinstance(entry, dict)
+                if (
+                    entry.get("assignment_id"), entry.get("scope_fingerprint")
+                ) not in eligible_ids
+            )
+        else:
+            eligible = [entry for entry in remaining if isinstance(entry, dict)]
+            skipped = []
+        blocked = [entry for entry in eligible if entry.get("upload_blocked")]
+        retryable = [entry for entry in eligible if not entry.get("upload_blocked")]
         if blocked:
             reasons = ", ".join(
                 f"{entry.get('task_id', entry.get('assignment_id', '?'))}:"
@@ -3469,6 +3745,12 @@ def cmd_retry_upload(args) -> int:
             print(
                 f"{len(retryable)} still pending and retryable (will retry "
                 "again on the next `dradar go`/`retry-upload`)"
+            )
+        if skipped:
+            print(
+                f"{len(skipped)} saved upload(s) were kept because their "
+                "server/account/plan/session scope is unknown, malformed, or "
+                "does not match this login; review them explicitly before retrying"
             )
         return 1
     print("all clear")
@@ -3730,7 +4012,7 @@ def cmd_cleanup(args) -> int:
 
     pending_ids = {
         entry.get("assignment_id") for entry in pending.load(HOME)
-        if entry.get("assignment_id")
+        if isinstance(entry, dict) and entry.get("assignment_id")
     }
     candidates: list[local_jobs.LocalJob] = []
     protected_active = protected_pending = protected_kept = 0
@@ -4242,6 +4524,7 @@ def cmd_go(args) -> int:
         # children; letting every child replay the same entries creates a
         # duplicate-upload herd precisely when the server asks us to slow down.
         if not getattr(args, "worker_child", False) and not fleet_pool:
+            _mark_pending_scope_required(client)
             _retry_pending_uploads(client)
 
         boundary_path = _prepare_assignment_boundary(
@@ -4459,7 +4742,9 @@ def _pool_ready_work_count(
     if active is None:
         one = data.get("assignment")
         active = [one] if one else []
-    pending_ids = pending.assignment_ids(HOME)
+    pending_ids = _pending_assignment_ids_for_client(
+        client, batch_id=getattr(client, "batch_id", None),
+    )
     waiting = sum(
         _assignment_is_ready_for_checkout(
             assignment, claimed_after=claimed_after,
@@ -4852,8 +5137,10 @@ def _run_worker_pool(args) -> int:
     except RunnerError as exc:
         sys.exit(str(exc))
     if fleet_pool:
+        _mark_pending_scope_required(client)
         _retry_pending_uploads(client, batch_id=args.batch_id)
     else:
+        _mark_pending_scope_required(client)
         _retry_pending_uploads(client)
 
     maximum = args.workers
@@ -4887,7 +5174,7 @@ def _run_worker_pool(args) -> int:
         )
     active, _free_pick = _prepare_batch(args, client)
     if _scoped_fleet_refill(args):
-        pending_now = _pending_uploads_for_batch(args.batch_id)
+        pending_now = _pending_uploads_for_client_batch(client, args.batch_id)
         ready_now = (
             _pool_ready_work_count(client)
             if active else 0
@@ -5499,8 +5786,9 @@ def _run_worker_pool(args) -> int:
             # an interrupted (recoverable) local state instead of a false clean
             # stop; the Agent can later invoke run --upload-only without
             # re-enrolling this device or starting another model.
+            _mark_pending_scope_required(client)
             _retry_pending_uploads(client, batch_id=args.batch_id)
-            if _pending_uploads_for_batch(args.batch_id):
+            if _pending_uploads_for_client_batch(client, args.batch_id):
                 print(
                     "worker pool stopped with a completed result still waiting "
                     "to upload; no model work will be repeated"
@@ -5654,7 +5942,9 @@ def _acquire_batch(
         except ApiError as exc:
             _exit_for(exc)
         active = [one] if one else []
-    pending_ids = pending.assignment_ids(HOME)
+    pending_ids = _pending_assignment_ids_for_client(
+        client, batch_id=getattr(client, "batch_id", None),
+    )
     blocked = [a for a in active if a.get("assignment_id") in pending_ids]
     if blocked:
         print(
@@ -5669,7 +5959,9 @@ def _run_batch(args, client: ApiClient, tasks_root: Path, active: list[dict],
     """Run a non-empty held batch serially: one version-pin check covers the
     whole batch (a single local checkout serves every cell; it sys.exit's on
     a mismatch unless --allow-task-drift), then per-cell confirm/skip/run."""
-    blocked_ids = pending.assignment_ids(HOME)
+    blocked_ids = _pending_assignment_ids_for_client(
+        client, batch_id=getattr(client, "batch_id", None),
+    )
     active = [a for a in active if a.get("assignment_id") not in blocked_ids]
     if not active:
         print("all held assignments already have durable pending results; refusing to rerun")
@@ -5813,7 +6105,12 @@ def _run_checkout_loop(args, client: ApiClient, tasks_root: Path,
         checkout_exclusions = (
             failed_ids | degraded_exclusions
             | local_empty_blocked_ids
-            | (pending.assignment_ids(HOME) & batch_assignment_ids)
+            | (
+                _pending_assignment_ids_for_client(
+                    client, batch_id=getattr(client, "batch_id", None),
+                )
+                & batch_assignment_ids
+            )
         )
         try:
             # A failed local cell is marked stopped so it is retryable later,
@@ -6364,7 +6661,9 @@ def _wait_for_scoped_refill_work(
             if envelope.get("agent_action") in {"stop_runner", "done"}:
                 return []
 
-            scoped_pending = _pending_uploads_for_batch(args.batch_id)
+            scoped_pending = _pending_uploads_for_client_batch(
+                client, args.batch_id,
+            )
             blocked_pending = [
                 entry for entry in scoped_pending if entry.get("upload_blocked")
             ]
@@ -6374,8 +6673,11 @@ def _wait_for_scoped_refill_work(
                     "no new model work will start until it is resolved"
                 )
             if scoped_pending:
+                _mark_pending_scope_required(client)
                 _retry_pending_uploads(client, batch_id=args.batch_id)
-                pending_after_retry = _pending_uploads_for_batch(args.batch_id)
+                pending_after_retry = _pending_uploads_for_client_batch(
+                    client, args.batch_id,
+                )
                 blocked_after_retry = [
                     entry for entry in pending_after_retry
                     if entry.get("upload_blocked")

--- a/tests/test_pending_upload.py
+++ b/tests/test_pending_upload.py
@@ -37,6 +37,24 @@ def test_record_replaces_same_assignment(tmp_path: Path):
     assert len(entries) == 1 and entries[0]["attempt"] == 2
 
 
+def test_record_preserves_same_assignment_from_another_scope(tmp_path: Path):
+    scope_a = pending.scope_fingerprint(
+        server="https://a.example", account_scope="a", batch_id="plan-a",
+    )
+    scope_b = pending.scope_fingerprint(
+        server="https://b.example", account_scope="b", batch_id="plan-b",
+    )
+    pending.record(tmp_path, {
+        "assignment_id": "reused", "scope_fingerprint": scope_a,
+    })
+    pending.record(tmp_path, {
+        "assignment_id": "reused", "scope_fingerprint": scope_b,
+    })
+    assert {
+        entry["scope_fingerprint"] for entry in pending.load(tmp_path)
+    } == {scope_a, scope_b}
+
+
 def test_remove_is_idempotent(tmp_path: Path):
     pending.record(tmp_path, {"assignment_id": "a1"})
     pending.remove(tmp_path, "a1")
@@ -116,15 +134,35 @@ def _entry(trial_dir: Path, **overrides) -> dict:
     """A pending-ledger entry dict — the shape _upload_trial takes."""
     e = {"assignment_id": "a1", "nonce": "nonce1", "task_id": "t1",
          "trial_dir": str(trial_dir), "meta": {}, "outcome": "completed",
-         "job_dir": None, "keep": True}
+         "job_dir": None, "keep": True,
+         # Production retry scans now require a non-secret account/server
+         # scope. Keep this fixture representative of a newly recorded row;
+         # tests that exercise legacy rows omit the field explicitly.
+         "scope_fingerprint": pending.scope_fingerprint(
+             server="https://api.example.com",
+             account_scope=ApiClient(
+                 "https://api.example.com", "drt_test",
+                 capabilities=(),
+             ).account_scope,
+         )}
     e.update(overrides)
+    if "scope_fingerprint" not in overrides:
+        e["scope_fingerprint"] = pending.scope_fingerprint(
+            server="https://api.example.com",
+            account_scope=ApiClient(
+                "https://api.example.com", "drt_test",
+                capabilities=(),
+            ).account_scope,
+            benchmark_id=e.get("benchmark_id"),
+            batch_id=e.get("batch_id"),
+        )
     return e
 
 
 def test_upload_success_clears_ledger(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(runloop, "HOME", tmp_path)
     trial_dir = _make_trial_dir(tmp_path)
-    pending.record(tmp_path, {"assignment_id": "a1", "task_id": "t1"})
+    pending.record(tmp_path, _entry(trial_dir))
     client = FakeClient(lambda aid: {"submission_id": "s1", "grade_status": "pending"})
     outcome = runloop._upload_trial(client, _entry(trial_dir, meta={"k": "v"}))
     assert outcome == "submitted"
@@ -136,7 +174,7 @@ def test_exact_empty_submission_ack_is_not_collapsed_to_submitted(
 ):
     monkeypatch.setattr(runloop, "HOME", tmp_path)
     trial_dir = _make_trial_dir(tmp_path)
-    pending.record(tmp_path, {"assignment_id": "a1", "task_id": "t1"})
+    pending.record(tmp_path, _entry(trial_dir))
     client = FakeClient(lambda _aid: {
         "submission_id": "s-empty",
         "grade_status": "invalid",
@@ -337,6 +375,7 @@ def test_maintenance_total_budget_exhaustion_keeps_ledger_and_exits_nonzero(
         runner_session_id="session-1234",
         owner_epoch=7,
         ledger_version=3,
+        batch_id="550e8400e29b41d4a716446655440000",
     )
     pending.record(tmp_path, entry)
     paths = []
@@ -369,6 +408,7 @@ def test_maintenance_total_budget_exhaustion_keeps_ledger_and_exits_nonzero(
     client = ApiClient(
         "https://api.example.com", "drt_test",
         transport=httpx.MockTransport(handler), capabilities=(),
+        batch_id="550e8400e29b41d4a716446655440000",
     )
     now = [0.0]
     waits = []
@@ -502,6 +542,312 @@ def test_plan_pending_replay_is_exact_batch_scoped(tmp_path: Path, monkeypatch):
     assert {entry["assignment_id"] for entry in pending.load(tmp_path)} == {
         "b", "legacy-without-scope",
     }
+
+
+def test_pending_retry_isolated_by_server_account_and_plan_scope(
+    tmp_path: Path, monkeypatch,
+):
+    """A shared HOME must not replay plan A's paid result through plan B."""
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    batch_a = "550e8400e29b41d4a716446655440000"
+    batch_b = "6ba7b8109dad11d180b400c04fd430c8"
+    client_a = ApiClient(
+        "https://server-a.example", "token-a", capabilities=(),
+        benchmark_id="bench", batch_id=batch_a,
+    )
+    client_b = ApiClient(
+        "https://server-b.example", "token-b", capabilities=(),
+        benchmark_id="bench", batch_id=batch_b,
+    )
+    pending.record(tmp_path, {
+        "assignment_id": "shared-assignment", "batch_id": batch_a,
+        "scope_fingerprint": runloop._pending_scope_fingerprint(
+            client_a, batch_id=batch_a,
+        ),
+    })
+    pending.record(tmp_path, {
+        "assignment_id": "from-b", "batch_id": batch_b,
+        "scope_fingerprint": runloop._pending_scope_fingerprint(
+            client_b, batch_id=batch_b,
+        ),
+    })
+    touched = []
+    monkeypatch.setattr(
+        runloop, "_upload_trial",
+        lambda _client, entry: touched.append(entry["assignment_id"]) or (
+            pending.remove(
+                tmp_path, entry["assignment_id"],
+                scope_fingerprint=entry.get("scope_fingerprint"),
+            )
+            or "submitted"
+        ),
+    )
+
+    runloop._mark_pending_scope_required(client_b)
+    assert runloop._retry_pending_uploads(client_b, batch_id=batch_b) == [
+        "submitted"
+    ]
+    assert touched == ["from-b"]
+    remaining = pending.load(tmp_path)
+    assert [entry["assignment_id"] for entry in remaining] == ["shared-assignment"]
+    # Scope-aware fencing must not let an old account/plan row block this
+    # account's worker registration or checkout path.
+    assert "shared-assignment" not in runloop._pending_assignment_ids_for_client(
+        client_b, batch_id=batch_b,
+    )
+
+
+def test_personal_client_derives_one_pending_batch_for_retry_and_fence(
+    tmp_path: Path, monkeypatch,
+):
+    """A normal client can recover one owned batch without guessing across plans."""
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    batch_id = "550e8400e29b41d4a716446655440000"
+    client = ApiClient(
+        "https://server.example", "token", capabilities=(),
+        benchmark_id="bench",
+    )
+    scope = runloop._pending_scope_fingerprint(client, batch_id=batch_id)
+    pending.record(tmp_path, {
+        "assignment_id": "owned", "batch_id": batch_id,
+        "scope_fingerprint": scope,
+    })
+    touched = []
+    monkeypatch.setattr(
+        runloop, "_upload_trial",
+        lambda _client, entry: touched.append(entry["assignment_id"]) or (
+            pending.remove(
+                tmp_path, entry["assignment_id"],
+                scope_fingerprint=entry.get("scope_fingerprint"),
+            )
+            or "submitted"
+        ),
+    )
+    runloop._mark_pending_scope_required(client)
+    assert "owned" in runloop._pending_assignment_ids_for_client(client)
+    assert runloop._retry_pending_uploads(client) == ["submitted"]
+    assert touched == ["owned"]
+    assert runloop._pending_assignment_ids_for_client(client) == set()
+
+
+def test_personal_client_fences_batch_pending_before_model_and_then_retries(
+    tmp_path: Path, monkeypatch,
+):
+    """A plain (batch-less) claim cannot rerun work saved by a prior batch."""
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    batch_id = "550e8400e29b41d4a716446655440000"
+    client = ApiClient(
+        "https://server.example", "token", capabilities=(),
+        benchmark_id="bench",
+    )
+    pending.record(tmp_path, {
+        "assignment_id": "owned", "batch_id": batch_id,
+        "scope_fingerprint": runloop._pending_scope_fingerprint(
+            client, batch_id=batch_id,
+        ),
+    })
+    monkeypatch.setattr(runloop, "check_task_content_hash", lambda *_a: True)
+    monkeypatch.setattr(
+        runloop, "run_trial",
+        lambda *_a, **_k: pytest.fail("durable pending work must fence the model"),
+    )
+    args = SimpleNamespace(allow_task_drift=False, dev_agent=False)
+    assignment = {
+        "assignment_id": "owned", "task_id": "task-owned", "nonce": "nonce",
+        "batch_id": None,
+    }
+    assert runloop._run_and_submit(
+        client, assignment, tmp_path, args, None,
+    ) == "pending-upload"
+
+    touched = []
+    monkeypatch.setattr(
+        runloop, "_upload_trial",
+        lambda _client, entry: touched.append(entry["assignment_id"]) or (
+            pending.remove(
+                tmp_path, entry["assignment_id"],
+                scope_fingerprint=entry.get("scope_fingerprint"),
+            )
+            or "submitted"
+        ),
+    )
+    runloop._mark_pending_scope_required(client)
+    assert runloop._retry_pending_uploads(client) == ["submitted"]
+    assert touched == ["owned"]
+
+
+def test_personal_client_replays_multiple_owned_batches(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    client = ApiClient(
+        "https://server.example", "token", capabilities=(),
+        benchmark_id="bench",
+    )
+    batches = [
+        "550e8400e29b41d4a716446655440000",
+        "6ba7b8109dad11d180b400c04fd430c8",
+    ]
+    for index, batch_id in enumerate(batches):
+        pending.record(tmp_path, {
+            "assignment_id": f"owned-{index}", "batch_id": batch_id,
+            "scope_fingerprint": runloop._pending_scope_fingerprint(
+                client, batch_id=batch_id,
+            ),
+        })
+    touched = []
+    monkeypatch.setattr(
+        runloop, "_upload_trial",
+        lambda _client, entry: touched.append(entry["assignment_id"]) or (
+            pending.remove(
+                tmp_path, entry["assignment_id"],
+                scope_fingerprint=entry.get("scope_fingerprint"),
+            )
+            or "submitted"
+        ),
+    )
+    runloop._mark_pending_scope_required(client)
+    assert runloop._retry_pending_uploads(client) == ["submitted", "submitted"]
+    assert touched == ["owned-0", "owned-1"]
+    assert pending.load(tmp_path) == []
+
+
+def test_personal_client_fails_closed_on_assignment_collision_across_batches(
+    tmp_path: Path, monkeypatch,
+):
+    """A reused assignment ID in two own batches is withheld, not guessed."""
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    client = ApiClient(
+        "https://server.example", "token", capabilities=(),
+        benchmark_id="bench",
+    )
+    batches = [
+        "550e8400e29b41d4a716446655440000",
+        "6ba7b8109dad11d180b400c04fd430c8",
+    ]
+    for batch_id in batches:
+        pending.record(tmp_path, {
+            "assignment_id": "reused", "batch_id": batch_id,
+            "scope_fingerprint": runloop._pending_scope_fingerprint(
+                client, batch_id=batch_id,
+            ),
+        })
+    monkeypatch.setattr(
+        runloop, "_upload_trial",
+        lambda *_args, **_kwargs: pytest.fail(
+            "assignment collision must stay local",
+        ),
+    )
+    runloop._mark_pending_scope_required(client)
+    assert runloop._retry_pending_uploads(client) == []
+    assert len(pending.load(tmp_path)) == 2
+    # Fencing remains conservative even though replay is withheld.
+    assert runloop._pending_assignment_ids_for_client(client) == {"reused"}
+
+
+def test_personal_client_skips_invalid_batch_but_preserves_evidence(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    client = ApiClient(
+        "https://server.example", "token", capabilities=(),
+        benchmark_id="bench",
+    )
+    pending.record(tmp_path, {
+        "assignment_id": "malformed", "batch_id": "not-a-uuid",
+        "scope_fingerprint": "not-a-real-scope",
+    })
+    monkeypatch.setattr(
+        runloop, "_upload_trial",
+        lambda *_args, **_kwargs: pytest.fail("invalid batch must stay local"),
+    )
+    runloop._mark_pending_scope_required(client)
+    assert runloop._retry_pending_uploads(client) == []
+    assert pending.load(tmp_path)[0]["assignment_id"] == "malformed"
+
+
+def test_retry_upload_keeps_malformed_ledger_rows_without_crashing(
+    tmp_path: Path, monkeypatch, capsys,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    raw_rows = [1, None, "not-an-entry"]
+    (tmp_path / "pending_uploads.json").write_text(json.dumps(raw_rows))
+    client = ApiClient("https://server.example", "token", capabilities=())
+    monkeypatch.setattr(runloop, "_load_config", lambda: {})
+    monkeypatch.setattr(runloop, "_client", lambda _cfg: client)
+
+    assert runloop.cmd_retry_upload(None) == 1
+    assert json.loads((tmp_path / "pending_uploads.json").read_text()) == raw_rows
+    output = capsys.readouterr().out
+    assert "malformed pending ledger row" in output
+    assert "unknown, malformed" in output
+
+
+def test_batch_helper_rejects_same_uuid_from_foreign_account(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    batch_id = "550e8400e29b41d4a716446655440000"
+    local = ApiClient("https://server.example", "token", capabilities=())
+    foreign = ApiClient("https://other.example", "token", capabilities=())
+    pending.record(tmp_path, {
+        "assignment_id": "foreign", "batch_id": batch_id,
+        "scope_fingerprint": runloop._pending_scope_fingerprint(
+            foreign, batch_id=batch_id,
+        ),
+    })
+    assert runloop._pending_uploads_for_client_batch(local, batch_id) == []
+
+
+def test_standalone_retry_keeps_legacy_entry_without_scope_fingerprint(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    client = ApiClient("https://server.example", "token", capabilities=())
+    pending.record(tmp_path, {
+        "assignment_id": "session-bound", "runner_session_id": "old-session",
+    })
+    monkeypatch.setattr(
+        runloop, "_upload_trial",
+        lambda *_args, **_kwargs: pytest.fail("unknown scope must stay local"),
+    )
+    runloop._mark_pending_scope_required(client)
+    assert runloop._retry_pending_uploads(client) == []
+    assert pending.load(tmp_path)[0]["assignment_id"] == "session-bound"
+
+
+def test_cmd_retry_upload_does_not_send_another_account_queue(
+    tmp_path: Path, monkeypatch, capsys,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    client_a = ApiClient("https://server.example", "token-a", capabilities=())
+    client_b = ApiClient("https://server.example", "token-b", capabilities=())
+    pending.record(tmp_path, {
+        "assignment_id": "from-a",
+        "scope_fingerprint": runloop._pending_scope_fingerprint(client_a),
+    })
+    pending.record(tmp_path, {
+        "assignment_id": "from-b",
+        "scope_fingerprint": runloop._pending_scope_fingerprint(client_b),
+    })
+    touched = []
+    monkeypatch.setattr(runloop, "_load_config", lambda: {})
+    monkeypatch.setattr(runloop, "_client", lambda _cfg: client_b)
+    monkeypatch.setattr(
+        runloop, "_upload_trial",
+        lambda _client, entry: touched.append(entry["assignment_id"]) or (
+            pending.remove(
+                tmp_path, entry["assignment_id"],
+                scope_fingerprint=entry.get("scope_fingerprint"),
+            )
+            or "submitted"
+        ),
+    )
+
+    assert runloop.cmd_retry_upload(None) == 1
+    assert touched == ["from-b"]
+    assert [entry["assignment_id"] for entry in pending.load(tmp_path)] == ["from-a"]
+    assert "scope is unknown, malformed, or does not match" in capsys.readouterr().out
 
 
 def test_intent_registration_conflict_keeps_artifact_without_submit(
@@ -1711,7 +2057,7 @@ def test_upload_failure_records_ledger_entry(tmp_path: Path, monkeypatch):
 def test_upload_409_means_already_landed_clears_ledger(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(runloop, "HOME", tmp_path)
     trial_dir = _make_trial_dir(tmp_path)
-    pending.record(tmp_path, {"assignment_id": "a1", "task_id": "t1"})
+    pending.record(tmp_path, _entry(trial_dir))
 
     def already(aid):
         raise ApiError("server returned 409: already submitted", status_code=409)
@@ -1743,7 +2089,7 @@ def test_stale_generation_409_is_not_misread_as_already_submitted(
 def test_upload_410_means_expired_clears_ledger(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(runloop, "HOME", tmp_path)
     trial_dir = _make_trial_dir(tmp_path)
-    pending.record(tmp_path, {"assignment_id": "a1", "task_id": "t1"})
+    pending.record(tmp_path, _entry(trial_dir))
 
     def expired(aid):
         raise ApiError("server returned 410: lease expired", status_code=410)
@@ -1760,7 +2106,7 @@ def test_transient_failure_with_409_in_message_is_not_misread_as_conflict(tmp_pa
     # treated as "already submitted". Only a real 409 response may do that.
     monkeypatch.setattr(runloop, "HOME", tmp_path)
     trial_dir = _make_trial_dir(tmp_path)
-    pending.record(tmp_path, {"assignment_id": "a1", "task_id": "t1"})
+    pending.record(tmp_path, _entry(trial_dir))
 
     def fail(aid):
         raise ApiError("cannot reach https://dradar.example.com:8409: connection refused")
@@ -1778,7 +2124,7 @@ def test_secret_in_added_patch_line_is_redacted_and_uploaded(tmp_path: Path, mon
         "diff --git a/app.py b/app.py\n"
         "--- a/app.py\n+++ b/app.py\n@@ -1 +1,2 @@\n old = True\n"
         "+api_key = \"ghp_ABCDEFghijkl0123456789ABCDEFghijkl0123\"\n")
-    pending.record(tmp_path, {"assignment_id": "a1", "task_id": "t1"})
+    pending.record(tmp_path, _entry(trial_dir))
     uploaded = {}
 
     class CaptureClient(FakeClient):


### PR DESCRIPTION
## 变更\n- 为 pending upload 写入不含凭据的 server/account/benchmark/canonical batch scope 指纹。\n- 普通客户端按每条记录的 batch 逐条安全恢复多个自有批次；跨账号、跨服务、跨 benchmark、非法 batch、同 assignment 跨批冲突和 legacy/malformed 行 fail-closed 并保留证据。\n- run-plan、Fleet、worker、cleanup、image-cache 与删除逻辑统一按 scope 过滤。\n\n## 证据\n- 独立复核：核心 scope 逻辑 PASS，无 P0 阻断。\n- 聚焦测试：317 passed；compileall、git diff --check 通过。\n- 完整套件：48 failed / 1629 passed / 2 skipped；48 个失败与 clean 基线同类，均为本机 sandbox 权限、loopback/lock 权限或 npm registry 网络限制，未发现新增业务失败。\n\n## 后续风险\n- 尚缺真实 Windows msvcrt 跨进程实测。\n- legacy 无 scope 行默认保留、不自动迁移。\n- 损坏 batch 当前不进入 scoped assignment fence，需后续保守 fence 工单。\n\n不包含生产发布、OTA、真实账号或真实跑题操作。