### PR TITLE
#0050: report pending CodeBuddy accounting after upload

### DIFF
--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -2593,6 +2593,15 @@ def _upload_trial(
         # volunteer whose quota was fine.
         print(f"recorded as invalid (not graded): {ack['submission_id']} — "
               "no points lost, the cell reopens for a fresh attempt")
+    elif (
+        ack.get("accounting_status") == "pending"
+        and ack.get("cost_status") == "pending"
+        and ack.get("points_status") == "pending"
+    ):
+        print(
+            f"submitted: {ack['submission_id']} (grading happens server-side; "
+            "cost and points are pending provider-usage verification)"
+        )
     else:
         print(f"submitted: {ack['submission_id']} (grading happens server-side)")
     if job_dir and entry.get("keep", False):

--- a/tests/test_pending_upload.py
+++ b/tests/test_pending_upload.py
@@ -169,6 +169,26 @@ def test_upload_success_clears_ledger(tmp_path: Path, monkeypatch):
     assert pending.load(tmp_path) == []
 
 
+def test_upload_reports_gradeable_result_with_pending_accounting(
+    tmp_path: Path, monkeypatch, capsys,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    client = FakeClient(lambda _aid: {
+        "submission_id": "s-pending-usage",
+        "grade_status": "pending",
+        "accounting_status": "pending",
+        "cost_status": "pending",
+        "points_status": "pending",
+    })
+
+    assert runloop._upload_trial(client, _entry(trial_dir)) == "submitted"
+    output = capsys.readouterr().out
+    assert "grading happens server-side" in output
+    assert "cost and points are pending provider-usage verification" in output
+    assert "invalid" not in output
+
+
 def test_exact_empty_submission_ack_is_not_collapsed_to_submitted(
     tmp_path: Path, monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- surface the server-owned pending accounting acknowledgement after a gradeable CodeBuddy upload
- keep the existing invalid and empty-submission terminal messages unchanged

## Verification
- full CLI suite: 1740 passed
- focused pending-upload and incomplete-usage regressions passed

## Scope
CLI display/acknowledgement only. The Server eligibility and settlement change is submitted separately. No merge, release, or production mutation is included.