### PR TITLE
fix: report startup API connection failures accurately

### DIFF
--- a/src/dradar/runloop.py
+++ b/src/dradar/runloop.py
@@ -1128,8 +1128,9 @@ def _claim_auto(client: ApiClient, n: int) -> list[dict]:
 def _exit_for(exc: ApiError) -> None:
     """Exit on a dead-end ApiError in the run flow with a next step, not just
     the raw server error. 401 means the token was reset/clobbered — recoverable
-    without support. status_code None means the request never reached the
-    server (DNS/connect/timeout), so any held leases are untouched. Everything
+    without support. status_code None means no complete HTTP response was
+    received. A read/write timeout can occur after the server has processed
+    the request, so it does not prove held leases are untouched. Everything
     else (e.g. 403 account suspended) carries the server's own explanation
     verbatim."""
     if exc.status_code == 401:
@@ -1170,8 +1171,13 @@ def _exit_for(exc: ApiError) -> None:
             "saved campaign with `dradar refill stop`"
         )
     if exc.status_code is None:
-        sys.exit(f"{exc}\ncheck your connection — held leases stay active, and "
-                 "`dradar resume` continues where you left off")
+        # Preserve the typed failure across this CLI exit. Fleet must not
+        # guess whether it was a transport, Docker, or login error from text.
+        raise SystemExit(
+            f"{exc}\ncheck your connection — no complete response was received; "
+            "the server may have processed the request. Inspect this run's "
+            "current state before retrying the original run instructions."
+        ) from exc
     sys.exit(str(exc))
 
 
@@ -4377,7 +4383,16 @@ def _preflight_scoped_provider(args) -> None:
 def _publish_fleet_startup_failure(args, reason: object) -> None:
     """Best-effort structured failure for the Agent-facing startup contract."""
     detail = " ".join(str(reason).split()).lower()
-    if "deep-swe" in detail or "task snapshot" in detail or "version pin" in detail:
+    api_error = reason.__cause__ if isinstance(reason, SystemExit) else reason
+    if isinstance(api_error, ApiError) and api_error.status_code is None:
+        code = "api_connection_failed"
+        reason_code = "startup-network-unavailable"
+        message = (
+            "准备运行时未能收到 DRadar 服务的完整响应，题目尚未在本机开始执行。"
+            "服务端可能已经处理请求；请先核对本次运行状态，"
+            "再使用原运行说明重试。"
+        )
+    elif "deep-swe" in detail or "task snapshot" in detail or "version pin" in detail:
         code = "task_environment_update_failed"
         reason_code = "startup-environment-not-ready"
         message = (

--- a/tests/test_go_menu.py
+++ b/tests/test_go_menu.py
@@ -451,16 +451,18 @@ def test_get_assignment_401_exits_with_token_recovery_hint(monkeypatch, tmp_path
     assert "radar page" in msg
 
 
-def test_get_assignment_network_error_exits_mentioning_resume(monkeypatch, tmp_path: Path):
+def test_get_assignment_network_error_requires_state_check_before_retry(monkeypatch, tmp_path: Path):
     _patch_run(monkeypatch)
-    client = ErrorClient(ApiError("cannot reach https://radar.example: boom",
-                                  status_code=None))
+    error = ApiError("cannot reach https://radar.example: boom", status_code=None)
+    client = ErrorClient(error)
     with pytest.raises(SystemExit) as excinfo:
         runloop._go_menu(_args(yes=True, dev_agent=None), {}, client, tmp_path)
     msg = str(excinfo.value)
     assert "cannot reach" in msg
     assert "check your connection" in msg
-    assert "leases stay active" in msg and "dradar resume" in msg
+    assert excinfo.value.__cause__ is error
+    assert "current state" in msg and "original run instructions" in msg
+    assert "leases stay active" not in msg and "dradar resume" not in msg
 
 
 def test_get_assignment_403_passes_server_detail_through(monkeypatch, tmp_path: Path):

--- a/tests/test_startup_transport_errors.py
+++ b/tests/test_startup_transport_errors.py
@@ -1,0 +1,114 @@
+"""Transport failures must survive the CLI exit and startup-report boundary."""
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from dradar import fleet, runloop
+from dradar.api_client import ApiClient, ApiError
+
+
+@pytest.fixture
+def startup_report(tmp_path, monkeypatch):
+    batch_id = "550e8400e29b41d4a716446655440000"
+    fleet._prepare_dirs(tmp_path)
+    monkeypatch.setattr(runloop, "HOME", tmp_path)
+    monkeypatch.setenv(fleet.CONTROLLER_ID_ENV, "test-controller")
+    monkeypatch.setenv(fleet.POOL_BATCH_ENV, batch_id)
+    monkeypatch.setenv(
+        fleet.POOL_STARTUP_FILE_ENV,
+        str(fleet._pool_startup_path(tmp_path, batch_id)),
+    )
+    monkeypatch.setattr(fleet, "controller_matches", lambda *_args: True)
+
+    def publish(error):
+        runloop._publish_fleet_startup_failure(
+            SimpleNamespace(worker_child=False, fleet_pool=True, batch_id=batch_id),
+            error,
+        )
+        return fleet._read_json(fleet._pool_startup_path(tmp_path, batch_id))
+
+    return publish
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        httpx.ReadTimeout("The read operation timed out"),
+        httpx.ConnectError("private auth endpoint in docker environment"),
+        httpx.WriteTimeout("private request detail"),
+    ],
+)
+def test_checkout_transport_failure_keeps_its_cause_and_safe_startup_report(
+    failure, startup_report,
+):
+    requests = []
+
+    def server(request):
+        requests.append(request)
+        raise failure
+
+    client = ApiClient(
+        "https://private.example.test", "",
+        transport=httpx.MockTransport(server), capabilities=(),
+    )
+    try:
+        with pytest.raises(ApiError) as api_failure:
+            client.checkout(session_id="test-session")
+    finally:
+        client._client.close()
+
+    # Exercise the helper outside an except block as well: relying on the
+    # ambient exception context would silently discard the typed cause here.
+    with pytest.raises(SystemExit) as exit_failure:
+        runloop._exit_for(api_failure.value)
+
+    assert len(requests) == 1  # A lost response must not replay checkout.
+    assert exit_failure.value.__cause__ is api_failure.value
+    assert "server may have processed" in str(exit_failure.value)
+    assert "held leases stay active" not in str(exit_failure.value)
+
+    report = startup_report(exit_failure.value)
+    assert report["status"] == "failed"
+    assert report["error_code"] == "api_connection_failed"
+    assert report["retryable"] is True
+    assert "完整响应" in report["user_message"]
+    assert "可能已经处理" in report["user_message"]
+    assert "private" not in report["user_message"]
+    assert "docker" not in report["user_message"].lower()
+
+
+def test_direct_api_transport_failure_uses_the_same_startup_report(startup_report):
+    report = startup_report(ApiError("private host connection failed"))
+
+    assert report["error_code"] == "api_connection_failed"
+    assert "private" not in report["user_message"]
+
+
+@pytest.mark.parametrize("status_code", [401, 403, 429, 503])
+def test_received_http_response_is_not_a_transport_failure(
+    startup_report, status_code,
+):
+    error = ApiError("HTTP response said read timeout", status_code=status_code)
+    try:
+        raise SystemExit("stopped") from error
+    except SystemExit as exited:
+        report = startup_report(exited)
+
+    assert report["error_code"] != "api_connection_failed"
+
+
+def test_worker_transport_failure_marker_does_not_contain_private_details(
+    monkeypatch, tmp_path,
+):
+    marker = tmp_path / "worker.started"
+    marker.write_text("preparing", encoding="utf-8")
+    monkeypatch.setenv(runloop._POOL_WORKER_ACTIVITY_ENV, str(marker))
+
+    runloop._publish_fleet_startup_failure(
+        SimpleNamespace(worker_child=True, fleet_pool=False),
+        ApiError("private connection details"),
+    )
+
+    assert marker.read_text(encoding="utf-8") == "preparing:startup-network-unavailable"


### PR DESCRIPTION
A transport failure during task preparation is converted from `ApiError` into `SystemExit`, losing the typed cause. Startup reporting then falls back to a generic local preparation error or guesses from words in the exception message. The exit hint also incorrectly promises that held leases are unchanged, although a checkout request may have been processed before its response was lost.

Preserve the transport error as the exit cause and report a fixed, sanitized API connection failure during startup. Direct users to inspect the current run before retrying the original instructions. This change does not replay checkout requests or reconcile server-side assignment state.

Validation:

- Added 9 regression cases covering read/write timeouts, connection errors, typed cause propagation, one request per checkout attempt, received HTTP error responses, and private-detail suppression.
- The new tests reproduced 5 failures before the fix and all 9 passed after it.
- 532 tests passed across startup transport errors, workers, API client, Fleet, run plans, flight recording, and the run menu, using an isolated DRadar test directory set before imports.
- `git diff --check` passed.
- After rebasing onto the current upstream main revision `82a1a003d340eb37ccd1b7a9663c34a6f700115a` (0.5.194), the same 532 tests passed again.

The issue was reproduced on client revision `e1e47e326be927cef91643ad4955c69fdb55d5ae` (0.5.190). The PR is based on current upstream main. No live assignments or model credentials were used by the added tests.