### PR TITLE
fix: preserve verified source proof when task builds remove origin

### DIFF
--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -43,7 +43,10 @@ from .codebuddy_provider import (
     codebuddy_subscription_session,
 )
 from .manifest import task_content_hash
-from .task_baseline import BASELINE_REQUEST_ENV, REMOTE_BASELINE, repository_identity
+from .task_baseline import (
+    BASELINE_REQUEST_ENV, REMOTE_BASELINE, SOURCE_COMMIT_PROOF,
+    SOURCE_ORIGIN_PROOF, repository_identity,
+)
 from .worker_events import (
     WORKER_EVENT_FILE_ENV,
     read_worker_event,
@@ -3515,6 +3518,34 @@ def _artifact_tasks_overlay(
                 "__DRADAR_BASE_COMMIT__", base_commit
             )
         if short_commit:
+            build_origin_proof = False
+            dockerfile = overlay_task / "environment" / "Dockerfile"
+            if dockerfile.is_file():
+                if not dockerfile.resolve().is_relative_to(overlay_task.resolve()):
+                    raise RunnerError("task Dockerfile escapes the private overlay")
+                text = dockerfile.read_text(encoding="utf-8")
+                # Preserve task behavior, including remote removal. Support
+                # only this explicit standalone shell-chain step; other forms
+                # must retain origin or fail closed at the pre-model check.
+                pattern = re.compile(
+                    r"^([ \t]*&& )git remote remove origin(?: "
+                    + re.escape("\\") + r")?[ \t]*$",
+                    re.MULTILINE,
+                )
+                removals = list(pattern.finditer(text))
+                if len(removals) > 1:
+                    raise RunnerError("task Dockerfile has ambiguous origin-removal steps")
+                if removals:
+                    removal = removals[0]
+                    step = removal.group(1)
+                    proof = (
+                        step + "git remote get-url origin > " + SOURCE_ORIGIN_PROOF + " \\\n"
+                        + step + "git rev-parse --verify '" + base_commit
+                        + "^{commit}' > " + SOURCE_COMMIT_PROOF + " \\\n"
+                    )
+                    text = text[:removal.start()] + proof + text[removal.start():]
+                    dockerfile.write_text(text, encoding="utf-8")
+                    build_origin_proof = True
             collector = collector.replace(
                 "base_ref='" + base_commit + "'",
                 'base_ref=$(cat ' + REMOTE_BASELINE + ')\n'
@@ -3523,6 +3554,7 @@ def _artifact_tasks_overlay(
             )
             baseline_request_path.write_text(json.dumps({
                 "base_commit": base_commit, "repository_url": repository_url,
+                "build_origin_proof": build_origin_proof,
             }))
             baseline_request_path.chmod(0o600)
         hook.write_text(collector, encoding="utf-8")

--- a/src/dradar/task_baseline.py
+++ b/src/dradar/task_baseline.py
@@ -9,6 +9,8 @@ from urllib.parse import urlsplit
 
 BASELINE_REQUEST_ENV = "DRADAR_TASK_BASELINE_REQUEST"
 REMOTE_BASELINE = "/tmp/dradar-task-base-commit"
+SOURCE_ORIGIN_PROOF = "/tmp/dradar-build-source-origin"
+SOURCE_COMMIT_PROOF = "/tmp/dradar-build-source-commit"
 
 
 def repository_identity(value):
@@ -36,24 +38,43 @@ async def verify_task_baseline(environment):
         raise ValueError("task baseline is not a hexadecimal commit abbreviation")
     expected_repository = repository_identity(request.get("repository_url"))
 
-    async def git(arguments):
+    async def git(arguments, *, allow_missing=False):
         result = await environment.exec(
             command="git --no-replace-objects -c safe.directory=/app -C /app " + arguments,
             env={"GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_NOSYSTEM": "1"},
             timeout_sec=30,
         )
         if result.return_code != 0:
+            if allow_missing:
+                return None
             raise ValueError("task baseline cannot be verified in the prepared source repository")
         return (result.stdout or "").strip()
 
     if await git("rev-parse --show-toplevel") != "/app":
         raise ValueError("task baseline source is not the prepared /app repository")
-    if repository_identity(await git("remote get-url origin")) != expected_repository:
+    origin = await git("remote get-url origin", allow_missing=True)
+    build_commit = None
+    if origin is None and request.get("build_origin_proof") is True:
+        # Only a runner-created per-run Dockerfile overlay enables this path.
+        # It records the real origin and declared commit immediately before
+        # the original task deliberately removes its remote. No remote lookup.
+        async def proof(filename):
+            result = await environment.exec(command="cat -- " + filename, timeout_sec=30)
+            if result.return_code != 0:
+                raise ValueError("task build source proof is missing")
+            return (result.stdout or "").strip()
+        origin = await proof(SOURCE_ORIGIN_PROOF)
+        build_commit = await proof(SOURCE_COMMIT_PROOF)
+        if re.fullmatch(r"[0-9a-f]{40}", build_commit) is None:
+            raise ValueError("task build commit proof is invalid")
+    if repository_identity(origin) != expected_repository:
         raise ValueError("prepared source repository differs from the task declaration")
     matches = (await git("rev-parse --disambiguate=" + prefix)).splitlines()
     if len(matches) != 1 or re.fullmatch(r"[0-9a-f]{40}", matches[0]) is None:
         raise ValueError("task baseline abbreviation is missing or ambiguous")
     commit = matches[0]
+    if build_commit is not None and build_commit != commit:
+        raise ValueError("resolved task baseline differs from the verified build commit")
     if not commit.startswith(prefix) or await git("cat-file -t " + commit) != "commit":
         raise ValueError("task baseline does not identify a commit object")
     # Persist the verified full object ID before any provider can run. The

--- a/tests/test_task_baseline.py
+++ b/tests/test_task_baseline.py
@@ -9,7 +9,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from dradar.task_baseline import BASELINE_REQUEST_ENV, REMOTE_BASELINE, verify_task_baseline
+from dradar.task_baseline import (
+    BASELINE_REQUEST_ENV, REMOTE_BASELINE, SOURCE_COMMIT_PROOF,
+    SOURCE_ORIGIN_PROOF, verify_task_baseline,
+)
 
 
 class LocalEnvironment:
@@ -25,6 +28,8 @@ class LocalEnvironment:
         assert timeout_sec <= 30
         command = command.replace("/app", shlex.quote(str(self.repo)))
         command = command.replace(REMOTE_BASELINE, shlex.quote(str(self.baseline)))
+        command = command.replace(SOURCE_ORIGIN_PROOF, shlex.quote(str(self.repo.parent / "origin-proof")))
+        command = command.replace(SOURCE_COMMIT_PROOF, shlex.quote(str(self.repo.parent / "commit-proof")))
         result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=timeout_sec)
         stdout = result.stdout
         if "--show-toplevel" in command and result.returncode == 0:
@@ -185,3 +190,107 @@ def test_collector_uses_resolved_original_commit_after_model_changes_head(source
         patch = (tmp_path / "artifacts/model.patch").read_text()
         assert "+ordinary implementation" in patch
         assert "answer.txt" in patch
+
+
+def test_original_dockerfile_remote_removal_preserves_verified_build_proof(source, tmp_path):
+    from dradar.runner import _artifact_tasks_overlay
+    repo, git, full, request, _ = source
+    task = tmp_path / "tasks" / "fixture-task"
+    (task / "environment").mkdir(parents=True)
+    (task / "task.toml").write_text(
+        '[metadata]\nbase_commit_hash = "' + full[:7] + '"\n'
+        'repository_url = "https://example.invalid/project/source"\n'
+    )
+    original = (
+        "FROM fixture\nRUN git clone https://example.invalid/project/source . \\\n"
+        " && git checkout -B fixture " + full[:7] + " \\\n"
+        " && git remote remove origin \\\n && true\n"
+    )
+    dockerfile = task / "environment/Dockerfile"
+    dockerfile.write_text(original)
+    with _artifact_tasks_overlay(
+        {"task_id": "fixture-task"}, task.parent, tmp_path / "work", "job",
+        baseline_request_path=request,
+    ) as selected:
+        overlay = (selected / "fixture-task/environment/Dockerfile").read_text()
+        assert json.loads(request.read_text())["build_origin_proof"] is True
+        assert overlay.index("git remote get-url origin") < overlay.index("git remote remove origin")
+        command = overlay.split("RUN ", 1)[1]
+        # Replace only transport in the fixture: preserve the original
+        # clone -> checkout declared prefix -> remove-origin build ordering.
+        command = command.replace(
+            "git clone https://example.invalid/project/source .",
+            "git clone " + shlex.quote(str(repo)) + " . && "
+            "git remote set-url origin https://example.invalid/project/source",
+        )
+        command = command.replace(SOURCE_ORIGIN_PROOF, shlex.quote(str(tmp_path / "origin-proof")))
+        command = command.replace(SOURCE_COMMIT_PROOF, shlex.quote(str(tmp_path / "commit-proof")))
+        built = tmp_path / "built"
+        built.mkdir()
+        subprocess.run(["sh", "-c", command], cwd=built, check=True)
+        assert not subprocess.check_output(["git", "-C", str(built), "remote"], text=True).strip()
+        assert (tmp_path / "commit-proof").read_text().strip() == full
+        asyncio.run(verify_task_baseline(LocalEnvironment(built)))
+        assert json.loads(request.with_suffix(".resolved.json").read_text())["resolved_commit"] == full
+    assert dockerfile.read_text() == original
+
+
+@pytest.mark.parametrize("proof", ["absent", "wrong-origin", "wrong-commit", "not-enabled"])
+def test_removed_origin_requires_matching_runner_enabled_build_proof(source, proof):
+    repo, git, full, request, configure = source
+    configure(full[:7])
+    value = json.loads(request.read_text())
+    value["build_origin_proof"] = proof != "not-enabled"
+    request.write_text(json.dumps(value))
+    git("remote", "remove", "origin")
+    if proof != "absent":
+        (repo.parent / "origin-proof").write_text(
+            "https://example.invalid/another/source" if proof == "wrong-origin"
+            else "https://example.invalid/project/source"
+        )
+        (repo.parent / "commit-proof").write_text("0" * 40 if proof == "wrong-commit" else full)
+    with pytest.raises(ValueError):
+        asyncio.run(verify_task_baseline(LocalEnvironment(repo)))
+    assert not request.with_suffix(".resolved.json").exists()
+
+
+@pytest.mark.parametrize("removal", [" && git remote rm origin", " && git remote remove origin && true"])
+def test_unknown_removal_forms_do_not_enable_build_proof(source, tmp_path, removal):
+    from dradar.runner import _artifact_tasks_overlay
+    _, _, full, request, _ = source
+    task = tmp_path / "tasks" / "fixture-task"
+    (task / "environment").mkdir(parents=True)
+    (task / "task.toml").write_text(
+        '[metadata]\nbase_commit_hash = "' + full[:7] + '"\n'
+        'repository_url = "https://example.invalid/project/source"\n'
+    )
+    original = "FROM fixture\nRUN true \\\n" + removal + "\n"
+    (task / "environment/Dockerfile").write_text(original)
+    with _artifact_tasks_overlay(
+        {"task_id": "fixture-task"}, task.parent, tmp_path / "work", "job",
+        baseline_request_path=request,
+    ) as selected:
+        assert json.loads(request.read_text())["build_origin_proof"] is False
+        assert (selected / "fixture-task/environment/Dockerfile").read_text() == original
+
+
+def test_dockerfile_symlink_cannot_modify_source_outside_overlay(source, tmp_path):
+    from dradar.runner import _artifact_tasks_overlay, RunnerError
+    _, _, full, request, _ = source
+    task = tmp_path / "tasks" / "fixture-task"
+    (task / "environment").mkdir(parents=True)
+    (task / "task.toml").write_text(
+        '[metadata]\nbase_commit_hash = "' + full[:7] + '"\n'
+        'repository_url = "https://example.invalid/project/source"\n'
+    )
+    external = tmp_path / "original-Dockerfile"
+    original = "FROM fixture\nRUN true \\\n && git remote remove origin\n"
+    external.write_text(original)
+    (task / "environment/Dockerfile").symlink_to(external)
+    with pytest.raises(RunnerError, match="escapes"):
+        with _artifact_tasks_overlay(
+            {"task_id": "fixture-task"}, task.parent, tmp_path / "work", "job",
+            baseline_request_path=request,
+        ):
+            pass
+    assert external.read_text() == original


### PR DESCRIPTION
The original eicrud task deliberately removes `origin` after cloning and checking out its declared base commit. The short-SHA validation introduced in #320 would still reject this task because the prepared repository no longer has a remote. #320 is merged, but no OTA containing it has been dispatched.

For the explicit standalone `&& git remote remove origin` build step, the private per-run task overlay now records the actual origin and full declared commit immediately before removal. The original removal still runs. Before inference, the validator can use that proof only when the runner generated this recognized overlay; it checks the declared source, the uniquely resolved local commit object and the recorded full SHA. Unknown removal forms, absent or mismatched proof, and Dockerfile paths escaping the private overlay fail closed. No new remote access or shared task mutation is introduced.

Validation: 146 baseline, runner and lifecycle tests passed. New local Git fixtures follow clone → checkout declared short SHA → remove origin, and cover missing/mismatched proof, unsupported removal forms and symlink escape. Independent review is pending. Production remains 0.5.191/s13; 0.5.193/s14 has not been published.
