### PR TITLE
test: isolate DRadar home before collection

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,28 @@ Pinning src/ at the front of sys.path removes the failure mode regardless of
 how (or whether) the package is installed in the interpreter.
 """
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config):
+    """Protect import-time paths before pytest collects application modules.
+
+    The per-test fixture runs too late for local_config.HOME and function
+    defaults that capture it. Give those paths a disposable session directory,
+    even when the caller already has DRADAR_HOME set to a real installation.
+    """
+
+    runtime_home = tempfile.TemporaryDirectory(prefix="dradar-pytest-")
+    config.add_cleanup(runtime_home.cleanup)
+    environment = pytest.MonkeyPatch()
+    environment.setenv("DRADAR_HOME", runtime_home.name)
+    config.add_cleanup(environment.undo)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_test_home_isolation.py
+++ b/tests/test_test_home_isolation.py
@@ -1,0 +1,81 @@
+"""Exercise collection-time isolation in a fresh pytest process."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+@pytest.mark.parametrize("inherited_home", [False, True])
+@pytest.mark.parametrize("collection_error", [False, True])
+def test_pytest_isolates_import_time_home_and_restores_environment(
+    tmp_path, inherited_home, collection_error,
+):
+    project = tmp_path / "project"
+    tests = project / "tests"
+    tests.mkdir(parents=True)
+    shutil.copyfile(Path(__file__).with_name("conftest.py"), tests / "conftest.py")
+    caller_home = tmp_path / "caller-home"
+    caller_home.mkdir()
+    sentinel = caller_home / "config.json"
+    sentinel.write_text('{"sentinel": true}', encoding="utf-8")
+    report = project / "collected-home.txt"
+    (tests / "test_probe.py").write_text(textwrap.dedent('''
+        import os
+        from pathlib import Path
+
+        from dradar import local_config, run_plans
+
+        # These assertions run during collection, before autouse fixtures.
+        home = local_config.HOME
+        assert home != Path(os.environ["PROBE_CALLER_HOME"])
+        assert home != Path.home() / ".dradar"
+        assert home == Path(os.environ["DRADAR_HOME"])
+        assert local_config.CONFIG_PATH == home / "config.json"
+        assert run_plans._root() == home / "run-plans"
+        assert run_plans.stable_device.__defaults__ == (home,)
+        assert local_config._load_config() == {}
+        Path(os.environ["PROBE_REPORT"]).write_text(str(home), encoding="utf-8")
+
+        if os.environ["PROBE_COLLECTION_ERROR"] == "1":
+            raise RuntimeError("deliberate collection failure")
+
+        def test_per_test_environment(tmp_path):
+            assert Path(os.environ["DRADAR_HOME"]) == tmp_path / "dradar-home"
+    '''), encoding="utf-8")
+    env = os.environ.copy()
+    env.pop("DRADAR_HOME", None)
+    if inherited_home:
+        env["DRADAR_HOME"] = str(caller_home)
+    env.update({
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+        "PROBE_CALLER_HOME": str(caller_home),
+        "PROBE_REPORT": str(report),
+        "PROBE_COLLECTION_ERROR": "1" if collection_error else "0",
+    })
+    script = textwrap.dedent('''
+        import os
+        from pathlib import Path
+        import pytest
+
+        original = os.environ.get("DRADAR_HOME")
+        result = pytest.main(["-q", "tests", "--tb=short"])
+        expected = 2 if os.environ["PROBE_COLLECTION_ERROR"] == "1" else 0
+        assert result == expected, (result, expected)
+        assert os.environ.get("DRADAR_HOME") == original
+        report = Path(os.environ["PROBE_REPORT"])
+        assert report.is_file(), "collection did not reach the isolated home"
+        assert not Path(report.read_text(encoding="utf-8")).exists()
+    ''')
+    result = subprocess.run(
+        [sys.executable, "-c", script], cwd=project, env=env,
+        text=True, capture_output=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert sentinel.read_text(encoding="utf-8") == '{"sentinel": true}'
+    assert list(caller_home.iterdir()) == [sentinel]


### PR DESCRIPTION
The autouse home fixture only sets `DRADAR_HOME` after collection. By then `local_config.HOME`, imported aliases, and default arguments have already captured the caller's real runtime directory. Tests can consequently inspect or write real client state, and fail in restricted environments even though a temporary directory is set during each test.

Set a disposable session directory in `pytest_configure`, before test modules are collected. Retain the existing per-test environment fixture and register cleanup to restore the caller's environment and remove the session directory, including when collection fails. This changes only the test harness.

Validation:

- Four subprocess regression cases cover inherited and unset `DRADAR_HOME`, normal completion, collection failure, import-time/default-bound paths, caller-state preservation, environment restoration, and temporary-directory cleanup. All four failed before the fix and pass after it.
- 527 related tests pass without manually setting `DRADAR_HOME` before pytest.
- The full suite in the restricted environment produced 1,871 passes, 9 failures, 2 setup errors, and 2 skips. Rechecking the four network/build/loopback-dependent cases with the required access produced 3 passes and 1 skip. The remaining seven failures require optional `pier` or `botocore` dependencies absent from this development environment; all seven reproduce on unmodified upstream `82a1a003d340eb37ccd1b7a9663c34a6f700115a` (1,870 passed, 7 failed, 3 skipped in that baseline run).
- `git diff --check` passes. The new tests use synthetic caller-state sentinels and no live assignments or model credentials.

This branch is based directly on upstream main and is independent of #326.