### PR TITLE
fix: stop the artifact-boundary walk from failing every DSH upload

### DIFF
--- a/src/dradar/artifact_boundary.py
+++ b/src/dradar/artifact_boundary.py
@@ -257,7 +257,7 @@ class TrialFiles:
         finally:
             os.close(fd)
 
-    def files(self, relative, *, suffix=None):
+    def files(self, relative, *, suffix=None, skip_dirs=frozenset()):
         parts = _parts(relative)
         fd = self.fd
         for name in parts:
@@ -279,6 +279,11 @@ class TrialFiles:
                     observed_entries[entry.name] = (*_identity(info), info.st_nlink)
                     path = prefix / entry.name
                     if stat.S_ISDIR(info.st_mode):
+                        # Pruned subtrees are never read, so their contents are
+                        # neither collected nor pinned; the pruned directory
+                        # entry itself stays pinned in this parent's snapshot.
+                        if path.as_posix() in skip_dirs:
+                            continue
                         walk(self._directory(directory, entry.name), path, depth + 1)
                     elif not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
                         raise UnsafeArtifact('unsafe_file_type')
@@ -326,6 +331,19 @@ def read_trial_file(root, relative, *, max_bytes=MAX_FILE_BYTES):
         raise UnsafeArtifact('artifact_io_rejected') from exc
 
 
+# DSH mounts the agent's own third-party home (a Node runtime) at
+# agent/dsh-home; its private state (sockets, lock files, caches) is neither
+# consumed nor uploaded by DRadar, and its unbounded contents must not be able
+# to fail an otherwise complete, paid run's upload. The walk prunes that whole
+# subtree and re-adds only the two DRadar-owned artifacts everything reads;
+# each re-added file still passes the full per-file read() verification.
+DSH_HOME_DIR = 'agent/dsh-home'
+DSH_HOME_ARTIFACTS = (
+    'agent/dsh-home/dsh-usage.json',
+    'agent/dsh-home/dsh-outcome.json',
+)
+
+
 @contextmanager
 def snapshot_agent(root, *, include_result=False):
     """Copy verified bytes into an unmounted, host-private scratch directory."""
@@ -333,7 +351,14 @@ def snapshot_agent(root, *, include_result=False):
         with tempfile.TemporaryDirectory(prefix='dradar-logs-') as temporary:
             destination = Path(temporary).resolve()  # host-created, not input
             with TrialFiles(root) as source:
-                paths = source.files('agent') if source.exists('agent') else []
+                paths = (
+                    source.files('agent', skip_dirs={DSH_HOME_DIR})
+                    if source.exists('agent') else []
+                )
+                paths.extend(
+                    relative for relative in DSH_HOME_ARTIFACTS
+                    if source.exists(relative)
+                )
                 extra = ['.dradar/host-output/trajectory.json', '.dradar/host-output/provider-usage.json', '.dradar/host-output/state.json']
                 if include_result:
                     extra.append('result.json')

--- a/tests/test_artifact_boundary.py
+++ b/tests/test_artifact_boundary.py
@@ -15,6 +15,54 @@ def trial(tmp_path):
     return root
 
 
+def _make_dsh_home(trial, *, fifo=False, junk=0):
+    home = trial / 'agent' / 'dsh-home'
+    (home / '.dsh' / 'state').mkdir(parents=True, exist_ok=True)
+    (home / 'dsh-usage.json').write_text('{"schema":"dsh-provider-usage-v2"}')
+    (home / 'dsh-outcome.json').write_text('{"schema":"dradar-dsh-outcome-v1"}')
+    # The agent's own third-party runtime state: never consumed, never uploaded.
+    (home / '.credentials.yaml').write_text('k: v')
+    if fifo:
+        os.mkfifo(home / '.dsh' / 'daemon.sock')
+    for index in range(junk):
+        (home / '.dsh' / 'state' / f'f{index}.json').write_text('{}')
+    return home
+
+
+def test_dsh_home_runtime_state_never_blocks_the_upload_snapshot(trial):
+    """Regress 0.5.196+: DSH mounts its Node home at agent/dsh-home, and the
+    strict whole-tree walk failed every DSH upload once that home contained a
+    socket/fifo or unbounded cache entries (all completed solves lost). The
+    walk now prunes that subtree and re-adds only the two DRadar artifacts."""
+    _make_dsh_home(trial, fifo=True, junk=5000)
+    with boundary.snapshot_agent(trial) as snapshot:
+        collected = sorted(
+            str(path.relative_to(snapshot))
+            for path in snapshot.rglob('*') if path.is_file()
+        )
+    assert collected == [
+        'agent/dsh-home/dsh-outcome.json',
+        'agent/dsh-home/dsh-usage.json',
+        'agent/sessions/normal.jsonl',
+    ]
+
+
+def test_snapshot_still_fail_closed_outside_dsh_home(trial):
+    _make_dsh_home(trial)
+    os.mkfifo(trial / 'agent' / 'rogue.sock')
+    with pytest.raises(boundary.UnsafeArtifact, match='unsafe_file_type'):
+        boundary.snapshot_agent(trial).__enter__()
+
+
+def test_dsh_home_artifacts_are_byte_verified(trial):
+    _make_dsh_home(trial, fifo=True)
+    with boundary.snapshot_agent(trial) as snapshot:
+        assert (snapshot / 'agent/dsh-home/dsh-usage.json').read_bytes() == (
+            b'{"schema":"dsh-provider-usage-v2"}'
+        )
+        assert not (snapshot / 'agent/dsh-home/.credentials.yaml').exists()
+
+
 def test_private_snapshot_preserves_bytes_and_is_outside_trial(trial):
     with boundary.snapshot_agent(trial) as snapshot:
         assert not snapshot.is_relative_to(trial)


### PR DESCRIPTION
User-reported: DSH solves complete but every submission fails. Flight-recorder evidence showed upload-blocked within 180ms of upload start, no intent ever reaching the server — the 0.5.196 artifact-boundary whole-tree walk of `agent/` hits DSH's mounted Node home (`agent/dsh-home`) whose runtime state (fifo/socket, lock files, >4096 cache entries) terminally blocks every DSH upload on 0.5.196+.

Production evidence (48h): all 5 upload-blocked events were DSH tasks (0.5.196/197/198); zero successful dsh-deepseek-v4.1-flash submissions ever; 0.5.190 DSH and all non-DSH harnesses unaffected. Local repro: fifo in dsh-home → unsafe_file_type; 5000 cache files → entry_limit.

Fix: `files()` gains `skip_dirs` subtree pruning; `snapshot_agent` prunes `agent/dsh-home` and re-adds only the two DRadar-owned artifacts (`dsh-usage.json`, `dsh-outcome.json`), each still fully verified per-file. DSH private state (incl. .credentials.yaml) no longer reaches even the scratch snapshot. Fail-closed outside the carve-out unchanged and pinned by new regression tests.

Verification: boundary/staging suites 39 passed; full suite 1940 passed (6 failures pre-exist identically on clean origin/main).