### PR TITLE
#0054 | CLI | 验证 GPT-6-Astra 透传与用量身份

### DIFF
--- a/tests/test_multi_agent_usage.py
+++ b/tests/test_multi_agent_usage.py
@@ -9,7 +9,8 @@ from dradar.runner import (
 
 def _session(path: Path, session_id: str, role: str, usages: list[dict],
              parent: str | None = None, inherited: dict | None = None,
-             history_mode: str | None = None) -> None:
+             history_mode: str | None = None,
+             model: str = "gpt-5.6-terra") -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     source = "exec"
     if role == "subagent":
@@ -35,7 +36,7 @@ def _session(path: Path, session_id: str, role: str, usages: list[dict],
         ]
     events += [
         {"type": "event_msg", "payload": {"type": "task_started"}},
-        {"type": "turn_context", "payload": {"model": "gpt-5.6-terra"}},
+        {"type": "turn_context", "payload": {"model": model}},
     ]
     events += [{"type": "event_msg", "timestamp": (
         f"2026-08-17T01:00:{index:02d}Z"
@@ -73,6 +74,22 @@ def test_aggregates_final_root_and_subagent_counters(tmp_path: Path):
     assert usage["sessions"][1]["parent_session_id"] == "root-1"
     assert usage["timed_usage_complete"] is True
     assert len(usage["token_usage_events"]) == 3
+
+
+def test_astra_identity_is_retained_in_uploaded_codex_usage(tmp_path: Path):
+    sessions = tmp_path / "agent" / "sessions"
+    _session(
+        sessions / "root.jsonl",
+        "root-astra",
+        "user",
+        [_usage(100, 60, 10, 4)],
+        model="gpt-6-astra",
+    )
+
+    usage = aggregate_codex_session_usage(tmp_path)
+
+    assert usage is not None and usage["complete"] is True
+    assert usage["sessions"][0]["model_name"] == "gpt-6-astra"
 
 
 def test_duplicate_session_id_uses_largest_cumulative_record(tmp_path: Path):

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -58,6 +58,29 @@ def test_codex_disables_server_side_network_tools(tmp_path, monkeypatch):
     assert config["__pier_allowlist"] == {"url": "https://chatgpt.com"}
 
 
+def test_codex_astra_assignment_reaches_pier_without_model_or_effort_aliasing(
+    tmp_path, monkeypatch,
+):
+    _stub_pier(monkeypatch)
+    (tmp_path / "abs-module-cache-flags").mkdir()
+    auth = tmp_path / "auth.json"
+    auth.write_text("{}")
+    monkeypatch.setenv("CODEX_AUTH_JSON_PATH", str(auth))
+    home = tmp_path / "home"
+    home.mkdir()
+
+    cmd = build_pier_command(
+        _assignment("codex", model="gpt-6-astra", effort="ultra"),
+        tmp_path,
+        tmp_path / "jobs",
+        "j",
+        home,
+    )
+
+    assert cmd[cmd.index("--model") + 1] == "gpt-6-astra"
+    assert "reasoning_effort=ultra" in cmd
+
+
 def test_codex_prompt_leaves_post_run_artifact_to_pier(tmp_path, monkeypatch):
     _stub_pier(monkeypatch)
     task = tmp_path / "abs-module-cache-flags"


### PR DESCRIPTION
## 变更
- 现有 Codex 通用执行链路无需生产代码修改
- 新增回归测试，证明 gpt-6-astra@ultra 原样传给 Codex/Pier
- 新增回归测试，证明上传用量保留 gpt-6-astra 身份

## 验证
- uv run pytest -q：1715 passed，2 skipped
- git diff --check：通过
- 离线命令构造：--model gpt-6-astra 与 reasoning_effort=ultra 原样保留

## 边界
- 未发布 OTA，未运行真实 Astra 样本，未改变生产状态
- Server 未提供可精确重建的 Astra 扁平价格，CLI 不补造价格