### PR TITLE
fix(runner,tests): force LF on container hooks and fix Windows path escaping in tests

### DIFF
--- a/src/dradar/runner.py
+++ b/src/dradar/runner.py
@@ -3481,6 +3481,7 @@ def _dsh_tasks_overlay(
                     "__DRADAR_BASE_COMMIT__", base_commit
                 ),
                 encoding="utf-8",
+                newline="\n",
             )
             hook.chmod(0o755)
         yield overlay_root
@@ -3613,7 +3614,7 @@ def _artifact_tasks_overlay(
                 "build_origin_proof": build_origin_proof,
             }))
             baseline_request_path.chmod(0o600)
-        hook.write_text(collector, encoding="utf-8")
+        hook.write_text(collector, encoding="utf-8", newline="\n")
         hook.chmod(0o755)
         yield overlay_root
 
@@ -3680,6 +3681,7 @@ def _antigravity_tasks_overlay(
                 "__DRADAR_BASE_COMMIT__", base_commit
             ),
             encoding="utf-8",
+            newline="\n",
         )
         hook.chmod(0o755)
         yield overlay_root

--- a/tests/test_antigravity_subscription.py
+++ b/tests/test_antigravity_subscription.py
@@ -123,11 +123,14 @@ def test_antigravity_task_overlay_captures_complete_worktree(
 
         logs = tmp_path / "logs"
         runnable = tmp_path / "collect.sh"
+        repo_posix = repository.as_posix()
+        artifacts_posix = (logs / "artifacts").as_posix()
         runnable.write_text(
-            script.replace("cd /app", f"cd {repository}").replace(
-                "/logs/artifacts", str(logs / "artifacts")
+            script.replace("cd /app", f"cd '{repo_posix}'").replace(
+                "/logs/artifacts", f"'{artifacts_posix}'"
             ),
             encoding="utf-8",
+            newline="\n",
         )
         subprocess.run(["sh", str(runnable)], check=True)
         patch = (logs / "artifacts" / "model.patch").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

This PR addresses two Windows cross-platform issues on the latest `0.5.199` main:

1. **CRLF Line Endings in Container Hooks (`runner.py`)**:
   When DRadar runs on a Windows host, Python's `Path.write_text` defaults to CRLF (`\r\n`).
   The generated `pre_artifacts.sh` hooks across `_dsh_tasks_overlay`, `_artifact_tasks_overlay`, and `_antigravity_tasks_overlay` are mounted directly into Linux containers.
   In the container, the trailing `\r` causes shell interpreter errors, causes `git status` / `git diff` commands to fail, and can generate corrupt patch output filenames (e.g. `model.patch\r`), causing trial submissions to fail with `model.patch missing` even when the agent executed successfully.
   **Fix**: Explicitly specify `newline="\n"` on all `hook.write_text` calls in `runner.py`.

2. **Windows Path Escaping in Test (`tests/test_antigravity_subscription.py`)**:
   In `test_antigravity_task_overlay_captures_complete_worktree`, the runnable `collect.sh` script interpolated `cd {repository}` using Windows backslash paths. Inside `sh`, backslashes were treated as escape sequences, causing the test to fail with `No such file or directory` on Windows.
   **Fix**: Use `.as_posix()` with single-quoting for directory paths when generating the test script.

## Verification

- `uv run pytest tests/test_antigravity_subscription.py`:
  - Before: 1 failed (`CalledProcessError: Command '['sh', '.../collect.sh']' returned non-zero exit status 1`)
  - After: 43 passed, 2 skipped in 2.38s.
- Real-world verification on Windows 11 host with Docker Desktop running `deep-swe` evaluation containers.
