### PR TITLE
#0050: preserve unreconciled CodeBuddy request evidence

### DIFF
--- a/src/dradar/pier_codebuddy.py
+++ b/src/dradar/pier_codebuddy.py
@@ -66,29 +66,35 @@ def _codebuddy_usage_facts(events: list[dict]) -> dict[str, object]:
     subset.  Missing or inconsistent evidence stays explicitly incomplete.
     """
 
-    terminals = [
+    terminal_events = [
         event for event in events
         if isinstance(event, dict)
         and event.get("type") == "result"
-        and isinstance(event.get("usage"), dict)
     ]
-    terminal = terminals[0] if len(terminals) == 1 else None
+    terminal = terminal_events[0] if len(terminal_events) == 1 else None
     terminal_usage = _usage_values(
         terminal.get("usage") if terminal is not None else None
     )
+    reasons: set[str] = set()
+    if not terminal_events:
+        reasons.add("terminal_aggregate_missing")
+    elif len(terminal_events) > 1:
+        reasons.add("terminal_aggregate_multiple")
+    elif terminal_usage is None:
+        reasons.add("terminal_usage_missing_or_invalid")
     names = (
         "input_tokens", "cache_read_input_tokens",
         "cache_creation_input_tokens", "output_tokens",
     )
     totals = {name: 0 for name in names}
     usage_by_message_id: dict[str, dict[str, int]] = {}
-    ledger_valid = True
+    conflicted_message_ids: set[str] = set()
     for event in events:
         if not isinstance(event, dict) or event.get("type") != "assistant":
             continue
         message = event.get("message")
         if not isinstance(message, dict):
-            ledger_valid = False
+            reasons.add("request_message_invalid")
             continue
         message_id = message.get("id")
         runtime_model = message.get("model")
@@ -97,7 +103,11 @@ def _codebuddy_usage_facts(events: list[dict]) -> dict[str, object]:
             and runtime_model
             and runtime_model != SUPPORTED_MODEL
         ):
-            ledger_valid = False
+            # A mismatched model is never admitted to the observed ledger.
+            # Correctly identified requests in the same stream remain useful
+            # evidence, but the run cannot reconcile or settle.
+            reasons.add("request_model_mismatch")
+            continue
         raw_usage = message.get("usage")
         usage = _usage_values(raw_usage)
         if usage is None:
@@ -110,17 +120,23 @@ def _codebuddy_usage_facts(events: list[dict]) -> dict[str, object]:
                 (_nonnegative_int(raw_usage.get(name)) or 0) > 0
                 for name in names
             ):
-                ledger_valid = False
+                reasons.add("request_usage_invalid")
             continue
         if sum(usage.values()) == 0:
             continue
         if not isinstance(message_id, str) or not message_id:
-            ledger_valid = False
+            reasons.add("request_id_missing")
+            continue
+        if message_id in conflicted_message_ids:
             continue
         previous = usage_by_message_id.get(message_id)
         if previous is not None:
             if previous != usage:
-                ledger_valid = False
+                # Neither side of a conflicting identity is authoritative.
+                # Remove only that request and preserve unrelated records.
+                reasons.add("request_id_conflict")
+                conflicted_message_ids.add(message_id)
+                del usage_by_message_id[message_id]
             continue
         usage_by_message_id[message_id] = usage
 
@@ -135,12 +151,20 @@ def _codebuddy_usage_facts(events: list[dict]) -> dict[str, object]:
             "cache_creation_tokens": usage["cache_creation_input_tokens"],
         })
 
-    terminal_success = bool(
-        terminal is not None
-        and terminal.get("is_error") is not True
-        and terminal.get("usage_is_incomplete") is not True
-        and terminal.get("subtype") in {"success", None}
-    )
+    if terminal is not None:
+        terminal_model = terminal.get("model")
+        if (
+            isinstance(terminal_model, str)
+            and terminal_model
+            and terminal_model != SUPPORTED_MODEL
+        ):
+            reasons.add("terminal_model_mismatch")
+        if terminal.get("is_error") is True:
+            reasons.add("terminal_error")
+        if terminal.get("usage_is_incomplete") is True:
+            reasons.add("terminal_usage_incomplete")
+        if terminal.get("subtype") not in {"success", None}:
+            reasons.add("terminal_status_not_success")
     if terminal_usage is not None:
         reported_total = terminal.get("total_tokens")
         if reported_total is not None:
@@ -149,39 +173,61 @@ def _codebuddy_usage_facts(events: list[dict]) -> dict[str, object]:
                 + terminal_usage["output_tokens"]
             )
             if _nonnegative_int(reported_total) != expected_total:
-                terminal_success = False
+                reasons.add("terminal_total_tokens_mismatch")
+    observed = bool(token_usage_events)
+    if not observed:
+        reasons.add("request_ledger_unavailable")
+    if terminal_usage is not None and terminal_usage != totals:
+        reasons.add("terminal_aggregate_mismatch")
     complete = bool(
-        terminal_success
-        and ledger_valid
+        not reasons
         and terminal_usage is not None
-        and token_usage_events
+        and observed
         and terminal_usage == totals
-        and sum(totals.values()) > 0
+        and totals["input_tokens"] + totals["output_tokens"] > 0
     )
-    selected = totals if complete else {name: 0 for name in names}
+    selected = totals if observed else {name: 0 for name in names}
     prompt = selected["input_tokens"]
+    reason_order = (
+        "terminal_aggregate_missing",
+        "terminal_aggregate_multiple",
+        "terminal_usage_missing_or_invalid",
+        "terminal_model_mismatch",
+        "terminal_error",
+        "terminal_usage_incomplete",
+        "terminal_status_not_success",
+        "terminal_total_tokens_mismatch",
+        "request_model_mismatch",
+        "request_message_invalid",
+        "request_usage_invalid",
+        "request_id_missing",
+        "request_id_conflict",
+        "request_ledger_unavailable",
+        "terminal_aggregate_mismatch",
+    )
+    incomplete_reasons = [reason for reason in reason_order if reason in reasons]
     return {
         "schema": "dradar-subscription-provider-usage-v1",
         "provider": "codebuddy",
         "model": SUPPORTED_MODEL,
         "complete": complete,
-        "request_count": len(token_usage_events) if complete else 0,
+        "request_count": len(token_usage_events) if observed else 0,
         "n_input_tokens": prompt,
         "n_cache_tokens": selected["cache_read_input_tokens"],
         "n_output_tokens": selected["output_tokens"],
         "cache_creation_tokens": selected["cache_creation_input_tokens"],
-        "token_usage_events": token_usage_events if complete else [],
+        "token_usage_events": token_usage_events if observed else [],
         "request_usage_complete": complete,
-        "request_usage_observed": complete,
+        "request_usage_observed": observed,
         "timed_usage_complete": False,
         "usage_incomplete_reason": (
-            None if complete else
-            "terminal_aggregate_missing_or_inconsistent"
-            if token_usage_events else
-            "request_ledger_unavailable_or_invalid"
+            None if complete else incomplete_reasons[0]
         ),
+        "usage_incomplete_reasons": incomplete_reasons,
         "usage_evidence_tier": (
-            "complete_reconciled" if complete else "unavailable"
+            "complete_reconciled" if complete
+            else "observed_unreconciled" if observed
+            else "unavailable"
         ),
         "provider_actual_cost_observed": False,
         "cost_semantics": "server-priced-api-equivalent",
@@ -450,10 +496,11 @@ class CodeBuddySubscription(ClaudeCode):
 
         super().populate_context_post_run(context)
         complete = usage["complete"] is True
+        observed = usage["request_usage_observed"] is True
         context.cost_usd = None
-        context.n_input_tokens = int(usage["n_input_tokens"]) if complete else 0
-        context.n_cache_tokens = int(usage["n_cache_tokens"]) if complete else 0
-        context.n_output_tokens = int(usage["n_output_tokens"]) if complete else 0
+        context.n_input_tokens = int(usage["n_input_tokens"]) if observed else 0
+        context.n_cache_tokens = int(usage["n_cache_tokens"]) if observed else 0
+        context.n_output_tokens = int(usage["n_output_tokens"]) if observed else 0
 
         trajectory_path = self.logs_dir / "trajectory.json"
         try:
@@ -481,9 +528,9 @@ class CodeBuddySubscription(ClaudeCode):
             metrics = {}
             trajectory["final_metrics"] = metrics
         metrics.update({
-            "total_prompt_tokens": usage["n_input_tokens"] if complete else None,
-            "total_cached_tokens": usage["n_cache_tokens"] if complete else None,
-            "total_completion_tokens": usage["n_output_tokens"] if complete else None,
+            "total_prompt_tokens": usage["n_input_tokens"] if observed else None,
+            "total_cached_tokens": usage["n_cache_tokens"] if observed else None,
+            "total_completion_tokens": usage["n_output_tokens"] if observed else None,
             "total_cost_usd": None,
         })
         extra = metrics.get("extra")
@@ -493,6 +540,8 @@ class CodeBuddySubscription(ClaudeCode):
             "billing_basis": "subscription",
             "cost_not_reported": True,
             "usage_complete": complete,
+            "usage_evidence_tier": usage["usage_evidence_tier"],
+            "usage_incomplete_reason": usage["usage_incomplete_reason"],
         })
         metrics["extra"] = extra
         try:

--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -1401,14 +1401,66 @@ def _subscription_trial_usage(trial_dir: Path, meta: dict) -> dict | None:
             "request_ledger_unavailable_or_invalid",
         },
         "codebuddy": {
+            # Legacy 0.5.189 sidecars may still be waiting for upload when a
+            # newer launcher resumes them. Accept their coarse codes without
+            # emitting those codes for newly observed runs.
             "terminal_aggregate_missing_or_inconsistent",
             "request_ledger_unavailable_or_invalid",
+            "terminal_aggregate_missing",
+            "terminal_aggregate_multiple",
+            "terminal_usage_missing_or_invalid",
+            "terminal_model_mismatch",
+            "terminal_error",
+            "terminal_usage_incomplete",
+            "terminal_status_not_success",
+            "terminal_total_tokens_mismatch",
+            "request_model_mismatch",
+            "request_message_invalid",
+            "request_usage_invalid",
+            "request_id_missing",
+            "request_id_conflict",
+            "request_ledger_unavailable",
+            "terminal_aggregate_mismatch",
         },
     }
     if (not complete and (
             value.get("complete") is not False
             or incomplete_reason not in allowed_incomplete_reasons[expected_provider])):
         return None
+    raw_incomplete_reasons = value.get("usage_incomplete_reasons")
+    if expected_provider != "codebuddy":
+        if raw_incomplete_reasons is not None:
+            return None
+        incomplete_reasons = None
+    else:
+        if raw_incomplete_reasons is None:
+            incomplete_reasons = [] if complete else [incomplete_reason]
+        elif (
+            not isinstance(raw_incomplete_reasons, list)
+            or len(raw_incomplete_reasons) > len(
+                allowed_incomplete_reasons[expected_provider]
+            )
+            or any(
+                not isinstance(reason, str)
+                or reason not in allowed_incomplete_reasons[expected_provider]
+                for reason in raw_incomplete_reasons
+            )
+            or len(set(raw_incomplete_reasons)) != len(raw_incomplete_reasons)
+        ):
+            return None
+        else:
+            incomplete_reasons = list(raw_incomplete_reasons)
+        if (
+            (complete and incomplete_reasons)
+            or (
+                not complete
+                and (
+                    not incomplete_reasons
+                    or incomplete_reasons[0] != incomplete_reason
+                )
+            )
+        ):
+            return None
     names = ("n_input_tokens", "n_cache_tokens", "n_output_tokens")
     if any(
         not isinstance(value.get(name), int)
@@ -1468,13 +1520,16 @@ def _subscription_trial_usage(trial_dir: Path, meta: dict) -> dict | None:
             return None
     else:
         events = []
-    return {
+    normalized = {
         **value,
         "token_usage_events": events,
         "request_usage_complete": request_complete,
         "request_usage_observed": observed,
         "timed_usage_complete": timed,
     }
+    if incomplete_reasons is not None:
+        normalized["usage_incomplete_reasons"] = incomplete_reasons
+    return normalized
 
 
 def _claude_trial_usage_from_trajectory(
@@ -2013,6 +2068,7 @@ def _upload_trial(
             "uncached_input_tokens", "cache_read_tokens", "cache_write_tokens",
             "token_usage_events", "timed_usage_complete",
             "request_usage_complete", "request_usage_observed",
+            "usage_incomplete_reasons",
             "timed_usage_incomplete_reason", "usage_aggregate_source",
             "usage_incomplete_reason", "usage_evidence_tier",
             "session_usage_model_request_count", "request_ledger_duplicate_count",

--- a/tests/test_codebuddy_subscription.py
+++ b/tests/test_codebuddy_subscription.py
@@ -516,44 +516,145 @@ def test_usage_accepts_real_stream_fragments_and_ignores_num_turns() -> None:
     assert facts["n_output_tokens"] == 70
 
 
-def test_usage_fails_closed_on_conflicting_positive_duplicate() -> None:
-    request = {
+def test_usage_quarantines_conflicting_duplicate_and_preserves_other_requests(
+) -> None:
+    conflicted = {
         "input_tokens": 10, "cache_read_input_tokens": 2,
         "cache_creation_input_tokens": 3, "output_tokens": 1,
+    }
+    trusted = {
+        "input_tokens": 40, "cache_read_input_tokens": 5,
+        "cache_creation_input_tokens": 7, "output_tokens": 4,
+    }
+    facts = _usage_function()([
+        {"type": "assistant", "message": {
+            "id": "m1", "model": CODEBUDDY_MODEL, "usage": conflicted,
+        }},
+        {"type": "assistant", "message": {
+            "id": "m1", "model": CODEBUDDY_MODEL,
+            "usage": {**conflicted, "output_tokens": 2},
+        }},
+        {"type": "assistant", "message": {
+            "id": "m2", "model": CODEBUDDY_MODEL, "usage": trusted,
+        }},
+        {"type": "result", "subtype": "success", "usage": {
+            name: conflicted[name] + trusted[name]
+            for name in conflicted
+        }},
+    ])
+    assert facts["complete"] is False
+    assert facts["request_usage_complete"] is False
+    assert facts["request_usage_observed"] is True
+    assert facts["usage_evidence_tier"] == "observed_unreconciled"
+    assert facts["usage_incomplete_reason"] == "request_id_conflict"
+    assert "terminal_aggregate_mismatch" in facts["usage_incomplete_reasons"]
+    assert facts["request_count"] == 1
+    assert facts["n_input_tokens"] == 40
+    assert facts["n_cache_tokens"] == 5
+    assert facts["n_output_tokens"] == 4
+    assert facts["token_usage_events"] == [{
+        "n_input_tokens": 40,
+        "n_cache_tokens": 5,
+        "n_output_tokens": 4,
+        "cache_creation_tokens": 7,
+    }]
+
+
+def test_usage_rejects_wrong_model_without_erasing_the_reason() -> None:
+    usage = {
+        "input_tokens": 1, "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0, "output_tokens": 1,
+    }
+    facts = _usage_function()([
+        {"type": "assistant", "message": {
+            "id": "m1", "model": "not-hy4", "usage": usage,
+        }},
+        {"type": "result", "subtype": "success", "num_turns": 1,
+         "usage": usage},
+    ])
+    assert facts["complete"] is False
+    assert facts["request_usage_observed"] is False
+    assert facts["usage_evidence_tier"] == "unavailable"
+    assert facts["usage_incomplete_reason"] == "request_model_mismatch"
+    assert facts["n_input_tokens"] == 0
+    assert facts["token_usage_events"] == []
+
+
+@pytest.mark.parametrize(
+    ("terminals", "reason"),
+    [
+        ([], "terminal_aggregate_missing"),
+        ([
+            {"type": "result", "subtype": "success"},
+            {"type": "result", "subtype": "success"},
+        ], "terminal_aggregate_multiple"),
+    ],
+)
+def test_usage_preserves_observed_requests_when_terminal_is_not_singular(
+    terminals: list[dict], reason: str,
+) -> None:
+    usage = {
+        "input_tokens": 100, "cache_read_input_tokens": 20,
+        "cache_creation_input_tokens": 10, "output_tokens": 8,
+    }
+    facts = _usage_function()([
+        {"type": "assistant", "message": {
+            "id": "m1", "model": CODEBUDDY_MODEL, "usage": usage,
+        }},
+        *[{**terminal, "usage": usage} for terminal in terminals],
+    ])
+    assert facts["complete"] is False
+    assert facts["request_usage_observed"] is True
+    assert facts["usage_evidence_tier"] == "observed_unreconciled"
+    assert facts["usage_incomplete_reason"] == reason
+    assert facts["request_count"] == 1
+    assert facts["n_input_tokens"] == 100
+    assert facts["n_cache_tokens"] == 20
+    assert facts["n_output_tokens"] == 8
+    assert len(facts["token_usage_events"]) == 1
+
+
+def test_usage_preserves_observed_requests_on_terminal_aggregate_mismatch(
+) -> None:
+    request = {
+        "input_tokens": 80, "cache_read_input_tokens": 10,
+        "cache_creation_input_tokens": 5, "output_tokens": 6,
     }
     facts = _usage_function()([
         {"type": "assistant", "message": {
             "id": "m1", "model": CODEBUDDY_MODEL, "usage": request,
         }},
-        {"type": "assistant", "message": {
-            "id": "m1", "model": CODEBUDDY_MODEL,
-            "usage": {**request, "output_tokens": 2},
+        {"type": "result", "subtype": "success", "usage": {
+            **request, "output_tokens": 9,
         }},
-        {"type": "result", "subtype": "success", "usage": request},
     ])
     assert facts["complete"] is False
-    assert facts["n_input_tokens"] == 0
+    assert facts["request_usage_observed"] is True
+    assert facts["usage_incomplete_reason"] == "terminal_aggregate_mismatch"
+    assert facts["request_count"] == 1
+    assert facts["n_input_tokens"] == 80
+    assert facts["n_output_tokens"] == 6
+    assert len(facts["token_usage_events"]) == 1
 
 
-def test_usage_fails_closed_on_mismatch_or_wrong_model() -> None:
+def test_usage_separates_terminal_model_and_total_mismatch_reasons() -> None:
     usage = {
-        "input_tokens": 1, "cache_read_input_tokens": 0,
-        "cache_creation_input_tokens": 0, "output_tokens": 1,
+        "input_tokens": 50, "cache_read_input_tokens": 4,
+        "cache_creation_input_tokens": 3, "output_tokens": 5,
     }
-    for model, terminal_usage in [
-        ("not-hy4", usage),
-        (CODEBUDDY_MODEL, {**usage, "output_tokens": 2}),
-    ]:
-        facts = _usage_function()([
-            {"type": "assistant", "message": {
-                "id": "m1", "model": model, "usage": usage,
-            }},
-            {"type": "result", "subtype": "success", "num_turns": 1,
-             "usage": terminal_usage},
-        ])
-        assert facts["complete"] is False
-        assert facts["n_input_tokens"] == 0
-        assert facts["token_usage_events"] == []
+    facts = _usage_function()([
+        {"type": "assistant", "message": {
+            "id": "m1", "model": CODEBUDDY_MODEL, "usage": usage,
+        }},
+        {"type": "result", "subtype": "success", "model": "not-hy4",
+         "total_tokens": 999, "usage": usage},
+    ])
+    assert facts["complete"] is False
+    assert facts["request_usage_observed"] is True
+    assert facts["usage_incomplete_reason"] == "terminal_model_mismatch"
+    assert facts["usage_incomplete_reasons"] == [
+        "terminal_model_mismatch", "terminal_total_tokens_mismatch",
+    ]
 
 
 def test_normalized_usage_preserves_codebuddy_attestation_fields(
@@ -596,6 +697,107 @@ def test_normalized_usage_preserves_codebuddy_attestation_fields(
     assert normalized["request_usage_observed"] is True
     assert normalized["provider_actual_cost_observed"] is False
     assert normalized["cost_semantics"] == "server-priced-api-equivalent"
+
+
+def test_normalized_usage_preserves_unreconciled_codebuddy_observations(
+    tmp_path: Path,
+) -> None:
+    usage = {
+        "input_tokens": 125,
+        "cache_read_input_tokens": 20,
+        "cache_creation_input_tokens": 5,
+        "output_tokens": 30,
+    }
+    facts = _usage_function()([{
+        "type": "assistant",
+        "message": {
+            "id": "m1", "model": CODEBUDDY_MODEL, "usage": usage,
+        },
+    }])
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    (agent_dir / "provider-usage.json").write_text(
+        json.dumps(facts), encoding="utf-8",
+    )
+
+    normalized = _subscription_trial_usage(
+        tmp_path, {"codebuddy_cli_version": CODEBUDDY_CLI_VERSION},
+    )
+
+    assert normalized is not None
+    assert normalized["complete"] is False
+    assert normalized["request_usage_complete"] is False
+    assert normalized["request_usage_observed"] is True
+    assert normalized["usage_evidence_tier"] == "observed_unreconciled"
+    assert normalized["usage_incomplete_reason"] == "terminal_aggregate_missing"
+    assert normalized["usage_incomplete_reasons"] == [
+        "terminal_aggregate_missing",
+    ]
+    assert normalized["request_count"] == 1
+    assert normalized["n_input_tokens"] == 125
+    assert normalized["n_cache_tokens"] == 20
+    assert normalized["n_output_tokens"] == 30
+
+
+def test_normalized_usage_rejects_unbounded_codebuddy_reason_text(
+    tmp_path: Path,
+) -> None:
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    (agent_dir / "provider-usage.json").write_text(json.dumps({
+        "schema": "dradar-subscription-provider-usage-v1",
+        "provider": "codebuddy",
+        "model": CODEBUDDY_MODEL,
+        "complete": False,
+        "request_count": 0,
+        "n_input_tokens": 0,
+        "n_cache_tokens": 0,
+        "n_output_tokens": 0,
+        "request_usage_complete": False,
+        "request_usage_observed": False,
+        "usage_evidence_tier": "unavailable",
+        "usage_incomplete_reason": "request_ledger_unavailable",
+        "usage_incomplete_reasons": ["contains user supplied text"],
+        "timed_usage_complete": False,
+        "token_usage_events": [],
+    }), encoding="utf-8")
+
+    assert _subscription_trial_usage(
+        tmp_path, {"codebuddy_cli_version": CODEBUDDY_CLI_VERSION},
+    ) is None
+
+
+def test_normalized_usage_accepts_legacy_codebuddy_reason(
+    tmp_path: Path,
+) -> None:
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    (agent_dir / "provider-usage.json").write_text(json.dumps({
+        "schema": "dradar-subscription-provider-usage-v1",
+        "provider": "codebuddy",
+        "model": CODEBUDDY_MODEL,
+        "complete": False,
+        "request_count": 0,
+        "n_input_tokens": 0,
+        "n_cache_tokens": 0,
+        "n_output_tokens": 0,
+        "request_usage_complete": False,
+        "request_usage_observed": False,
+        "usage_evidence_tier": "unavailable",
+        "usage_incomplete_reason": (
+            "terminal_aggregate_missing_or_inconsistent"
+        ),
+        "timed_usage_complete": False,
+        "token_usage_events": [],
+    }), encoding="utf-8")
+
+    normalized = _subscription_trial_usage(
+        tmp_path, {"codebuddy_cli_version": CODEBUDDY_CLI_VERSION},
+    )
+    assert normalized is not None
+    assert normalized["usage_incomplete_reasons"] == [
+        "terminal_aggregate_missing_or_inconsistent",
+    ]
 
 
 def test_pier_dockerfile_rewrite_uses_only_reviewed_local_image(

--- a/tests/test_pending_upload.py
+++ b/tests/test_pending_upload.py
@@ -1851,6 +1851,64 @@ def test_incomplete_kimi_usage_keeps_tokens_and_cost_unavailable(
     ) == "submitted"
 
 
+def test_incomplete_codebuddy_usage_uploads_observed_ledger_without_settlement(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    trial_dir = _make_trial_dir(tmp_path)
+    agent_dir = trial_dir / "agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "provider-usage.json").write_text(json.dumps({
+        "schema": "dradar-subscription-provider-usage-v1",
+        "provider": "codebuddy",
+        "model": "hy4-preview",
+        "complete": False,
+        "request_count": 1,
+        "n_input_tokens": 300,
+        "n_cache_tokens": 200,
+        "n_output_tokens": 21,
+        "cache_creation_tokens": 80,
+        "request_usage_complete": False,
+        "request_usage_observed": True,
+        "usage_evidence_tier": "observed_unreconciled",
+        "usage_incomplete_reason": "terminal_aggregate_missing",
+        "usage_incomplete_reasons": ["terminal_aggregate_missing"],
+        "timed_usage_complete": False,
+        "provider_actual_cost_observed": False,
+        "cost_semantics": "server-priced-api-equivalent",
+        "token_usage_events": [{
+            "n_input_tokens": 300,
+            "n_cache_tokens": 200,
+            "n_output_tokens": 21,
+            "cache_creation_tokens": 80,
+        }],
+    }), encoding="utf-8")
+
+    class CaptureClient(FakeClient):
+        def submit(self, assignment_id, nonce, patch, trajectory, result, meta,
+                   outcome="completed", resume_generation=None,
+                   trajectory_bundle=None):
+            assert meta["usage_aggregation_complete"] is False
+            assert meta["request_usage_complete"] is False
+            assert meta["request_usage_observed"] is True
+            assert meta["usage_evidence_tier"] == "observed_unreconciled"
+            assert meta["usage_incomplete_reason"] == "terminal_aggregate_missing"
+            assert meta["usage_incomplete_reasons"] == [
+                "terminal_aggregate_missing",
+            ]
+            assert meta["n_input_tokens"] == 300
+            assert meta["n_cache_tokens"] == 200
+            assert meta["n_output_tokens"] == 21
+            assert meta["cost_usd"] is None
+            assert meta["provider_actual_cost_observed"] is False
+            return {"submission_id": "s1", "grade_status": "pending"}
+
+    assert runloop._upload_trial(
+        CaptureClient(lambda _aid: None),
+        _entry(trial_dir, meta={"codebuddy_cli_version": "2.137.1"}),
+    ) == "submitted"
+
+
 def test_upload_suppresses_cost_when_any_subagent_usage_is_missing(
     tmp_path: Path, monkeypatch,
 ):


### PR DESCRIPTION
## Context

CodeBuddy request usage was all-or-nothing: any terminal aggregate, model, or duplicate-record mismatch erased otherwise trustworthy per-request observations. Server grading is already decoupled from accounting, but the CLI sidecar still represented an incomplete ledger as no requests.

## Changes

- preserve structurally valid, correctly modeled, non-conflicting per-request observations when reconciliation is incomplete
- quarantine only conflicting request IDs instead of discarding unrelated requests
- keep complete=false and request_usage_complete=false so server cost and points settlement remain blocked
- emit bounded reason codes for missing/multiple terminals, model mismatch, duplicate-ID conflict, aggregate mismatch, and related terminal/request failures
- validate reason lists before upload and retain compatibility with pending 0.5.189 sidecars
- carry observed tokens through trajectory/upload metadata without estimating cost or points

## Verification

- targeted: 147 passed
- full suite: 1748 passed
- git diff --check: passed

## Safety

No identity, model, patch, or anti-cheat validation was relaxed. No version bump, OTA build, deployment, or production mutation is included.