### PR TITLE
#0061：公开导入已有订阅凭据并隔离 Claude OAuth 配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,7 @@ DRadar 服务端。若代理协议、容器路由或官方镜像下载不可用�
 
 Claude Code Harness 只接受 Claude.ai 订阅 OAuth，不接受 `ANTHROPIC_API_KEY`、
 `ANTHROPIC_AUTH_TOKEN`、Bedrock 或自定义 API Base URL。普通 `claude auth login` 用于先确认
-当前账号和模型权限；Pier 容器需要官方 `claude setup-token` 生成的长期订阅 OAuth，统一由
-下面的交互式命令采集，输入不回显：
+当前账号和模型权限。原有的长期订阅 `setup-token` 流程继续支持，输入不回显：
 
 ```bash
 claude install latest
@@ -213,6 +212,18 @@ dradar provider setup claude
 dradar provider status claude --live
 dradar doctor --agent claude-code
 ```
+
+已有官方 Claude OAuth 配置时，也可以显式导入完整订阅配置，避免重新登录：
+
+```bash
+dradar provider setup claude --claude-config-dir /private/official-claude-config
+```
+
+源目录中的 `.credentials.json` 必须由当前用户所有且为 `0600` 普通文件；仅导入完整
+`claudeAiOauth` 配置，不导入 plugins、hooks 或 MCP。原文件保持不变，且不会把 access token
+转换成 setup-token。容器配置保存在采集目录之外，仅将会话日志单独保留；即使清理失败，
+认证文件也不会进入上传目录。导入配置被明确选择后，不会自动回退到旧 setup-token 或
+遗留的按量 API/云后端认证。可用 `CLAUDE_CLI_PATH` 明确选择现有官方 CLI。
 
 当前运行合同固定为 Claude Code `2.1.251`，前端展示两张模型卡片：
 
@@ -379,6 +390,11 @@ dradar go --pick TASK_ID:glm-5.3:high
 dradar go --pick TASK_ID:glm-5.3-flash:high
 ```
 
+已有私有 Coding Plan key 文件时，使用
+`dradar provider setup zcode --coding-plan-key-file /private/coding-plan-key`。
+文件须由当前用户所有且为 `0600` 普通文件；导入前只验证 Coding Plan 专用入口，不回退
+到普通按量 API 入口。验证失败保留旧凭据，成功时也不修改源文件。
+
 `provider setup` 会从官方桌面安装的 `Resources/glm/zcode.cjs` 导入协议 CLI；新任务默认
 使用当前已验证的 `0.16.5`。桌面版本与内嵌协议 CLI 版本分别管理，assignment 中的旧版本
 只作兼容提示，不会阻塞本机最新版。普通 GLM-5.3 接受 `0.16.x >= 0.16.3`，Flash 接受
@@ -394,6 +410,12 @@ allowlist/denylist，保留完整编码和 `Agent` 子代理能力；网络仍�
 端点。任务中断不会恢复 ZCode session/rollout；运行完成后的精确产物只走待上传账本。
 
 ### Google Antigravity Gemini 3.7 Flash 订阅 OAuth agent
+
+已有官方 `.gemini` consumer OAuth 目录时，可运行
+`dradar provider setup antigravity --antigravity-oauth-dir /private/official/.gemini`。
+导入只保存 OAuth、最小 project 选择和当前受审查设置，不复制历史会话、缓存、MCP 或
+备份凭据，不发起新的容器 OAuth 登录。源文件必须私有且归当前用户所有，源目录保持不变，
+失败保留旧配置。导入证明本地格式与运行时就绪，不证明某模型仍有额度或调用资格。
 
 Antigravity 只使用 DRadar 独立的 Google OAuth 状态和固定 Linux CLI `1.1.22`，模型固定为
 `gemini-3.7-flash` 的 `low`/`medium`/`high` 三档。每题在 Pier Docker 中使用

--- a/src/dradar/cli.py
+++ b/src/dradar/cli.py
@@ -17,6 +17,7 @@ dropped once a grep of the public consumers showed nothing reaching through
 
 import argparse
 import sys
+from pathlib import Path
 
 from . import __version__
 from .agent_schema import cmd_schema
@@ -440,6 +441,13 @@ def main(argv: list[str] | None = None) -> int:
             "codebuddy", "hy4",
         )
     )
+    imports = p_provider_setup.add_mutually_exclusive_group()
+    imports.add_argument("--coding-plan-key-file", type=Path,
+                         help="ZCode: import an existing private Coding Plan key file")
+    imports.add_argument("--claude-config-dir", type=Path,
+                         help="Claude: import an existing native subscription OAuth configuration")
+    imports.add_argument("--antigravity-oauth-dir", type=Path,
+                         help="Antigravity: import an existing official .gemini OAuth directory")
     p_provider_setup.set_defaults(func=cmd_provider_setup)
     p_provider_status = provider_sub.add_parser(
         "status", help="check provider readiness without displaying credentials")

--- a/src/dradar/credential_files.py
+++ b/src/dradar/credential_files.py
@@ -1,0 +1,116 @@
+"""Small file-boundary helpers for explicit, local credential imports."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import stat
+import tempfile
+from pathlib import Path
+
+MAX_CREDENTIAL_BYTES = 256 * 1024
+
+
+def is_claude_metered_auth(name: str) -> bool:
+    return name in {
+        "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL", "ANTHROPIC_CUSTOM_HEADERS",
+        "CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX", "CLAUDE_CODE_USE_FOUNDRY",
+        "GOOGLE_APPLICATION_CREDENTIALS", "ANTHROPIC_VERTEX_PROJECT_ID", "CLOUD_ML_REGION",
+    } or name.startswith(("AWS_", "ANTHROPIC_FOUNDRY_", "AZURE_"))
+
+
+def _reject_links(path: Path) -> None:
+    for component in (path.absolute(), *path.absolute().parents):
+        if component.is_symlink():
+            raise ValueError("credential paths must not contain symbolic links")
+
+
+def read_private_credential(path: Path) -> bytes:
+    """Read one owned regular file without following a final symlink or FIFO."""
+    _reject_links(path)
+    before = path.lstat()
+    if not stat.S_ISREG(before.st_mode):
+        raise ValueError("credential source must be a regular file, not a link")
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    fd = os.open(path, flags)
+    with os.fdopen(fd, "rb") as source:
+        info = os.fstat(source.fileno())
+        if not stat.S_ISREG(info.st_mode) or (info.st_dev, info.st_ino) != (before.st_dev, before.st_ino):
+            raise ValueError("credential source changed while opening")
+        if os.name != "nt":
+            if info.st_uid != os.getuid() or stat.S_IMODE(info.st_mode) & 0o077:
+                raise ValueError("credential source must be owned by you and mode 0600")
+        content = source.read(MAX_CREDENTIAL_BYTES + 1)
+    if not content or len(content) > MAX_CREDENTIAL_BYTES:
+        raise ValueError("credential source is empty or too large")
+    return content
+
+
+def private_directory(path: Path) -> None:
+    _reject_links(path)
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    info = path.lstat()
+    if not stat.S_ISDIR(info.st_mode):
+        raise ValueError("credential directory must not be a symlink")
+    if os.name != "nt":
+        if info.st_uid != os.getuid():
+            raise ValueError("credential directory must be owned by you")
+        os.chmod(path, 0o700)
+
+
+def atomic_private_credential(path: Path, content: bytes) -> None:
+    private_directory(path.parent)
+    if path.exists() or path.is_symlink():
+        read_private_credential(path)
+    fd, name = tempfile.mkstemp(prefix=".credential-", dir=path.parent)
+    temporary = Path(name)
+    try:
+        with os.fdopen(fd, "wb") as target:
+            target.write(content)
+            target.flush()
+            os.fsync(target.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def credential_json(content: bytes) -> dict:
+    def unique(pairs):
+        result = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError("duplicate credential field")
+            result[key] = value
+        return result
+    try:
+        payload = json.loads(content, object_pairs_hook=unique)
+    except (UnicodeError, ValueError):
+        raise ValueError("credential JSON is invalid") from None
+    if not isinstance(payload, dict):
+        raise ValueError("credential JSON must be an object")
+    return payload
+
+
+def claude_config_payload(content: bytes) -> dict:
+    """Keep native OAuth intact; never reinterpret it as a setup token."""
+    payload = credential_json(content)
+    oauth = payload.get("claudeAiOauth")
+    if not isinstance(oauth, dict):
+        raise ValueError("official Claude OAuth configuration is missing")
+    access = oauth.get("accessToken")
+    refresh = oauth.get("refreshToken")
+    scopes = oauth.get("scopes")
+    subscription = oauth.get("subscriptionType")
+    if (
+        not isinstance(access, str) or not access.startswith("sk-ant-oat")
+        or not isinstance(refresh, str) or not refresh.strip()
+        or not isinstance(scopes, list) or "user:inference" not in scopes
+        or not all(isinstance(scope, str) for scope in scopes)
+        or not isinstance(subscription, str) or subscription.lower() not in {"pro", "max", "team", "enterprise"}
+        or type(oauth.get("expiresAt")) not in (int, float)
+        or not math.isfinite(oauth["expiresAt"]) or oauth["expiresAt"] <= 0
+        or any(key in payload for key in ("apiKey", "anthropicApiKey", "ANTHROPIC_API_KEY"))
+    ):
+        raise ValueError("a complete Claude subscription OAuth configuration is required; API credentials are not accepted")
+    return {"claudeAiOauth": oauth}

--- a/src/dradar/doctor.py
+++ b/src/dradar/doctor.py
@@ -39,8 +39,9 @@ from .providers import (
     ZCODE_CLI_VERSION,
     prepare_antigravity_auth,
     antigravity_auth_path,
-    claude_oauth_error,
-    claude_oauth_path,
+    claude_cli_path,
+    claude_subscription_error,
+    claude_subscription_path,
     deepseek_api_key,
     deepseek_catalog_error,
     deepseek_opted_in,
@@ -382,8 +383,8 @@ def plan_environment_issue(
             )
         return None
     if harness == CLAUDE_AGENT:
-        executable = shutil.which("claude")
-        ready = bool(executable) and claude_oauth_error() is None
+        executable = claude_cli_path()
+        ready = bool(executable) and claude_subscription_error() is None
         if not ready:
             return _plan_issue(
                 harness, "current_tool_not_ready",
@@ -714,10 +715,10 @@ def cmd_doctor(args) -> int:
     auth = runner.codex_auth_path()
     codex_ready = bool(codex) and auth.is_file()
     claude_requested = claude_only or (
-        selected_agent is None and claude_oauth_path().exists()
+        selected_agent is None and claude_subscription_path().exists()
     )
-    claude_cli = shutil.which("claude") if claude_requested else None
-    claude_oauth_issue = claude_oauth_error() if claude_requested else None
+    claude_cli = claude_cli_path() if claude_requested else None
+    claude_oauth_issue = claude_subscription_error() if claude_requested else None
     claude_ready = bool(claude_cli and claude_oauth_issue is None)
     grok_requested = grok_only or (
         selected_agent is None and grok_auth_path().exists()

--- a/src/dradar/pier_claude.py
+++ b/src/dradar/pier_claude.py
@@ -1,10 +1,8 @@
 """Subscription-only Claude Code adapter for the stock Pier runtime.
 
-The adapter deliberately accepts one owner-only file produced from
-``claude setup-token``. It rejects Anthropic API credentials and keeps the
-secret out of Pier argv, task files, trajectories, and DRadar HTTP payloads.
-Claude Code itself receives the OAuth value only in its process environment
-inside the disposable Pier container.
+The adapter accepts either an owner-only ``claude setup-token`` file or a
+native subscription OAuth configuration. Native credentials stay outside
+collected logs even if cleanup cannot run. API credentials are rejected.
 """
 
 from __future__ import annotations
@@ -12,11 +10,22 @@ from __future__ import annotations
 import os
 import stat
 import json
+import re
+import shlex
+import tempfile
+import uuid
 from pathlib import Path
 
 from pier.agents.installed.claude_code import ClaudeCode
 from pier.environments.base import BaseEnvironment
 from pier.models.agent.context import AgentContext
+from pier.models.trial.paths import EnvironmentPaths
+try:
+    from _dradar_credential_files import claude_config_payload, read_private_credential, is_claude_metered_auth
+except ModuleNotFoundError as exc:
+    if exc.name != "_dradar_credential_files":
+        raise
+    from dradar.credential_files import claude_config_payload, read_private_credential, is_claude_metered_auth
 try:
     from _dradar_worker_events import emit_worker_registered
 except ModuleNotFoundError:
@@ -32,17 +41,23 @@ except ModuleNotFoundError as exc:
 class ClaudeCodeSubscription(ClaudeCode):
     """Claude.ai subscription variant with a fail-closed auth boundary."""
 
-    def __init__(self, *args, oauth_token_file: str, **kwargs):
-        self._oauth_token_path = Path(oauth_token_file)
-        self._oauth_token = self._read_private_oauth(self._oauth_token_path)
+    def __init__(self, *args, oauth_token_file: str | None = None,
+                 oauth_config_file: str | None = None, **kwargs):
+        if bool(oauth_token_file) == bool(oauth_config_file):
+            raise ValueError("select exactly one Claude subscription authentication format")
+        self._oauth_token = None
+        self._oauth_config = None
+        self._remote_config_root = None
+        if oauth_config_file:
+            payload = claude_config_payload(read_private_credential(Path(oauth_config_file)))
+            self._oauth_config = json.dumps(payload, separators=(",", ":")).encode()
+        else:
+            self._oauth_token_path = Path(oauth_token_file)
+            self._oauth_token = self._read_private_oauth(self._oauth_token_path)
         extra_env = dict(kwargs.pop("extra_env", {}) or {})
-        for name in (
-            "ANTHROPIC_API_KEY",
-            "ANTHROPIC_AUTH_TOKEN",
-            "ANTHROPIC_BASE_URL",
-            "CLAUDE_CODE_OAUTH_TOKEN",
-        ):
-            extra_env.pop(name, None)
+        for name in list(extra_env):
+            if is_claude_metered_auth(name) or name in {"CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CONFIG_DIR"}:
+                extra_env.pop(name, None)
         # Safe mode disables host/project customizations but leaves built-in
         # tools and the outer bypassPermissions policy intact. This makes the
         # benchmark reproducible without reducing in-container coding access.
@@ -68,15 +83,65 @@ class ClaudeCodeSubscription(ClaudeCode):
     def _get_env(self, key: str) -> str | None:
         if key == "CLAUDE_CODE_OAUTH_TOKEN":
             return self._oauth_token
-        if key in {
-            "ANTHROPIC_API_KEY",
-            "ANTHROPIC_AUTH_TOKEN",
-            "ANTHROPIC_BASE_URL",
-            "CLAUDE_CODE_USE_BEDROCK",
-            "AWS_BEARER_TOKEN_BEDROCK",
-        } or key.startswith("AWS_"):
+        if is_claude_metered_auth(key):
             return None
         return super()._get_env(key)
+
+    def build_process_env(self, base=None, *, include_resolved_env=True):
+        env = super().build_process_env(base, include_resolved_env=include_resolved_env)
+        env = {key: value for key, value in env.items() if not is_claude_metered_auth(key)}
+        if self._oauth_config is not None:
+            env.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
+        if self._remote_config_root and "CLAUDE_CONFIG_DIR" in env:
+            env["CLAUDE_CONFIG_DIR"] = self._remote_config_root
+        return env
+
+    async def exec_as_agent(self, environment, command, env=None, cwd=None, timeout_sec=None):
+        if env:
+            env = {key: value for key, value in env.items() if not is_claude_metered_auth(key)}
+            if self._remote_config_root and "CLAUDE_CONFIG_DIR" in env:
+                env["CLAUDE_CONFIG_DIR"] = self._remote_config_root
+                env.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
+        return await super().exec_as_agent(
+            environment, command, env=env, cwd=cwd, timeout_sec=timeout_sec,
+        )
+
+    async def _prepare_native_config(self, environment):
+        # Upstream places CLAUDE_CONFIG_DIR inside /logs/agent. Never put an
+        # OAuth JSON there, even temporarily: failed cleanup must stay private.
+        root = "/tmp/dradar-claude-auth-" + uuid.uuid4().hex
+        self._remote_config_root = root
+        uid_result = await super().exec_as_agent(environment, "id -u", timeout_sec=30)
+        uid = (uid_result.stdout or "").strip()
+        if uid_result.return_code != 0 or not re.fullmatch(r"[0-9]+", uid):
+            raise ValueError("cannot identify the Claude container user")
+        result = await self.exec_as_root(environment, command=f"umask 077; mkdir {shlex.quote(root)}", timeout_sec=30)
+        if result.return_code != 0:
+            raise ValueError("cannot create private Claude configuration directory")
+        with tempfile.TemporaryDirectory(prefix="dradar-claude-upload-") as temporary:
+            source = Path(temporary) / ".credentials.json"
+            fd = os.open(source, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(fd, "wb") as stream:
+                stream.write(self._oauth_config)
+            await environment.upload_file(source, root + "/.credentials.json")
+        result = await self.exec_as_root(
+            environment, command=(
+                f"chmod 700 {shlex.quote(root)} && "
+                f"chmod 600 {shlex.quote(root + '/.credentials.json')} && "
+                f"chown -R {uid} {shlex.quote(root)}"
+            ), timeout_sec=30,
+        )
+        if result.return_code != 0:
+            raise ValueError("cannot protect private Claude configuration")
+        projects = str(EnvironmentPaths.agent_dir / "sessions" / "projects")
+        result = await super().exec_as_agent(
+            environment, command=(
+                f"mkdir -p {shlex.quote(projects)} && "
+                f"ln -s {shlex.quote(projects)} {shlex.quote(root + '/projects')}"
+            ), timeout_sec=30,
+        )
+        if result.return_code != 0:
+            raise ValueError("cannot retain Claude session logs separately from authentication")
 
     async def run(
         self,
@@ -84,8 +149,20 @@ class ClaudeCodeSubscription(ClaudeCode):
         environment: BaseEnvironment,
         context: AgentContext,
     ) -> None:
-        emit_worker_registered(runtime="pier", context="agent", profile="claude")
-        await super().run(instruction, environment, context)
+        try:
+            if self._oauth_config is not None:
+                await self._prepare_native_config(environment)
+            emit_worker_registered(runtime="pier", context="agent", profile="claude")
+            await super().run(instruction, environment, context)
+        finally:
+            if self._remote_config_root:
+                root = self._remote_config_root
+                self._remote_config_root = None
+                result = await self.exec_as_root(
+                    environment, command=f"rm -rf -- {shlex.quote(root)}", timeout_sec=30,
+                )
+                if result.return_code != 0:
+                    raise ValueError("private Claude credential cleanup failed; credentials remain outside collected logs")
 
     def populate_context_post_run(self, context) -> None:
         """Keep upstream ATIF output and add a reconciled subscription ledger."""

--- a/src/dradar/provider_config.py
+++ b/src/dradar/provider_config.py
@@ -1,18 +1,21 @@
-"""Interactive, local-only model-provider credential setup."""
+"""Local provider setup, including explicit imports of existing credentials."""
 
 from __future__ import annotations
 
 import getpass
 import hashlib
+import json
 import os
 import platform
 import shutil
 import ssl
+import stat
 import subprocess
 import sys
 import tarfile
 import tempfile
 import urllib.request
+from datetime import datetime
 from pathlib import Path
 from urllib.parse import urlsplit
 
@@ -30,6 +33,14 @@ from .codebuddy_provider import (
     ensure_codebuddy_runtime_image,
     import_host_login,
     managed_codebuddy_home,
+)
+from .credential_files import (
+    atomic_private_credential,
+    claude_config_payload,
+    credential_json,
+    private_directory,
+    read_private_credential,
+    is_claude_metered_auth,
 )
 from .codebuddy_provider import (
     credential_status as codebuddy_credential_status,
@@ -56,10 +67,13 @@ from .providers import (
     ZCODE_MODELS,
     ZCODE_OFFICIAL_DOWNLOAD_PAGE,
     antigravity_auth_path,
+    antigravity_auth_error,
     antigravity_home,
     antigravity_ready_path,
-    claude_oauth_error,
-    claude_oauth_path,
+    claude_config_path,
+    claude_cli_path,
+    claude_subscription_error,
+    claude_subscription_path,
     deepseek_api_key,
     deepseek_credential_source,
     deepseek_secret_error,
@@ -689,7 +703,11 @@ def _claude_cli_version(executable: str | Path) -> str | None:
 def _setup_claude_subscription() -> int:
     """Import an official Claude.ai setup token into DRadar's private store."""
 
-    executable = shutil.which("claude")
+    configured = claude_config_path()
+    if configured.exists() or configured.is_symlink():
+        # Re-running setup must not silently select a different legacy login.
+        return _status_claude_subscription(live=False)
+    executable = claude_cli_path()
     version = _claude_cli_version(executable) if executable else None
     if not executable or version != CLAUDE_CLI_VERSION:
         print(
@@ -734,15 +752,15 @@ def _setup_claude_subscription() -> int:
 
 
 def _status_claude_subscription(*, live: bool) -> int:
-    path = claude_oauth_path()
-    issue = claude_oauth_error(path)
+    path = claude_subscription_path()
+    issue = claude_subscription_error()
     if issue is not None:
         print(
             f"Claude Code provider not ready: {issue}. Run "
             "`dradar provider setup claude`."
         )
         return 1
-    executable = shutil.which("claude")
+    executable = claude_cli_path()
     version = _claude_cli_version(executable) if executable else None
     if version != CLAUDE_CLI_VERSION:
         print(
@@ -759,11 +777,15 @@ def _status_claude_subscription(*, live: bool) -> int:
 
 
 def _live_claude_status(executable: str, path: Path) -> int:
-    token = path.read_text(encoding="utf-8").strip()
     base_env = provider_subprocess_env()
-    for name in (*CLAUDE_API_KEY_ENVS, "CLAUDE_CODE_OAUTH_TOKEN"):
-        base_env.pop(name, None)
-    base_env["CLAUDE_CODE_OAUTH_TOKEN"] = token
+    for name in list(base_env):
+        if is_claude_metered_auth(name) or name in {"CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CONFIG_DIR"}:
+            base_env.pop(name, None)
+    if path.name == ".credentials.json":
+        claude_config_payload(read_private_credential(path))
+        base_env["CLAUDE_CONFIG_DIR"] = str(path.parent)
+    else:
+        base_env["CLAUDE_CODE_OAUTH_TOKEN"] = path.read_text(encoding="utf-8").strip()
     for model in sorted(CLAUDE_MODELS):
         command = [
             executable, "-p", "--safe-mode", "--disable-slash-commands",
@@ -792,9 +814,145 @@ def _live_claude_status(executable: str, path: Path) -> int:
     return 0
 
 
+def _owned_source_directory(path: Path) -> None:
+    info = path.lstat()
+    if not stat.S_ISDIR(info.st_mode):
+        raise ValueError("OAuth source directory must not be a symlink")
+    if os.name != "nt" and info.st_uid != os.getuid():
+        raise ValueError("OAuth source directory must be owned by you")
+
+
+def _import_zcode_key(source: Path) -> int:
+    if source.resolve() == zcode_secret_path().resolve():
+        raise ValueError("import source must be separate from managed credentials")
+    key = read_private_credential(source).decode("utf-8").strip()
+    if not key or any(character.isspace() for character in key):
+        raise ValueError("Coding Plan key must be one non-empty line")
+    cli = zcode_cli_path()
+    if zcode_cli_error(cli) is not None:
+        print("A compatible official ZCode runtime is required before import; previous credentials were preserved.")
+        return 1
+    # Verify the explicit Coding Plan endpoint before changing any credential.
+    # Never fall back to a general, metered BigModel API endpoint.
+    if _live_zcode_status(key) != 0:
+        print("Coding Plan validation failed; previous credentials were preserved.")
+        return 1
+    target = zcode_secret_path()
+    if target.exists() or target.is_symlink():
+        read_private_credential(target)
+    store_zcode_cli(cli)
+    atomic_private_credential(target, (key + "\n").encode())
+    print("Existing Coding Plan key imported privately; source unchanged, no model request made.")
+    return 0
+
+
+def _import_claude_config(source: Path) -> int:
+    _owned_source_directory(source)
+    if source.resolve() == claude_config_path().parent.resolve():
+        raise ValueError("import source must be separate from managed credentials")
+    payload = claude_config_payload(read_private_credential(source / ".credentials.json"))
+    target = claude_config_path()
+    atomic_private_credential(target, json.dumps(payload, separators=(",", ":")).encode())
+    print("Native Claude subscription OAuth configuration imported privately; source unchanged.")
+    print("No setup-token conversion, login, or model request was performed; verify runtime readiness with provider status.")
+    return 0
+
+
+def _import_antigravity_config(source: Path) -> int:
+    _owned_source_directory(source)
+    _owned_source_directory(source / "antigravity-cli")
+    content = read_private_credential(source / "antigravity-cli" / "antigravity-oauth-token")
+    payload = credential_json(content)
+    token = payload.get("token")
+    if (
+        payload.get("auth_method") != "consumer" or not isinstance(token, dict)
+        or not all(isinstance(token.get(key), str) and token[key].strip()
+                   for key in ("access_token", "refresh_token", "expiry"))
+        or str(token.get("token_type", "")).lower() != "bearer"
+    ):
+        raise ValueError("existing official consumer OAuth credentials are required")
+    try:
+        expiry = datetime.fromisoformat(token["expiry"].replace("Z", "+00:00"))
+        if expiry.tzinfo is None:
+            raise ValueError
+    except ValueError:
+        raise ValueError("official OAuth expiry must include a timezone") from None
+    # Retain only project selection, never source MCP commands, logs or history.
+    project_config = None
+    config_file = source / "config" / "config.json"
+    if config_file.exists() or config_file.is_symlink():
+        _owned_source_directory(config_file.parent)
+        original = credential_json(read_private_credential(config_file))
+        settings = original.get("userSettings", {})
+        if not isinstance(settings, dict):
+            raise ValueError("invalid official project configuration")
+        project_config = {"userSettings": {
+            key: settings[key] for key in ("projectId", "project_id", "defaultProjectId")
+            if isinstance(settings.get(key), str)
+        }}
+    target = antigravity_auth_path()
+    if source.resolve() == target.resolve():
+        raise ValueError("source must be separate from the managed import target")
+    if target.is_symlink() or (target.exists() and not target.is_dir()):
+        raise ValueError("managed OAuth target must be a real directory")
+    ready = antigravity_ready_path()
+    old_ready = read_private_credential(ready) if ready.exists() or ready.is_symlink() else None
+    docker = shutil.which("docker")
+    if not docker or _ensure_antigravity_linux_cli(docker) is None:
+        print("Antigravity runtime preparation failed; previous credentials were preserved.")
+        return 1
+    private_directory(target.parent)
+    with tempfile.TemporaryDirectory(prefix=".oauth-import-", dir=target.parent) as temporary:
+        staging_home = Path(temporary)
+        staged = antigravity_auth_path(staging_home)
+        atomic_private_credential(staged / "antigravity-cli" / "antigravity-oauth-token", content)
+        if project_config is not None:
+            atomic_private_credential(staged / "config" / "config.json", json.dumps(project_config).encode())
+        restore_antigravity_settings(staging_home)
+        mark_antigravity_ready(staging_home)
+        if antigravity_auth_error(staging_home) is not None:
+            raise ValueError("imported local OAuth state did not validate")
+        backup = staging_home / "previous-auth"
+        if target.exists():
+            target.rename(backup)
+        try:
+            staged.rename(target)
+            atomic_private_credential(ready, read_private_credential(antigravity_ready_path(staging_home)))
+        except BaseException:
+            if target.exists():
+                shutil.rmtree(target)
+            if backup.exists():
+                backup.rename(target)
+            if old_ready is not None:
+                atomic_private_credential(ready, old_ready)
+            else:
+                ready.unlink(missing_ok=True)
+            raise
+    print("Existing Antigravity consumer OAuth imported privately; source unchanged.")
+    print("No new OAuth login or live model check was performed; local readiness is not proof of model quota.")
+    return 0
+
+
 def cmd_provider_setup(args) -> int:
     """Read a DeepSeek key without echoing it or placing it in argv/history."""
 
+    imports = (
+        ("coding_plan_key_file", {"zcode"}, _import_zcode_key),
+        ("claude_config_dir", {"claude", "claude-code"}, _import_claude_config),
+        ("antigravity_oauth_dir", {"antigravity", "agy"}, _import_antigravity_config),
+    )
+    for option, providers, importer in imports:
+        source = getattr(args, option, None)
+        if source is None:
+            continue
+        if args.provider not in providers:
+            print("The selected credential import option does not match this provider.")
+            return 2
+        try:
+            return importer(Path(source).expanduser())
+        except (OSError, ValueError) as exc:
+            print(f"Existing credential import failed ({type(exc).__name__}); previous credentials were preserved.")
+            return 1
     if args.provider in {"claude", "claude-code"}:
         return _setup_claude_subscription()
     if args.provider == "grok":

--- a/src/dradar/providers.py
+++ b/src/dradar/providers.py
@@ -1329,6 +1329,33 @@ def claude_oauth_path(home: Path | None = None) -> Path:
     return claude_home(home) / CLAUDE_OAUTH_TOKEN_FILENAME
 
 
+def claude_config_path(home: Path | None = None) -> Path:
+    return claude_home(home) / "oauth-config" / ".credentials.json"
+
+
+def claude_cli_path() -> str | None:
+    explicit = os.environ.get("CLAUDE_CLI_PATH", "").strip()
+    return str(Path(explicit).expanduser()) if explicit else shutil.which("claude")
+
+
+def claude_subscription_path(home: Path | None = None) -> Path:
+    config = claude_config_path(home)
+    # An invalid imported configuration must not silently select another login.
+    return config if config.exists() or config.is_symlink() else claude_oauth_path(home)
+
+
+def claude_subscription_error(home: Path | None = None) -> str | None:
+    path = claude_subscription_path(home)
+    if path == claude_oauth_path(home):
+        return claude_oauth_error(path)
+    from .credential_files import claude_config_payload, read_private_credential
+    try:
+        claude_config_payload(read_private_credential(path))
+    except (OSError, ValueError):
+        return "Claude native OAuth configuration is unsafe or incomplete"
+    return None
+
+
 def claude_oauth_error(path: Path | None = None) -> str | None:
     """Validate an owner-only Claude.ai subscription setup token.
 
@@ -1401,20 +1428,22 @@ def store_claude_oauth_token(
 
 @contextmanager
 def claude_subscription_session(directory: Path, *, home: Path | None = None):
-    """Expose the canonical OAuth token to one host-side Pier adapter.
+    """Expose the selected subscription credential to one Pier adapter.
 
     Claude setup tokens do not rotate in place, so concurrent trials may read
     the same owner-only file. The adapter transfers only the value to Claude's
-    process environment inside the disposable task container.
+    process environment inside the disposable task container. Native OAuth
+    configuration instead receives a private container-local snapshot; the
+    authority file is never mounted writable or changed by the adapter.
     """
 
-    canonical = claude_oauth_path(home)
-    issue = claude_oauth_error(canonical)
+    canonical = claude_subscription_path(home)
+    issue = claude_subscription_error(home)
     if issue is not None:
         raise ValueError(issue + "; run `dradar provider setup claude` first")
     directory.mkdir(parents=True, exist_ok=True)
     yield canonical
-    issue = claude_oauth_error(canonical)
+    issue = claude_subscription_error(home)
     if issue is not None:
         raise ValueError("Claude OAuth credential became unsafe: " + issue)
 
@@ -1983,7 +2012,7 @@ def advertised_capabilities(
     if grok_cli_path(environ) and grok_auth_error() is None:
         capabilities.append(GROK_CAPABILITY)
     if (
-        claude_oauth_error() is None
+        claude_subscription_error() is None
         and Path(__file__).with_name("pier_claude.py").is_file()
     ):
         capabilities.append(CLAUDE_CAPABILITY)

--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -698,13 +698,17 @@ def _ensure_codex_agent_module(home: Path) -> Path:
 def _ensure_claude_agent_module(home: Path) -> Path:
     source = Path(__file__).with_name("pier_claude.py")
     usage_source = Path(__file__).with_name("claude_usage.py")
-    if not source.is_file() or not usage_source.is_file():
+    credential_source = Path(__file__).with_name("credential_files.py")
+    if not source.is_file() or not usage_source.is_file() or not credential_source.is_file():
         raise RunnerError(
             "Claude Code Pier adapter is missing; reinstall or upgrade dradar"
         )
     _ensure_worker_event_module(home)
     _materialize_shared_file(
         home / CLAUDE_USAGE_MODULE_FILENAME, usage_source.read_bytes()
+    )
+    _materialize_shared_file(
+        home / "_dradar_credential_files.py", credential_source.read_bytes()
     )
     return _materialize_shared_file(
         home / CLAUDE_AGENT_MODULE_FILENAME, source.read_bytes()
@@ -1513,11 +1517,15 @@ def build_pier_command(
                 "Claude Code subscription OAuth is unavailable; run "
                 "`dradar provider setup claude` in your own interactive Terminal"
             )
+        credential_argument = (
+            "oauth_config_file" if provider_auth_path.name == ".credentials.json"
+            else "oauth_token_file"
+        )
         cmd += [
             "--model", assignment["model"],
             "--ak", f"reasoning_effort={assignment['effort']}",
             "--ak", f"version={CLAUDE_CLI_VERSION}",
-            "--ak", f"oauth_token_file={provider_auth_path}",
+            "--ak", f"{credential_argument}={provider_auth_path}",
             "--ak", f"disallowed_tools={CLAUDE_DISALLOWED_TOOLS}",
             "--ae", "API_TIMEOUT_MS=3000000",
             "--ae", "CLAUDE_CODE_AUTO_COMPACT_WINDOW=1000000",

--- a/tests/test_provider_credential_imports.py
+++ b/tests/test_provider_credential_imports.py
@@ -1,0 +1,215 @@
+"""Explicit imports preserve authority sources and keep secrets out of artifacts."""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from dradar import credential_files, provider_config, providers, runner
+
+MARKER = 'INERT_CREDENTIAL_SENTINEL_0061'
+
+
+def private(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(value if isinstance(value, bytes) else value.encode())
+    path.chmod(0o600)
+    return path
+
+
+def claude_payload():
+    return {'claudeAiOauth': {
+        'accessToken': 'sk-ant-oat01-' + MARKER,
+        'refreshToken': 'refresh-' + MARKER,
+        'expiresAt': 1900000000000,
+        'scopes': ['user:profile', 'user:inference'],
+        'subscriptionType': 'pro', 'rateLimitTier': 'default_claude_pro',
+    }}
+
+
+def agy_source(path):
+    private(path / 'antigravity-cli' / 'antigravity-oauth-token', json.dumps({
+        'auth_method': 'consumer', 'token': {'access_token': MARKER, 'refresh_token': MARKER,
+        'token_type': 'Bearer', 'expiry': '2030-01-01T00:00:00Z'}}))
+    private(path / 'config' / 'config.json', json.dumps({'userSettings': {
+        'projectId': 'local-project', 'mcpServers': {'do-not-import': MARKER}}}))
+    private(path / 'antigravity-cli' / 'conversation.json', MARKER)
+    return path
+
+
+@pytest.fixture
+def isolated(tmp_path, monkeypatch):
+    home=tmp_path/'managed'
+    monkeypatch.setenv('DRADAR_HOME',str(home))
+    return home
+
+
+@pytest.mark.parametrize('kind', ['link','parent_link','wide','fifo','foreign_owner'])
+def test_unsafe_sources_rejected(tmp_path, monkeypatch, kind):
+    source=private(tmp_path/'source'/'key',MARKER)
+    if kind=='link':
+        link=tmp_path/'link';link.symlink_to(source);source=link
+    elif kind=='parent_link':
+        link=tmp_path/'parent';link.symlink_to(source.parent,target_is_directory=True);source=link/source.name
+    elif kind=='wide': source.chmod(0o644)
+    elif kind=='fifo':
+        source.unlink();os.mkfifo(source)
+    else: monkeypatch.setattr(credential_files.os,'getuid',lambda: source.stat().st_uid+1)
+    with pytest.raises((ValueError,OSError)):
+        credential_files.read_private_credential(source)
+
+
+def test_claude_import_preserves_native_config_and_legacy_source(tmp_path,isolated):
+    source=private(tmp_path/'source'/'.credentials.json',json.dumps(claude_payload()))
+    before=source.read_bytes(),source.stat().st_mtime_ns,source.stat().st_mode
+    legacy=providers.store_claude_oauth_token('sk-ant-oat01-'+MARKER*2)
+    assert provider_config._import_claude_config(source.parent)==0
+    imported=providers.claude_config_path()
+    assert json.loads(imported.read_text())==claude_payload()
+    assert imported.stat().st_mode & 0o077 == 0
+    assert legacy.read_text().strip()=='sk-ant-oat01-'+MARKER*2
+    assert (source.read_bytes(),source.stat().st_mtime_ns,source.stat().st_mode)==before
+    assert providers.claude_subscription_path()==imported
+    assert providers.claude_subscription_error() is None
+    imported.write_text('{}')
+    assert providers.claude_subscription_error() is not None  # no silent old-login fallback
+
+
+@pytest.mark.parametrize('invalid', [b'not json',b'{"apiKey":"inert-api-key"}', b'{"claudeAiOauth":{}}'])
+def test_bad_claude_import_retains_previous(tmp_path,isolated,invalid):
+    old=private(providers.claude_config_path(),json.dumps(claude_payload()))
+    before=old.read_bytes()
+    source=private(tmp_path/'source'/'.credentials.json',invalid)
+    with pytest.raises(ValueError):provider_config._import_claude_config(source.parent)
+    assert old.read_bytes()==before
+
+
+def test_atomic_failure_preserves_old_bytes(tmp_path,monkeypatch):
+    target=private(tmp_path/'private'/'key','old')
+    def fail(*_):raise OSError('inert write failure')
+    monkeypatch.setattr(credential_files.os,'replace',fail)
+    with pytest.raises(OSError):credential_files.atomic_private_credential(target,b'new')
+    assert target.read_bytes()==b'old'
+    assert list(target.parent.iterdir())==[target]
+
+
+def test_zcode_validates_coding_endpoint_before_commit(tmp_path,isolated,monkeypatch):
+    source=private(tmp_path/'source-key',MARKER)
+    old=private(providers.zcode_secret_path(),'previous')
+    monkeypatch.setattr(provider_config,'zcode_cli_path',lambda:'/official/zcode.cjs')
+    monkeypatch.setattr(provider_config,'zcode_cli_error',lambda _:None)
+    installed=[]
+    monkeypatch.setattr(provider_config,'store_zcode_cli',lambda p:installed.append(p))
+    monkeypatch.setattr(provider_config,'_live_zcode_status',lambda key:1)
+    assert provider_config._import_zcode_key(source)==1
+    assert old.read_text()=='previous' and installed==[]
+    monkeypatch.setattr(provider_config,'_live_zcode_status',lambda key:0 if key==MARKER else 1)
+    assert provider_config._import_zcode_key(source)==0
+    assert old.read_text().strip()==MARKER and source.read_text()==MARKER
+    assert provider_config._ZCODE_MODELS_URL=='https://open.bigmodel.cn/api/coding/paas/v4/models'
+
+
+def test_antigravity_import_is_minimal_and_never_logs_in(tmp_path,isolated,monkeypatch):
+    source=agy_source(tmp_path/'official')
+    secret=(source/'antigravity-cli/antigravity-oauth-token').read_bytes()
+    monkeypatch.setattr(provider_config.shutil,'which',lambda _:'/docker')
+    monkeypatch.setattr(provider_config,'_ensure_antigravity_linux_cli',lambda _:'/official/antigravity')
+    assert provider_config._import_antigravity_config(source)==0
+    target=providers.antigravity_auth_path()
+    assert (target/'antigravity-cli/antigravity-oauth-token').read_bytes()==secret
+    assert (source/'antigravity-cli/antigravity-oauth-token').read_bytes()==secret
+    assert not (target/'antigravity-cli/conversation.json').exists()
+    assert json.loads((target/'config/config.json').read_text())=={'userSettings':{'projectId':'local-project'}}
+    assert providers.antigravity_auth_error() is None
+
+
+def test_antigravity_failure_restores_previous_auth_and_proof(tmp_path,isolated,monkeypatch):
+    monkeypatch.setattr(provider_config.shutil,'which',lambda _:'/docker')
+    monkeypatch.setattr(provider_config,'_ensure_antigravity_linux_cli',lambda _:'/official/antigravity')
+    source=agy_source(tmp_path/'official')
+    assert provider_config._import_antigravity_config(source)==0
+    target=providers.antigravity_auth_path()/'antigravity-cli/antigravity-oauth-token'
+    before=target.read_bytes();ready=providers.antigravity_ready_path();proof=ready.read_bytes()
+    real=provider_config.atomic_private_credential
+    failures=[]
+    def fail_once(path,data):
+        if path==ready and not failures:
+            failures.append(True);raise OSError('inert proof failure')
+        return real(path,data)
+    monkeypatch.setattr(provider_config,'atomic_private_credential',fail_once)
+    with pytest.raises(OSError):provider_config._import_antigravity_config(source)
+    assert target.read_bytes()==before and ready.read_bytes()==proof
+
+
+def test_claude_runner_uses_native_file_argument(tmp_path,isolated,monkeypatch):
+    monkeypatch.setattr(runner.shutil,'which',lambda _:'/usr/bin/pier')
+    source=private(tmp_path/'source'/'.credentials.json',json.dumps(claude_payload()))
+    provider_config._import_claude_config(source.parent)
+    tasks=tmp_path/'tasks';(tasks/'task-1').mkdir(parents=True)
+    assignment={'assignment_id':'test-1','task_id':'task-1','agent':providers.CLAUDE_AGENT,
+        'provider':providers.CLAUDE_PROVIDER,'model':providers.CLAUDE_SONNET_MODEL,'effort':'high',
+        'agent_version':providers.CLAUDE_CLI_VERSION,'est_minutes':5}
+    argv=runner.build_pier_command(assignment,tasks,tmp_path/'jobs','job',tmp_path/'work',provider_auth_path=providers.claude_subscription_path())
+    assert f'oauth_config_file={providers.claude_config_path()}' in argv
+    assert not any(x.startswith('oauth_token_file=') for x in argv)
+    assert MARKER not in repr(argv)
+
+
+@pytest.mark.parametrize('finish',['normal','agent_error','cleanup_failure'])
+def test_native_claude_credentials_never_enter_collected_logs(tmp_path,monkeypatch,finish):
+    from dradar.pier_claude import ClaudeCodeSubscription
+    from pier.agents.installed.claude_code import ClaudeCode
+    source=private(tmp_path/'source'/'.credentials.json',json.dumps(claude_payload()))
+    container=tmp_path/'container';(container/'tmp').mkdir(parents=True)
+    logs=container/'logs/agent';logs.mkdir(parents=True)
+    traces=[]
+    def mapped(value):return str(container)+value
+    class Environment:
+        default_user=None
+        def agent_process_env(self,env):return env
+        async def upload_file(self,src,target):
+            shutil.copyfile(src,mapped(target))
+        async def exec(self,command,cwd=None,env=None,timeout_sec=None,user=None):
+            traces.append((command,env))
+            if command.endswith('run-inert-model'):
+                assert env and env['CLAUDE_CONFIG_DIR'].startswith('/tmp/dradar-claude-auth-')
+                assert not any(credential_files.is_claude_metered_auth(k) for k in env)
+                assert 'CLAUDE_CODE_OAUTH_TOKEN' not in env
+                cfg=Path(mapped(env['CLAUDE_CONFIG_DIR']))
+                assert json.loads((cfg/'.credentials.json').read_text())==claude_payload()
+                project=cfg/'projects/-app/session';project.mkdir(parents=True)
+                (project/'events.jsonl').write_text('{"type":"assistant","message":"normal session"}\n')
+                return SimpleNamespace(return_code=0,stdout='',stderr='')
+            if 'rm -rf -- /tmp/dradar-claude-auth-' in command and finish=='cleanup_failure':
+                return SimpleNamespace(return_code=1,stdout='',stderr='inert cleanup failure')
+            local=command.replace('/tmp/dradar-claude-auth-',mapped('/tmp/dradar-claude-auth-')).replace('/logs/agent',mapped('/logs/agent'))
+            r=subprocess.run(['bash','-c',local],capture_output=True,text=True)
+            return SimpleNamespace(return_code=r.returncode,stdout=r.stdout,stderr=r.stderr)
+    async def native_run(self,instruction,environment,context):
+        assert self._get_env('ANTHROPIC_API_KEY') is None
+        await self.exec_as_agent(environment,'run-inert-model',env={
+            'CLAUDE_CONFIG_DIR':'/logs/agent/sessions','ANTHROPIC_API_KEY':'METERED_SENTINEL',
+            'AWS_ACCESS_KEY_ID':'METERED_SENTINEL','CLAUDE_CODE_USE_VERTEX':'1',
+            'CLAUDE_CODE_OAUTH_TOKEN':'OTHER_LOGIN_SENTINEL'})
+        if finish=='agent_error':raise RuntimeError('inert model error')
+    monkeypatch.setattr(ClaudeCode,'run',native_run)
+    monkeypatch.setattr('dradar.pier_claude.emit_worker_registered',lambda **_:None)
+    monkeypatch.setenv('ANTHROPIC_API_KEY','METERED_SENTINEL')
+    agent=ClaudeCodeSubscription(logs,oauth_config_file=str(source),model_name='claude-sonnet-5',
+        extra_env={'ANTHROPIC_API_KEY':'METERED_SENTINEL','CLAUDE_CODE_USE_VERTEX':'1'})
+    if finish=='normal':asyncio.run(agent.run('ordinary task',Environment(),None))
+    else:
+        with pytest.raises((RuntimeError,ValueError)):asyncio.run(agent.run('ordinary task',Environment(),None))
+    assert list((logs/'sessions/projects').rglob('events.jsonl'))
+    assert all(MARKER.encode() not in f.read_bytes() for f in logs.rglob('*') if f.is_file())
+    assert not list(logs.rglob('.credentials.json'))
+    assert MARKER not in repr(traces) and 'METERED_SENTINEL' not in repr(traces)
+    remaining=list((container/'tmp').rglob('.credentials.json'))
+    assert bool(remaining)==(finish=='cleanup_failure')
+    assert json.loads(source.read_text())==claude_payload()

--- a/tests/test_run_plans.py
+++ b/tests/test_run_plans.py
@@ -2414,7 +2414,7 @@ def test_claude_plan_accepts_ready_subscription_runtime(monkeypatch):
     )
     monkeypatch.setattr(doctor, "_probe", lambda _command: True)
     monkeypatch.setattr(doctor.runner, "ensure_pier", lambda: None)
-    monkeypatch.setattr(doctor, "claude_oauth_error", lambda: None)
+    monkeypatch.setattr(doctor, "claude_subscription_error", lambda: None)
 
     assert doctor.plan_environment_issue(
         _plan(harness="claude-code", task_count=1),
@@ -2505,7 +2505,7 @@ def test_claude_plan_fails_closed_with_actionable_setup(missing, monkeypatch):
     monkeypatch.setattr(doctor, "_probe", lambda _command: True)
     monkeypatch.setattr(doctor.runner, "ensure_pier", lambda: None)
     monkeypatch.setattr(
-        doctor, "claude_oauth_error",
+        doctor, "claude_subscription_error",
         lambda: "missing OAuth" if missing == "oauth" else None,
     )
 


### PR DESCRIPTION
已有订阅凭据无法通过公开命令进入隔离运行目录，导致自动化不得不复制秘密或重复登录。新增三个明确的公开导入参数：ZCode Coding Plan key 文件、Claude 原生 OAuth 配置目录、Antigravity 官方 OAuth 目录；源凭据不变，导入失败保留旧配置。

Claude 保留原 setup-token 分支，原生 OAuth 配置独立放在容器私有目录，采集目录只保留会话日志；清理失败也不会把认证文件纳入上传。显式订阅模式清除按量 API/云后端覆盖。私有主机路径、账号管理局内核及 ds0 Pier 补丁均不进入本 PR。

验证：相关运行计划、Fleet、doctor、provider 回归 549 项通过；既有动作校验 54 项通过。本轮独立 QA 为认证邻域 163 项及动作校验 54 项；没有把旧 #317 作者自测当作独立 review。固定候选 f25c4b8 在隔离 ds0 环境完成 Claude/ZCode/Antigravity 各 1 题真实执行、上传及判分，分数分别 0/1/1，均未 flagged；0 分为正常未通过。

发布说明：本 PR 相对 main 只含认证导入及其文档/测试；相对当前正式 0.5.190/e1e47e3，完整待发版本还包含 main 已合入的 #317 动作边界校验，共 17 个文件。#318/24bda98 的外层复制 prompt 与本地会话重构未包含，#0057 全助手外层验收仍后置。只走既有 CLI-only OTA，不发布 Server/Web。保留前一签名 stable 制品及源码作为恢复点，遵守既有递增 sequence/版本和不可变制品规则。
