### PR TITLE
#0049 Fix CodeBuddy first-run runtime dependency

### DIFF
--- a/src/dradar/codebuddy_provider.py
+++ b/src/dradar/codebuddy_provider.py
@@ -19,12 +19,18 @@ from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
 
+from .codebuddy_runtime import (
+    CODEBUDDY_BASE_IMAGE,
+    CODEBUDDY_CLI_VERSION,
+    CODEBUDDY_CONTAINER_IMAGE,
+    CODEBUDDY_IMAGE_LABEL,
+    codebuddy_install_command,
+)
 from .local_config import HOME
 
 CODEBUDDY_AGENT = "codebuddy"
 CODEBUDDY_PROVIDER = "codebuddy-subscription"
 CODEBUDDY_MODEL = "hy4-preview"
-CODEBUDDY_CLI_VERSION = "2.137.1"
 CODEBUDDY_NATIVE_EFFORTS = (
     "minimal", "low", "medium", "high", "xhigh", "max",
 )
@@ -40,17 +46,11 @@ CODEBUDDY_RUN_CONFIG_VERSION = (
 CODEBUDDY_RUNTIME_PROFILE = (
     "pier-codebuddy-hy4-preview-isolated-copy-concurrent-v2"
 )
-CODEBUDDY_CONTAINER_IMAGE = f"dradar-codebuddy:{CODEBUDDY_CLI_VERSION}"
 CODEBUDDY_SOURCE_IMAGE_ENV = "DRADAR_CODEBUDDY_SOURCE_IMAGE"
 CODEBUDDY_HOME_ENV = "CODEBUDDY_CONFIG_DIR"
 CODEBUDDY_AUTH_DIR_ENV = "DRADAR_CODEBUDDY_AUTH_DIR"
 CODEBUDDY_MANAGED_HOME_ENV = "DRADAR_CODEBUDDY_MANAGED_HOME"
 CODEBUDDY_HOME_RELATIVE_PATH = Path("providers") / "codebuddy" / "current"
-CODEBUDDY_IMAGE_LABEL = "io.codex-radar.codebuddy.version"
-CODEBUDDY_BASE_IMAGE = (
-    "docker.io/library/debian:bookworm-slim@"
-    "sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171"
-)
 CODEBUDDY_STORE_MAX_FILES = 256
 CODEBUDDY_STORE_MAX_BYTES = 32 * 1024 * 1024
 CODEBUDDY_AUTH_MAX_FILES = 16
@@ -562,13 +562,11 @@ def ensure_codebuddy_runtime_image(docker: str | None = None) -> str:
         raise ValueError("Docker CLI is unavailable")
     if codebuddy_runtime_image_error(executable) is None:
         return CODEBUDDY_CONTAINER_IMAGE
-    from .pier_codebuddy import _install_command
-
     dockerfile = (
         f"FROM {CODEBUDDY_BASE_IMAGE}\n"
         'SHELL ["/bin/bash", "-lc"]\n'
         f"LABEL {CODEBUDDY_IMAGE_LABEL}={CODEBUDDY_CLI_VERSION}\n"
-        f"RUN {_install_command()}\n"
+        f"RUN {codebuddy_install_command()}\n"
     )
     try:
         built = subprocess.run(

--- a/src/dradar/codebuddy_runtime.py
+++ b/src/dradar/codebuddy_runtime.py
@@ -1,0 +1,66 @@
+"""Pier-free definition of the pinned CodeBuddy container runtime."""
+
+from __future__ import annotations
+
+import shlex
+
+CODEBUDDY_CLI_VERSION = "2.137.1"
+CODEBUDDY_CONTAINER_IMAGE = f"dradar-codebuddy:{CODEBUDDY_CLI_VERSION}"
+CODEBUDDY_IMAGE_LABEL = "io.codex-radar.codebuddy.version"
+CODEBUDDY_BASE_IMAGE = (
+    "docker.io/library/debian:bookworm-slim@"
+    "sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171"
+)
+
+_BASE_URL = (
+    "https://acc-1258344699.cos.ap-guangzhou.myqcloud.com/"
+    "@tencent-ai/codebuddy-code/releases/download"
+)
+_LINUX_SHA256 = {
+    "aarch64": "fe75f4491157837460d33fc201d9062dc1dde67c241ffb96bfac96dda92cbda1",
+    "x86_64": "a09e887057cde96383ecab875faac7a3d357094c7147f3bc3a69dd7d68d2887b",
+}
+
+
+def codebuddy_install_command() -> str:
+    """Return the reviewed shell command used to build the pinned image."""
+
+    return (
+        "set -euo pipefail; "
+        "if command -v apt-get >/dev/null 2>&1; then "
+        "apt-get update && DEBIAN_FRONTEND=noninteractive "
+        "apt-get install -y --no-install-recommends curl ca-certificates tar; "
+        "elif command -v apk >/dev/null 2>&1; then "
+        "apk add --no-cache curl ca-certificates tar; "
+        "elif command -v dnf >/dev/null 2>&1; then "
+        "dnf install -y curl ca-certificates tar; "
+        "elif command -v yum >/dev/null 2>&1; then "
+        "yum install -y curl ca-certificates tar; "
+        "else echo 'No supported package manager found' >&2; exit 1; fi; "
+        "arch=$(uname -m); "
+        f"case \"$arch\" in aarch64|arm64) asset=arm64; "
+        f"sha={_LINUX_SHA256['aarch64']} ;; "
+        f"x86_64|amd64) asset=x86_64; sha={_LINUX_SHA256['x86_64']} ;; "
+        "*) echo \"unsupported CodeBuddy architecture: $arch\" >&2; exit 2 ;; esac; "
+        "tmp=$(mktemp -d); trap 'rm -rf \"$tmp\"' EXIT; "
+        f"url={shlex.quote(_BASE_URL + '/' + CODEBUDDY_CLI_VERSION)}/"
+        "codebuddy-code_Linux_${asset}.tar.gz; "
+        "curl --fail --silent --show-error --location "
+        "--output \"$tmp/codebuddy.tar.gz\" \"$url\"; "
+        "printf '%s  %s\\n' \"$sha\" \"$tmp/codebuddy.tar.gz\" "
+        "| sha256sum --check --strict -; "
+        "tar -xzf \"$tmp/codebuddy.tar.gz\" -C \"$tmp\"; "
+        "mkdir -p /opt/codebuddy/bin; "
+        "install -m 0755 \"$tmp/codebuddy\" /opt/codebuddy/bin/codebuddy; "
+        "test \"$(/opt/codebuddy/bin/codebuddy --version)\" = "
+        f"\"{CODEBUDDY_CLI_VERSION}\""
+    )
+
+
+__all__ = [
+    "CODEBUDDY_BASE_IMAGE",
+    "CODEBUDDY_CLI_VERSION",
+    "CODEBUDDY_CONTAINER_IMAGE",
+    "CODEBUDDY_IMAGE_LABEL",
+    "codebuddy_install_command",
+]

--- a/src/dradar/pier_codebuddy.py
+++ b/src/dradar/pier_codebuddy.py
@@ -16,21 +16,22 @@ from pier.models.agent.context import AgentContext
 from pier.models.agent.install import AgentInstallSpec, InstallStep
 from pier.models.agent.network import NetworkAllowlist
 try:
+    from _dradar_codebuddy_runtime import (
+        CODEBUDDY_CLI_VERSION,
+        codebuddy_install_command,
+    )
+except ModuleNotFoundError:
+    from dradar.codebuddy_runtime import (
+        CODEBUDDY_CLI_VERSION,
+        codebuddy_install_command,
+    )
+try:
     from _dradar_worker_events import emit_worker_registered
 except ModuleNotFoundError:
     from dradar.worker_events import emit_worker_registered
 
-CODEBUDDY_CLI_VERSION = "2.137.1"
 SUPPORTED_MODEL = "hy4-preview"
 SUPPORTED_EFFORTS = {"low", "high", "max"}
-_BASE_URL = (
-    "https://acc-1258344699.cos.ap-guangzhou.myqcloud.com/"
-    "@tencent-ai/codebuddy-code/releases/download"
-)
-_LINUX_SHA256 = {
-    "aarch64": "fe75f4491157837460d33fc201d9062dc1dde67c241ffb96bfac96dda92cbda1",
-    "x86_64": "a09e887057cde96383ecab875faac7a3d357094c7147f3bc3a69dd7d68d2887b",
-}
 
 
 def _nonnegative_int(value: object) -> int | None:
@@ -187,37 +188,7 @@ def _codebuddy_usage_facts(events: list[dict]) -> dict[str, object]:
     }
 
 
-def _install_command() -> str:
-    return (
-        "set -euo pipefail; "
-        "if command -v apt-get >/dev/null 2>&1; then "
-        "apt-get update && DEBIAN_FRONTEND=noninteractive "
-        "apt-get install -y --no-install-recommends curl ca-certificates tar; "
-        "elif command -v apk >/dev/null 2>&1; then "
-        "apk add --no-cache curl ca-certificates tar; "
-        "elif command -v dnf >/dev/null 2>&1; then "
-        "dnf install -y curl ca-certificates tar; "
-        "elif command -v yum >/dev/null 2>&1; then "
-        "yum install -y curl ca-certificates tar; "
-        "else echo 'No supported package manager found' >&2; exit 1; fi; "
-        "arch=$(uname -m); "
-        f"case \"$arch\" in aarch64|arm64) asset=arm64; "
-        f"sha={_LINUX_SHA256['aarch64']} ;; "
-        f"x86_64|amd64) asset=x86_64; sha={_LINUX_SHA256['x86_64']} ;; "
-        "*) echo \"unsupported CodeBuddy architecture: $arch\" >&2; exit 2 ;; esac; "
-        "tmp=$(mktemp -d); trap 'rm -rf \"$tmp\"' EXIT; "
-        f"url={shlex.quote(_BASE_URL + '/' + CODEBUDDY_CLI_VERSION)}/"
-        "codebuddy-code_Linux_${asset}.tar.gz; "
-        "curl --fail --silent --show-error --location "
-        "--output \"$tmp/codebuddy.tar.gz\" \"$url\"; "
-        "printf '%s  %s\\n' \"$sha\" \"$tmp/codebuddy.tar.gz\" "
-        "| sha256sum --check --strict -; "
-        "tar -xzf \"$tmp/codebuddy.tar.gz\" -C \"$tmp\"; "
-        "mkdir -p /opt/codebuddy/bin; "
-        "install -m 0755 \"$tmp/codebuddy\" /opt/codebuddy/bin/codebuddy; "
-        "test \"$(/opt/codebuddy/bin/codebuddy --version)\" = "
-        f"\"{CODEBUDDY_CLI_VERSION}\""
-    )
+_install_command = codebuddy_install_command
 
 
 class CodeBuddySubscription(ClaudeCode):

--- a/src/dradar/provider_config.py
+++ b/src/dradar/provider_config.py
@@ -913,6 +913,14 @@ def _setup_codebuddy_subscription() -> int:
         return 1
     try:
         image = ensure_codebuddy_runtime_image(docker)
+    except ModuleNotFoundError as exc:
+        missing = exc.name or "an installed component"
+        print(
+            "CodeBuddy login was imported, but runtime preparation is missing "
+            f"{missing}. Reinstall or upgrade dradar, then run "
+            "`dradar provider setup codebuddy` again."
+        )
+        return 1
     except ValueError as exc:
         print(f"CodeBuddy login was imported, but runtime preparation failed: {exc}")
         return 1

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -225,6 +225,7 @@ CODEBUDDY_AGENT_IMPORT_PATH = (
     "_dradar_pier_codebuddy:CodeBuddySubscription"
 )
 CODEBUDDY_AGENT_MODULE_FILENAME = "_dradar_pier_codebuddy.py"
+CODEBUDDY_RUNTIME_MODULE_FILENAME = "_dradar_codebuddy_runtime.py"
 BETA_SUBSCRIPTION_TRIAL_TIMEOUT_FLOOR_SEC = 120 * 60
 # A cold multi-worker BuildKit start can spend tens of minutes pulling base
 # images and package layers.  Three task windows (90 minutes for the common
@@ -901,6 +902,14 @@ def _ensure_codebuddy_agent_module(home: Path) -> Path:
         raise RunnerError(
             "CodeBuddy Pier adapter is missing; reinstall or upgrade dradar"
         )
+    runtime_source = Path(__file__).with_name("codebuddy_runtime.py")
+    if not runtime_source.is_file():
+        raise RunnerError(
+            "CodeBuddy runtime definition is missing; reinstall or upgrade dradar"
+        )
+    _materialize_shared_file(
+        home / CODEBUDDY_RUNTIME_MODULE_FILENAME, runtime_source.read_bytes()
+    )
     _ensure_worker_event_module(home)
     return _materialize_shared_file(
         home / CODEBUDDY_AGENT_MODULE_FILENAME, source.read_bytes()

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -7,6 +7,7 @@ pre_artifacts.sh, then downloaded by pier into the trial dir.
 
 import glob
 import hashlib
+import importlib.resources
 import json
 import math
 import os
@@ -723,13 +724,18 @@ def _ensure_runtime_safety_module(home: Path) -> Path:
 
 def _ensure_worker_event_module(home: Path) -> Path:
     """Copy the tiny Pier->CLI lifecycle sidecar helper into the run dir."""
-    source = Path(__file__).with_name("worker_events.py")
-    if not source.is_file():
+    try:
+        source = (
+            importlib.resources.files("dradar")
+            .joinpath("worker_events.py")
+            .read_bytes()
+        )
+    except (FileNotFoundError, OSError) as exc:
         raise RunnerError(
             "Pier worker lifecycle helper is missing; reinstall or upgrade dradar"
-        )
+        ) from exc
     return _materialize_shared_file(
-        home / "_dradar_worker_events.py", source.read_bytes(),
+        home / "_dradar_worker_events.py", source,
     )
 
 
@@ -897,22 +903,25 @@ def _ensure_dsh_agent_module(home: Path) -> Path:
 
 
 def _ensure_codebuddy_agent_module(home: Path) -> Path:
-    source = Path(__file__).with_name("pier_codebuddy.py")
-    if not source.is_file():
+    package = importlib.resources.files("dradar")
+    try:
+        adapter = package.joinpath("pier_codebuddy.py").read_bytes()
+    except (FileNotFoundError, OSError) as exc:
         raise RunnerError(
             "CodeBuddy Pier adapter is missing; reinstall or upgrade dradar"
-        )
-    runtime_source = Path(__file__).with_name("codebuddy_runtime.py")
-    if not runtime_source.is_file():
+        ) from exc
+    try:
+        runtime = package.joinpath("codebuddy_runtime.py").read_bytes()
+    except (FileNotFoundError, OSError) as exc:
         raise RunnerError(
             "CodeBuddy runtime definition is missing; reinstall or upgrade dradar"
-        )
+        ) from exc
     _materialize_shared_file(
-        home / CODEBUDDY_RUNTIME_MODULE_FILENAME, runtime_source.read_bytes()
+        home / CODEBUDDY_RUNTIME_MODULE_FILENAME, runtime
     )
     _ensure_worker_event_module(home)
     return _materialize_shared_file(
-        home / CODEBUDDY_AGENT_MODULE_FILENAME, source.read_bytes()
+        home / CODEBUDDY_AGENT_MODULE_FILENAME, adapter
     )
 
 

--- a/tests/test_codebuddy_subscription.py
+++ b/tests/test_codebuddy_subscription.py
@@ -401,6 +401,50 @@ def test_runtime_image_gate_executes_the_labeled_binary_once_per_image(
     assert sum(command[1] == "run" for command in calls) == 1
 
 
+def test_missing_runtime_image_builds_without_importing_pier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    issues = iter(["image missing", None])
+    monkeypatch.setattr(
+        codebuddy_provider,
+        "codebuddy_runtime_image_error",
+        lambda _docker: next(issues),
+    )
+    seen: dict[str, object] = {}
+
+    def fake_run(command, **kwargs):
+        seen.update(command=command, **kwargs)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(codebuddy_provider.subprocess, "run", fake_run)
+
+    assert codebuddy_provider.ensure_codebuddy_runtime_image("docker") == (
+        f"dradar-codebuddy:{CODEBUDDY_CLI_VERSION}"
+    )
+    assert seen["command"][1:3] == ["build", "--progress=plain"]
+    dockerfile = seen["input"]
+    assert f"LABEL {codebuddy_provider.CODEBUDDY_IMAGE_LABEL}=" in dockerfile
+    assert CODEBUDDY_CLI_VERSION in dockerfile
+    assert "codebuddy-code_Linux_${asset}.tar.gz" in dockerfile
+
+
+def test_existing_runtime_image_skips_build(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        codebuddy_provider, "codebuddy_runtime_image_error", lambda _docker: None,
+    )
+    monkeypatch.setattr(
+        codebuddy_provider.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("existing image must skip build"),
+    )
+
+    assert codebuddy_provider.ensure_codebuddy_runtime_image("docker") == (
+        f"dradar-codebuddy:{CODEBUDDY_CLI_VERSION}"
+    )
+
+
 def test_usage_reconciles_request_ledger_and_terminal_aggregate() -> None:
     facts = _usage_function()([
         {
@@ -641,3 +685,16 @@ def test_adapter_and_pier_bootstrap_keep_credentials_and_tools_narrow() -> None:
     assert '"subscription_oauth_coordination": "host-monotonic-merge-v2"' in runloop
     assert '"codebuddy_credential_mode": "isolated-run-copy-concurrent-v2"' in runloop
     assert "CodeBuddy HY4 canary assignments require the serial runner" not in runloop
+
+
+def test_codebuddy_adapter_materializes_its_pier_free_runtime_module(
+    tmp_path: Path,
+) -> None:
+    from dradar import runner
+
+    adapter = runner._ensure_codebuddy_agent_module(tmp_path)
+    runtime = tmp_path / runner.CODEBUDDY_RUNTIME_MODULE_FILENAME
+
+    assert adapter == tmp_path / runner.CODEBUDDY_AGENT_MODULE_FILENAME
+    assert runtime.is_file()
+    assert "from pier" not in runtime.read_text(encoding="utf-8")

--- a/tests/test_codebuddy_wheel_smoke.py
+++ b/tests/test_codebuddy_wheel_smoke.py
@@ -1,0 +1,132 @@
+"""Artifact-level smoke tests for a standard, Pier-free CodeBuddy install."""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import subprocess
+import tomllib
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).parents[1]
+
+
+@pytest.fixture(scope="module")
+def codebuddy_artifacts(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> tuple[Path, Path]:
+    uv = shutil.which("uv")
+    if uv is None:
+        pytest.skip("uv is required for the wheel artifact smoke test")
+    output = tmp_path_factory.mktemp("codebuddy-wheel")
+    subprocess.run(
+        [uv, "build", "--wheel", "--out-dir", str(output)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    wheels = list(output.glob("dradar-*.whl"))
+    assert len(wheels) == 1
+    release_spec = importlib.util.spec_from_file_location(
+        "dradar_ota_release", ROOT / "scripts" / "ota_release.py",
+    )
+    assert release_spec is not None and release_spec.loader is not None
+    release = importlib.util.module_from_spec(release_spec)
+    release_spec.loader.exec_module(release)
+    zipapp = output / "dradar-smoke.pyz"
+    version = tomllib.loads(
+        (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )["project"]["version"]
+    release._build_zipapp(
+        ROOT,
+        zipapp,
+        version=version,
+        sequence=1,
+        commit="1" * 40,
+        tree="2" * 40,
+        target=("linux", "x86_64"),
+    )
+    return wheels[0], zipapp
+
+
+@pytest.mark.parametrize("python_name", ["python3.11", "python3.13"])
+def test_standard_wheel_prepares_first_codebuddy_image_without_pier(
+    codebuddy_artifacts: tuple[Path, Path],
+    python_name: str,
+    tmp_path: Path,
+) -> None:
+    uv = shutil.which("uv")
+    python = shutil.which(python_name)
+    if uv is None or python is None:
+        pytest.skip(f"{python_name} is unavailable")
+    environment = tmp_path / "venv"
+    wheel, zipapp = codebuddy_artifacts
+    subprocess.run(
+        [uv, "venv", "--python", python, str(environment)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    environment_python = environment / "bin" / "python"
+    subprocess.run(
+        [
+            uv,
+            "pip",
+            "install",
+            "--python",
+            str(environment_python),
+            str(wheel),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    smoke = r'''
+import importlib.metadata
+import importlib.util
+import sys
+from types import SimpleNamespace
+
+artifact = sys.argv[1]
+if artifact:
+    sys.path.insert(0, artifact)
+assert importlib.util.find_spec("pier") is None
+assert "datacurve-pier" not in {
+    distribution.metadata["Name"].lower()
+    for distribution in importlib.metadata.distributions()
+}
+
+from dradar import codebuddy_provider
+
+issues = iter(["image missing", None])
+codebuddy_provider.codebuddy_runtime_image_error = lambda _docker: next(issues)
+seen = {}
+def build(command, **kwargs):
+    seen.update(command=command, **kwargs)
+    return SimpleNamespace(returncode=0, stdout="", stderr="")
+codebuddy_provider.subprocess.run = build
+assert codebuddy_provider.ensure_codebuddy_runtime_image("docker") == (
+    codebuddy_provider.CODEBUDDY_CONTAINER_IMAGE
+)
+assert seen["command"][1] == "build"
+assert "codebuddy-code_Linux_${asset}.tar.gz" in seen["input"]
+
+codebuddy_provider.codebuddy_runtime_image_error = lambda _docker: None
+def unexpected(*_args, **_kwargs):
+    raise AssertionError("existing image must skip the build path")
+codebuddy_provider.subprocess.run = unexpected
+assert codebuddy_provider.ensure_codebuddy_runtime_image("docker") == (
+    codebuddy_provider.CODEBUDDY_CONTAINER_IMAGE
+)
+'''
+    for artifact in ("", str(zipapp)):
+        subprocess.run(
+            [str(environment_python), "-I", "-c", smoke, artifact],
+            check=True,
+            capture_output=True,
+            text=True,
+        )

--- a/tests/test_codebuddy_wheel_smoke.py
+++ b/tests/test_codebuddy_wheel_smoke.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 import pytest
 
-
 ROOT = Path(__file__).parents[1]
 
 
@@ -54,7 +53,7 @@ def codebuddy_artifacts(
 
 
 @pytest.mark.parametrize("python_name", ["python3.11", "python3.13"])
-def test_standard_wheel_prepares_first_codebuddy_image_without_pier(
+def test_standard_artifacts_prepare_and_materialize_codebuddy_without_pier(
     codebuddy_artifacts: tuple[Path, Path],
     python_name: str,
     tmp_path: Path,
@@ -87,8 +86,11 @@ def test_standard_wheel_prepares_first_codebuddy_image_without_pier(
     )
     smoke = r'''
 import importlib.metadata
+import importlib.resources
 import importlib.util
 import sys
+import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 
 artifact = sys.argv[1]
@@ -100,7 +102,7 @@ assert "datacurve-pier" not in {
     for distribution in importlib.metadata.distributions()
 }
 
-from dradar import codebuddy_provider
+from dradar import codebuddy_provider, runner
 
 issues = iter(["image missing", None])
 codebuddy_provider.codebuddy_runtime_image_error = lambda _docker: next(issues)
@@ -122,11 +124,22 @@ codebuddy_provider.subprocess.run = unexpected
 assert codebuddy_provider.ensure_codebuddy_runtime_image("docker") == (
     codebuddy_provider.CODEBUDDY_CONTAINER_IMAGE
 )
+
+with tempfile.TemporaryDirectory() as directory:
+    home = Path(directory)
+    adapter = runner._ensure_codebuddy_agent_module(home)
+    runtime = home / runner.CODEBUDDY_RUNTIME_MODULE_FILENAME
+    worker_events = home / "_dradar_worker_events.py"
+    package = importlib.resources.files("dradar")
+    assert adapter.read_bytes() == package.joinpath("pier_codebuddy.py").read_bytes()
+    assert runtime.read_bytes() == package.joinpath("codebuddy_runtime.py").read_bytes()
+    assert worker_events.read_bytes() == package.joinpath("worker_events.py").read_bytes()
 '''
     for artifact in ("", str(zipapp)):
-        subprocess.run(
+        completed = subprocess.run(
             [str(environment_python), "-I", "-c", smoke, artifact],
-            check=True,
+            check=False,
             capture_output=True,
             text=True,
         )
+        assert completed.returncode == 0, completed.stderr

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -793,6 +793,40 @@ def test_codebuddy_setup_accepts_newer_compatible_host_as_login_source(
     assert "dradar-codebuddy:2.137.1" in output
 
 
+def test_codebuddy_setup_reports_missing_runtime_component_without_traceback(
+    tmp_path, monkeypatch, capsys,
+):
+    monkeypatch.setattr(
+        provider_config, "codebuddy_executable", lambda: "/usr/bin/codebuddy",
+    )
+    monkeypatch.setattr(
+        provider_config,
+        "codebuddy_host_cli_status",
+        lambda _executable: (None, "2.143.0"),
+    )
+    monkeypatch.setattr(provider_config, "import_host_login", lambda: tmp_path)
+    monkeypatch.setattr(
+        provider_config, "codebuddy_credential_status", lambda: (True, "ready"),
+    )
+    monkeypatch.setattr(
+        provider_config.shutil,
+        "which",
+        lambda name: "/usr/bin/docker" if name == "docker" else None,
+    )
+
+    def missing_component(_docker):
+        raise ModuleNotFoundError("No module named 'component'", name="component")
+
+    monkeypatch.setattr(
+        provider_config, "ensure_codebuddy_runtime_image", missing_component,
+    )
+
+    assert provider_config._setup_codebuddy_subscription() == 1
+    output = capsys.readouterr().out
+    assert "runtime preparation is missing component" in output
+    assert "Reinstall or upgrade dradar" in output
+
+
 def test_codebuddy_status_distinguishes_host_login_source_from_pinned_runtime(
     tmp_path, monkeypatch, capsys,
 ):


### PR DESCRIPTION
## Summary
- move the pinned CodeBuddy image definition into a lightweight standard-library-only module
- stop first-run image preparation from importing the Pier adapter
- materialize the lightweight runtime module beside the standalone Pier adapter
- report missing runtime components as an actionable provider setup error

## Verification
- 77 focused CodeBuddy/provider/artifact tests passed
- built wheel and OTA zipapp smoke-tested in clean Python 3.11 and 3.13 environments with production dependencies and no datacurve-pier
- first-image and existing-image branches both covered
- full suite: 1712 passed, 2 skipped

## Scope
CLI only. No merge, OTA publication, Server/Web/Cloudflare change, or production mutation.